### PR TITLE
feat: BTF func resolution, exit mode pcapng, version flag & CI fixes

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -52,6 +52,16 @@ var flags = []cli.Flag{
 	},
 }
 
+func init() {
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:        "version",
+		Aliases:     []string{"V"},
+		Usage:       "print the version",
+		HideDefault: true,
+		Local:       true,
+	}
+}
+
 func main() {
 	app := &cli.Command{
 		Name:      "xdp-ninja",

--- a/docs/ja/TODO.md
+++ b/docs/ja/TODO.md
@@ -19,13 +19,14 @@
 ## 既知の制限
 
 - [ ] tail call 先プログラムへの fentry/fexit アタッチが動作しない
-  - `bpf_tail_call` はプログラムジャンプであり通常の関数呼び出しではないため、
-    カーネルの BPF trampoline が介入しない
-  - dispatcher にアタッチすれば tail call 前のパケットは捕捉可能
+  - JIT が tail call 時にプロローグをスキップするため trampoline が発火しない
+  - `__noinline` サブ関数への fentry も tail call 経由では発火しない（検証済み）
+  - 詳細: [docs/ja/tailcall-trampoline-limitation.md](tailcall-trampoline-limitation.md)
   - 対処法:
-    - カーネル側の対応を待つ (fentry on tail call targets)
-    - tail call 挿入方式に切り替える (既存プログラムの差し替えが必要)
-    - tail call 先のプログラムにフック用の BPF subprogram を追加してもらう
+    - `--wrap` モード: prog_array の value を wrapper に書き換えて leaf の前に挟む（設計済み、未実装）
+      - entry 相当のみ。exit は取れない（tail call は制御が戻らないため）
+      - 設計: [docs/ja/wrap-mode-design.md](wrap-mode-design.md)
+    - カーネル側の対応を待つ（該当パッチは現時点で存在しない）
 
 - [ ] フィルタ実行時の scratch buffer コピーオーバーヘッド (~80ns)
   - verifier が xdp_buff->data 経由のメモリロードを scalar として拒否するため、

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -3,8 +3,10 @@ package attach
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
 	"github.com/vishvananda/netlink"
 )
 
@@ -12,7 +14,7 @@ import (
 type XDPInfo struct {
 	ProgID    uint32
 	Program   *ebpf.Program
-	FuncName  string
+	FuncName  string // BTF-resolved entry function name
 	IfaceName string
 }
 
@@ -23,16 +25,16 @@ func FindXDPProgramByID(progID uint32) (*XDPInfo, error) {
 		return nil, fmt.Errorf("getting program (id=%d): %w", progID, err)
 	}
 
-	info, err := prog.Info()
+	funcName, err := resolveEntryFunc(prog, progID)
 	if err != nil {
 		prog.Close()
-		return nil, fmt.Errorf("getting program info (id=%d): %w", progID, err)
+		return nil, err
 	}
 
 	return &XDPInfo{
 		ProgID:   progID,
 		Program:  prog,
-		FuncName: info.Name,
+		FuncName: funcName,
 	}, nil
 }
 
@@ -53,16 +55,97 @@ func FindXDPProgram(ifaceName string) (*XDPInfo, error) {
 		return nil, fmt.Errorf("getting XDP program (id=%d): %w", xdp.ProgId, err)
 	}
 
-	info, err := prog.Info()
+	funcName, err := resolveEntryFunc(prog, xdp.ProgId)
 	if err != nil {
 		prog.Close()
-		return nil, fmt.Errorf("getting program info (id=%d): %w", xdp.ProgId, err)
+		return nil, err
 	}
 
 	return &XDPInfo{
 		ProgID:    xdp.ProgId,
 		Program:   prog,
-		FuncName:  info.Name,
+		FuncName:  funcName,
 		IfaceName: ifaceName,
 	}, nil
+}
+
+// resolveEntryFunc resolves the entry function name from the program's BTF.
+//
+// fentry/fexit requires BTF, so this function errors if BTF is unavailable
+// or the function name cannot be unambiguously resolved.
+//
+// Resolution order:
+//  1. Exact match: prog.Info().Name matches a btf.Func
+//  2. Prefix match: prog name is truncated (>=15 chars, BPF_OBJ_NAME_LEN limit)
+//     and a btf.Func starts with that prefix — but only if exactly one matches
+//  3. Single Func: BTF has exactly one Func entry
+//  4. Error: ambiguous or no match
+func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
+	info, err := prog.Info()
+	if err != nil {
+		return "", fmt.Errorf("program id=%d: getting info: %w", progID, err)
+	}
+	progName := info.Name
+
+	handle, err := prog.Handle()
+	if err != nil {
+		return "", fmt.Errorf("program %q (id=%d): BTF unavailable (required for fentry/fexit): %w", progName, progID, err)
+	}
+	defer handle.Close()
+
+	spec, err := handle.Spec(nil)
+	if err != nil {
+		return "", fmt.Errorf("program %q (id=%d): reading BTF: %w", progName, progID, err)
+	}
+
+	// 1. Exact match
+	var fn *btf.Func
+	if err := spec.TypeByName(progName, &fn); err == nil {
+		return fn.Name, nil
+	}
+
+	// Collect all Func entries
+	var funcs []string
+	for typ, err := range spec.All() {
+		if err != nil {
+			break
+		}
+		if f, ok := typ.(*btf.Func); ok {
+			funcs = append(funcs, f.Name)
+		}
+	}
+
+	if len(funcs) == 0 {
+		return "", fmt.Errorf("program %q (id=%d): no btf.Func found in BTF", progName, progID)
+	}
+
+	// 2. Prefix match (prog name may be truncated to 15 chars by kernel)
+	if len(progName) >= 15 {
+		var matches []string
+		for _, name := range funcs {
+			if strings.HasPrefix(name, progName) {
+				matches = append(matches, name)
+			}
+		}
+		if len(matches) == 1 {
+			return matches[0], nil
+		}
+		if len(matches) > 1 {
+			return "", fmt.Errorf(
+				"program %q (id=%d): ambiguous BTF function name (truncated prog name matches %d funcs: %v)",
+				progName, progID, len(matches), matches,
+			)
+		}
+	}
+
+	// 3. Single Func
+	if len(funcs) == 1 {
+		return funcs[0], nil
+	}
+
+	// 4. Ambiguous
+	return "", fmt.Errorf(
+		"program %q (id=%d): cannot resolve entry function from BTF (%d candidates: %v)",
+		progName, progID, len(funcs), funcs,
+	)
 }


### PR DESCRIPTION
## Summary
- **Exit mode pcapng**: XDP action (ABORTED/DROP/PASS/TX/REDIRECT) をpcapngのインターフェース名として埋め込み、Wiresharkで可視化可能に
- **BTF function name resolution**: カーネルの BPF_OBJ_NAME_LEN (16byte) 切り詰めに対応し、BTF Funcからエントリ関数名を正確に解決
- **--version flag**: ldflags経由でバージョン情報を埋め込み。`-v` (verbose) との衝突を `-V` = version で解消
- **CI**: vimto + ghcr.io 認証付きカーネルイメージ取得に修正、goreleaser snapshot ターゲット追加

## Test plan
- [ ] `go test ./internal/output/` — exit mode pcapng interface テスト
- [x] `xdp-ninja -V` でバージョン表示、`-v` で verbose が動作すること
- [x] CI の BPF load test が通ること