### PR TITLE
feat: add --func/--list-funcs/--list-progs for __noinline subfunction probing

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           FILES=$(git diff --name-only "${{ github.event.before }}" HEAD | tr '\n' ' ')
           if [[ -n "$FILES" ]]; then
-            lefthook run pre-commit --file $FILES
+            lefthook run pre-commit --file "$FILES"
           fi
 
       - name: Run lefthook (pull_request)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,72 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        id: setup-go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
+            ${{ runner.os }}-go-
+
+      - name: Cache golangci-lint
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            golangci-lint-${{ runner.os }}-${{ steps.setup-go.outputs.go-version }}-
+            golangci-lint-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y libpcap-dev
+
+      - name: Install lint tools
+        run: make install-lint-tools
+
+      - name: Run lefthook (push)
+        if: github.event_name == 'push'
+        run: |
+          FILES=$(git diff --name-only "${{ github.event.before }}" HEAD | tr '\n' ' ')
+          if [[ -n "$FILES" ]]; then
+            lefthook run pre-commit --file $FILES
+          fi
+
+      - name: Run lefthook (pull_request)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          make lint-ci DIFF_FROM_BRANCH_NAME=origin/${{ github.base_ref }}
+
+      - name: Check modified files
+        if: failure()
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "::error::Files were modified by lefthook. Please run 'make lint' locally and commit the changes."
+            git status --porcelain
+            git diff
+          fi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 150
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "on"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,28 @@
 .PHONY: build clean test test-unit test-bpf test-integration test-all vet goreleaser
+.PHONY: install-lint-tools lint lint-ci
 
 BINARY = xdp-ninja
+DIFF_FROM_BRANCH_NAME ?= main
 
 build:
 	go build -o $(BINARY) ./cmd/xdp-ninja/
 
 vet:
 	go vet ./...
+
+## Lint:
+
+install-lint-tools: ## install lint tools
+	./scripts/install_lint_tools.sh
+
+lint: ## Run lefthook pre-commit on all files
+	lefthook run pre-commit --all-files
+
+lint-ci: ## Run lefthook pre-commit on changed files (for CI)
+	FILES="$$(git diff --name-only $(DIFF_FROM_BRANCH_NAME) HEAD | tr '\n' ' ')"; \
+	if [ -n "$$FILES" ]; then \
+		lefthook run pre-commit --file $$FILES; \
+	fi
 
 test: test-unit
 

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,8 @@ lint: ## Run lefthook pre-commit on all files
 	lefthook run pre-commit --all-files
 
 lint-ci: ## Run lefthook pre-commit on changed files (for CI)
-	FILES="$$(git diff --name-only $(DIFF_FROM_BRANCH_NAME) HEAD | tr '\n' ' ')"; \
-	if [ -n "$$FILES" ]; then \
-		lefthook run pre-commit --file $$FILES; \
+	@if ! git diff --quiet $(DIFF_FROM_BRANCH_NAME) HEAD; then \
+		git diff --name-only -z $(DIFF_FROM_BRANCH_NAME) HEAD | xargs -0 lefthook run pre-commit --file; \
 	fi
 
 test: test-unit

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ sudo xdp-ninja -i eth0 --mode exit | tcpdump -n -r -
 | `--mode` | `entry` (before XDP, default) or `exit` (after XDP) |
 | `--func` | Attach to a specific `__noinline` subfunction by BTF name |
 | `--list-funcs` | List available BTF functions in the target program and exit |
+| `--list-progs` | List tail call targets reachable from the target program and exit |
 | `-w, --write` | Write to pcap file instead of stdout |
 | `-c, --count` | Stop after N packets (0 = unlimited) |
 | `-v, --verbose` | Verbose output to stderr |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ sudo xdp-ninja -i eth0 -w capture.pcap -c 100
 # Attach by BPF program ID (for multi-prog / libxdp setups)
 sudo xdp-ninja -p 42 | tcpdump -n -r -
 
+# List available BTF functions in the target program
+sudo xdp-ninja -i eth0 --list-funcs
+
+# Attach to a specific __noinline subfunction
+sudo xdp-ninja -i eth0 --func process_packet | tcpdump -n -r -
+
 # Capture both before and after (run two instances)
 sudo xdp-ninja -i eth0 | tcpdump -n -r -
 sudo xdp-ninja -i eth0 --mode exit | tcpdump -n -r -
@@ -54,11 +60,47 @@ sudo xdp-ninja -i eth0 --mode exit | tcpdump -n -r -
 | `-i, --interface` | Network interface to capture on |
 | `-p, --prog-id` | BPF program ID to attach to (alternative to `-i`) |
 | `--mode` | `entry` (before XDP, default) or `exit` (after XDP) |
+| `--func` | Attach to a specific `__noinline` subfunction by BTF name |
+| `--list-funcs` | List available BTF functions in the target program and exit |
 | `-w, --write` | Write to pcap file instead of stdout |
 | `-c, --count` | Stop after N packets (0 = unlimited) |
 | `-v, --verbose` | Verbose output to stderr |
 
 Specify either `-i` or `-p`, not both.
+
+### Attaching to subfunctions
+
+You can use `--func` to attach fentry/fexit to a `__noinline` subfunction inside the target XDP program, instead of the entry function. The subfunction must take `struct xdp_md *ctx` as its first argument.
+
+Use `--list-funcs` to discover available functions:
+
+```bash
+sudo xdp-ninja -i eth0 --list-funcs
+```
+
+Both global and static `__noinline` subfunctions work:
+
+```c
+/* Global — always survives in BTF */
+__attribute__((noinline))
+int classify_packet(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end) return 1;
+    return 2;
+}
+
+/* Static — also works, but the body must be non-trivial */
+static __attribute__((noinline))
+int parse_headers(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end) return -1;
+    return 2;
+}
+```
+
+> **Note:** The subfunction must have a non-trivial body (e.g. access `ctx->data`). A trivial body like `return 2;` will be constant-folded by `clang -O2`, eliminating the bpf2bpf call entirely.
 
 ## Prerequisites
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -46,6 +46,18 @@ var flags = []cli.Flag{
 		Name: "count", Aliases: []string{"c"},
 		Usage: "exit after capturing N packets (0 = unlimited)",
 	},
+	&cli.StringFlag{
+		Name:  "func",
+		Usage: "attach to a specific __noinline subfunction (by BTF name) instead of the entry function",
+	},
+	&cli.BoolFlag{
+		Name:  "list-funcs",
+		Usage: "list available BTF functions in the target program and exit",
+	},
+	&cli.BoolFlag{
+		Name:  "list-progs",
+		Usage: "list tail call targets reachable from the target program and exit",
+	},
 	&cli.BoolFlag{
 		Name: "verbose", Aliases: []string{"v"},
 		Usage: "verbose output to stderr",
@@ -99,6 +111,42 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 	defer info.Program.Close()
+
+	// --list-progs: show tail call targets, then exit
+	if cmd.Bool("list-progs") {
+		fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
+
+		targets, err := attach.ListTailCallTargets(info.Program)
+		if err != nil {
+			return err
+		}
+		for _, t := range targets {
+			fmt.Fprintf(os.Stderr, "id=%-6d %s (tailcall[%d])\n", t.ProgID, t.ProgName, t.Index)
+		}
+		return nil
+	}
+
+	// --list-funcs: print available BTF functions and exit
+	if cmd.Bool("list-funcs") {
+		funcs, err := attach.ListFuncs(info.Program)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "BTF functions in program (id=%d):\n", info.ProgID)
+		for _, f := range funcs {
+			fmt.Fprintf(os.Stderr, "  %-40s [%s]\n", f.Name, f.Linkage)
+		}
+		return nil
+	}
+
+	// --func: override target function name
+	if funcName := cmd.String("func"); funcName != "" {
+		if err := attach.ValidateSubfunc(info.Program, info.ProgID, funcName); err != nil {
+			return err
+		}
+		logVerbose(cmd, "overriding entry function with --func %q", funcName)
+		info.FuncName = funcName
+	}
 
 	filterExpr := strings.Join(cmd.Args().Slice(), " ")
 	logVerbose(cmd, "found XDP program %q (id=%d)", info.FuncName, info.ProgID)

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -110,7 +110,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	defer info.Program.Close()
+	defer func() { _ = info.Program.Close() }()
 
 	// --list-progs: show tail call targets, then exit
 	if cmd.Bool("list-progs") {
@@ -158,19 +158,27 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	defer probe.Close()
+	defer func() {
+		if cerr := probe.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: closing probe: %v\n", cerr)
+		}
+	}()
 
 	writer, err := output.NewWriter(cmd.String("write"), mode)
 	if err != nil {
 		return err
 	}
-	defer writer.Close()
+	defer func() {
+		if cerr := writer.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: closing writer: %v\n", cerr)
+		}
+	}()
 
 	reader, err := capture.NewReader(probe.EventsMap, 256*1024)
 	if err != nil {
 		return err
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	label := fmt.Sprintf("prog %q id=%d", info.FuncName, info.ProgID)
 	if info.IfaceName != "" {
@@ -212,7 +220,7 @@ func captureLoop(cmd *cli.Command, reader *capture.Reader, writer *output.Writer
 
 	go func() {
 		<-sig
-		reader.Close()
+		_ = reader.Close()
 	}()
 
 	count := int(cmd.Int("count"))

--- a/docs/en/handtest-func-tailcall.md
+++ b/docs/en/handtest-func-tailcall.md
@@ -1,0 +1,468 @@
+# Manual Test: xdp-ninja Packet Capture
+
+Step-by-step manual verification of xdp-ninja features.
+Starting from basic fentry/fexit on entry functions,
+progressing through `--func` subfunction probing, and tail call environments.
+
+## Prerequisites
+
+- Linux kernel 6.x or later (bpf2bpf call + tail call coexistence support)
+- Root privileges
+- clang, bpftool, tcpdump
+
+## 0. Build
+
+```bash
+cd /path/to/xdp-ninja
+go build -o xdp-ninja ./cmd/xdp-ninja/
+```
+
+---
+
+## Part 1: fentry/fexit on Entry Functions
+
+The simplest case. Attach to the XDP program's entry function and capture packets.
+
+### 1.1 Create Test Program
+
+```bash
+cat > /tmp/xdp_simple.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("xdp")
+int xdp_pass(struct xdp_md *ctx) {
+    return 2; /* XDP_PASS */
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_simple.c -o /tmp/xdp_simple.o
+```
+
+### 1.2 Set Up Environment
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+# Attach XDP program
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_simple.o sec xdp
+```
+
+Verify connectivity:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 1.3 fentry (Capture Before XDP Processing)
+
+Terminal 1:
+
+```bash
+sudo ./xdp-ninja -i vtest0 -v | tcpdump -n -r -
+```
+
+Terminal 2:
+
+```bash
+sudo ip netns exec nstest ping -c 5 10.77.0.1
+```
+
+Expected: ICMP packets are captured.
+
+### 1.4 fexit (Capture After XDP Processing)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --mode exit -v | tcpdump -n -r -
+```
+
+Expected: ICMP packets are captured.
+
+### 1.5 With Filters
+
+```bash
+# Matching filter
+sudo ./xdp-ninja -i vtest0 "icmp" -v | tcpdump -n -r -
+
+# Non-matching filter
+sudo ./xdp-ninja -i vtest0 "tcp port 80" -v -c 3 | tcpdump -n -r -
+```
+
+Expected: The icmp filter captures packets; tcp port 80 results in `0 packets captured`.
+
+### 1.6 Pcap File Output
+
+```bash
+sudo ./xdp-ninja -i vtest0 -w /tmp/capture.pcap -c 5 &
+sudo ip netns exec nstest ping -c 5 10.77.0.1
+wait
+tcpdump -n -r /tmp/capture.pcap
+```
+
+Expected: A pcap file is generated and readable by tcpdump.
+
+### 1.7 Cleanup
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```
+
+---
+
+## Part 2: Subfunction Probing with `--func`
+
+Attach to `__noinline` subfunctions and capture packets.
+The test program includes both global and static subfunctions.
+
+### 2.1 Create Test Program
+
+```
+xdp_main
+  └─ classify_packet  [global __noinline]
+      └─ parse_headers  [static __noinline]
+```
+
+```bash
+cat > /tmp/xdp_subfunc.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#define ETH_P_IP     0x0800
+#define IPPROTO_ICMP 1
+
+struct ethhdr {
+    unsigned char h_dest[6];
+    unsigned char h_source[6];
+    __be16        h_proto;
+} __attribute__((packed));
+
+struct iphdr {
+    __u8   ihl_ver;
+    __u8   tos;
+    __be16 tot_len;
+    __be16 id;
+    __be16 frag_off;
+    __u8   ttl;
+    __u8   protocol;
+    __be16 check;
+    __be32 saddr;
+    __be32 daddr;
+} __attribute__((packed));
+
+/* static __noinline: verified in the caller's context */
+static __attribute__((noinline))
+int parse_headers(struct xdp_md *ctx) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return -1;
+
+    if (eth->h_proto != __builtin_bswap16(ETH_P_IP))
+        return -1;
+
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return -1;
+
+    return ip->protocol;
+}
+
+/* global __noinline: verified independently by the verifier */
+__attribute__((noinline))
+int classify_packet(struct xdp_md *ctx) {
+    int proto = parse_headers(ctx);
+    if (proto == IPPROTO_ICMP)
+        return 2; /* XDP_PASS */
+    return 2; /* XDP_PASS */
+}
+
+SEC("xdp")
+int xdp_main(struct xdp_md *ctx) {
+    return classify_packet(ctx);
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_subfunc.c -o /tmp/xdp_subfunc.o
+```
+
+> **Note:** The subfunction body must be non-trivial (e.g., access `ctx->data`).
+> A trivial body like `return 2;` will be constant-folded by `clang -O2`,
+> eliminating the bpf2bpf call entirely.
+
+### 2.2 Set Up Environment
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_subfunc.o sec xdp
+```
+
+Verify connectivity:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 2.3 List Functions with `--list-funcs`
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-funcs
+```
+
+Expected output:
+
+```
+BTF functions in program (id=XXXX):
+  parse_headers                              [static]
+  classify_packet                            [global]
+  xdp_main                                   [global]
+```
+
+### 2.4 fentry on `classify_packet` (global)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func classify_packet -v | tcpdump -n -r -
+```
+
+Expected: ICMP packets are captured.
+
+### 2.5 fentry on `parse_headers` (static)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func parse_headers -v | tcpdump -n -r -
+```
+
+Expected: Packets are captured as well.
+
+### 2.6 fexit on Subfunction
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func classify_packet --mode exit -v | tcpdump -n -r -
+```
+
+Expected: Packets are captured.
+
+### 2.7 Non-existent Function Name (Error)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func no_such_func
+```
+
+Expected: Error message listing available functions.
+
+### 2.8 Cleanup
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```
+
+---
+
+## Part 3: Subfunction Probing in a Tail Call Environment
+
+Verify that fentry/fexit on subfunctions works when the parent program
+is reached via tail call from a dispatcher.
+
+### 3.1 Create Test Program
+
+```
+xdp_dispatcher
+  └─ tail call ─→ xdp_leaf
+                    └─ classify_packet  [global]
+                        └─ parse_headers  [static]
+```
+
+```bash
+cat > /tmp/xdp_tc_subfunc.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#define ETH_P_IP     0x0800
+#define IPPROTO_ICMP 1
+
+struct ethhdr {
+    unsigned char h_dest[6];
+    unsigned char h_source[6];
+    __be16        h_proto;
+} __attribute__((packed));
+
+struct iphdr {
+    __u8   ihl_ver;
+    __u8   tos;
+    __be16 tot_len;
+    __be16 id;
+    __be16 frag_off;
+    __u8   ttl;
+    __u8   protocol;
+    __be16 check;
+    __be32 saddr;
+    __be32 daddr;
+} __attribute__((packed));
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, 1);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+} prog_array SEC(".maps");
+
+/* static __noinline */
+static __attribute__((noinline))
+int parse_headers(struct xdp_md *ctx) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return -1;
+
+    if (eth->h_proto != __builtin_bswap16(ETH_P_IP))
+        return -1;
+
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return -1;
+
+    return ip->protocol;
+}
+
+/* global __noinline */
+__attribute__((noinline))
+int classify_packet(struct xdp_md *ctx) {
+    int proto = parse_headers(ctx);
+    if (proto == IPPROTO_ICMP)
+        return 2;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_leaf(struct xdp_md *ctx) {
+    return classify_packet(ctx);
+}
+
+SEC("xdp")
+int xdp_dispatcher(struct xdp_md *ctx) {
+    bpf_tail_call(ctx, &prog_array, 0);
+    return 2;
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_tc_subfunc.c -o /tmp/xdp_tc_subfunc.o
+```
+
+### 3.2 Set Up Environment
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+# Load with bpftool (dispatcher and leaf as separate programs)
+sudo rm -rf /sys/fs/bpf/tctest
+sudo mkdir -p /sys/fs/bpf/tctest
+sudo bpftool prog loadall /tmp/xdp_tc_subfunc.o /sys/fs/bpf/tctest
+
+# Get program IDs
+DISP_ID=$(sudo bpftool prog show pinned /sys/fs/bpf/tctest/xdp_dispatcher | head -1 | awk '{print $1}' | tr -d ':')
+LEAF_ID=$(sudo bpftool prog show pinned /sys/fs/bpf/tctest/xdp_leaf | head -1 | awk '{print $1}' | tr -d ':')
+echo "DISP_ID=$DISP_ID LEAF_ID=$LEAF_ID"
+
+# Attach dispatcher to interface
+sudo bpftool net attach xdp id "$DISP_ID" dev vtest0
+
+# Pin prog_array and set up the tail call
+MAP_ID=$(sudo bpftool prog show id "$DISP_ID" | grep -oP 'map_ids \K\d+')
+sudo bpftool map pin id "$MAP_ID" /sys/fs/bpf/tctest/prog_array
+sudo bpftool map update pinned /sys/fs/bpf/tctest/prog_array key 0 0 0 0 value id "$LEAF_ID"
+```
+
+Verify connectivity:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 3.3 Discover Tail Call Targets with `--list-progs`
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-progs
+```
+
+Expected output:
+
+```
+id=XXXX   xdp_dispatcher
+id=YYYY   xdp_leaf (tailcall[0])
+```
+
+### 3.4 List Leaf's Subfunctions
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --list-funcs
+```
+
+### 3.5 fentry on Subfunction (Via Tail Call)
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --func classify_packet -v | tcpdump -n -r -
+```
+
+Expected: ICMP packets are captured.
+The bpf2bpf call inside the tail-called program goes through its trampoline normally.
+
+### 3.6 fexit on Subfunction
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --func classify_packet --mode exit -v | tcpdump -n -r -
+```
+
+Expected: Packets are captured.
+
+### 3.7 Direct Attach to Tail Call Target Entry (Does Not Fire)
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID -v -c 3 | tcpdump -n -r -
+```
+
+Expected: `0 packets captured`.
+Tail calls use `jmp` to bypass the entry function's trampoline,
+so fentry on the entry function does not fire.
+However, internal bpf2bpf calls are regular function calls
+and their trampolines work correctly.
+
+### 3.8 Cleanup
+
+```bash
+sudo bpftool net detach xdp dev vtest0
+sudo rm -rf /sys/fs/bpf/tctest
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```

--- a/docs/ja/handtest-func-tailcall.md
+++ b/docs/ja/handtest-func-tailcall.md
@@ -1,0 +1,466 @@
+# ハンドテスト: xdp-ninja パケットキャプチャ
+
+xdp-ninja の各機能を手動で検証する手順書。
+シンプルな XDP プログラムへの fentry/fexit から始め、
+`--func` によるサブ関数プローブ、tail call 環境での動作まで段階的に確認する。
+
+## 前提条件
+
+- Linux kernel 6.x 以上（bpf2bpf call と tail call の共存をサポート）
+- root 権限
+- clang, bpftool, tcpdump
+
+## 0. ビルド
+
+```bash
+cd /path/to/xdp-ninja
+go build -o xdp-ninja ./cmd/xdp-ninja/
+```
+
+---
+
+## Part 1: エントリ関数への fentry/fexit
+
+最もシンプルなケース。XDP プログラムのエントリ関数にアタッチしてパケットをキャプチャする。
+
+### 1.1 テスト用プログラムの作成
+
+```bash
+cat > /tmp/xdp_simple.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("xdp")
+int xdp_pass(struct xdp_md *ctx) {
+    return 2; /* XDP_PASS */
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_simple.c -o /tmp/xdp_simple.o
+```
+
+### 1.2 環境構築
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+# XDP プログラムをアタッチ
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_simple.o sec xdp
+```
+
+疎通確認:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 1.3 fentry（XDP 処理前のキャプチャ）
+
+ターミナル 1:
+
+```bash
+sudo ./xdp-ninja -i vtest0 -v | tcpdump -n -r -
+```
+
+ターミナル 2:
+
+```bash
+sudo ip netns exec nstest ping -c 5 10.77.0.1
+```
+
+期待: ICMP パケットがキャプチャされる。
+
+### 1.4 fexit（XDP 処理後のキャプチャ）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --mode exit -v | tcpdump -n -r -
+```
+
+期待: ICMP パケットがキャプチャされる。
+
+### 1.5 フィルタ付き
+
+```bash
+# マッチするフィルタ
+sudo ./xdp-ninja -i vtest0 "icmp" -v | tcpdump -n -r -
+
+# マッチしないフィルタ
+sudo ./xdp-ninja -i vtest0 "tcp port 80" -v -c 3 | tcpdump -n -r -
+```
+
+期待: icmp フィルタではキャプチャされ、tcp port 80 では `0 packets captured`。
+
+### 1.6 pcap ファイル出力
+
+```bash
+sudo ./xdp-ninja -i vtest0 -w /tmp/capture.pcap -c 5 &
+sudo ip netns exec nstest ping -c 5 10.77.0.1
+wait
+tcpdump -n -r /tmp/capture.pcap
+```
+
+期待: pcap ファイルが生成され、tcpdump で読める。
+
+### 1.7 クリーンアップ
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```
+
+---
+
+## Part 2: `--func` によるサブ関数プローブ
+
+`__noinline` サブ関数にアタッチしてキャプチャする。
+global と static の両方を含むプログラムで動作を確認する。
+
+### 2.1 テスト用プログラムの作成
+
+```
+xdp_main
+  └─ classify_packet  [global __noinline]
+      └─ parse_headers  [static __noinline]
+```
+
+```bash
+cat > /tmp/xdp_subfunc.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#define ETH_P_IP     0x0800
+#define IPPROTO_ICMP 1
+
+struct ethhdr {
+    unsigned char h_dest[6];
+    unsigned char h_source[6];
+    __be16        h_proto;
+} __attribute__((packed));
+
+struct iphdr {
+    __u8   ihl_ver;
+    __u8   tos;
+    __be16 tot_len;
+    __be16 id;
+    __be16 frag_off;
+    __u8   ttl;
+    __u8   protocol;
+    __be16 check;
+    __be32 saddr;
+    __be32 daddr;
+} __attribute__((packed));
+
+/* static __noinline: verifier が呼び出し元のコンテキストで検証する */
+static __attribute__((noinline))
+int parse_headers(struct xdp_md *ctx) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return -1;
+
+    if (eth->h_proto != __builtin_bswap16(ETH_P_IP))
+        return -1;
+
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return -1;
+
+    return ip->protocol;
+}
+
+/* global __noinline: verifier が独立して検証する */
+__attribute__((noinline))
+int classify_packet(struct xdp_md *ctx) {
+    int proto = parse_headers(ctx);
+    if (proto == IPPROTO_ICMP)
+        return 2; /* XDP_PASS */
+    return 2; /* XDP_PASS */
+}
+
+SEC("xdp")
+int xdp_main(struct xdp_md *ctx) {
+    return classify_packet(ctx);
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_subfunc.c -o /tmp/xdp_subfunc.o
+```
+
+> **注意:** `__noinline` サブ関数の body は `ctx->data` 等にアクセスする非自明な処理が必要。
+> `return 2;` だけの trivial な body は `clang -O2` で定数畳み込みされ、bpf2bpf call ごと消える。
+
+### 2.2 環境構築
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_subfunc.o sec xdp
+```
+
+疎通確認:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 2.3 `--list-funcs` で関数一覧を確認
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-funcs
+```
+
+期待出力:
+
+```
+BTF functions in program (id=XXXX):
+  parse_headers                              [static]
+  classify_packet                            [global]
+  xdp_main                                   [global]
+```
+
+### 2.4 fentry on `classify_packet`（global）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func classify_packet -v | tcpdump -n -r -
+```
+
+期待: ICMP パケットがキャプチャされる。
+
+### 2.5 fentry on `parse_headers`（static）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func parse_headers -v | tcpdump -n -r -
+```
+
+期待: 同様にキャプチャされる。
+
+### 2.6 fexit on サブ関数
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func classify_packet --mode exit -v | tcpdump -n -r -
+```
+
+期待: キャプチャされる。
+
+### 2.7 存在しない関数名（エラー）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func no_such_func
+```
+
+期待: 利用可能な関数名を含むエラーメッセージ。
+
+### 2.8 クリーンアップ
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```
+
+---
+
+## Part 3: tail call 環境でのサブ関数プローブ
+
+dispatcher が tail call で leaf を呼び出す構成で、
+leaf 内のサブ関数に fentry/fexit をアタッチできることを確認する。
+
+### 3.1 テスト用プログラムの作成
+
+```
+xdp_dispatcher
+  └─ tail call ─→ xdp_leaf
+                    └─ classify_packet  [global]
+                        └─ parse_headers  [static]
+```
+
+```bash
+cat > /tmp/xdp_tc_subfunc.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#define ETH_P_IP     0x0800
+#define IPPROTO_ICMP 1
+
+struct ethhdr {
+    unsigned char h_dest[6];
+    unsigned char h_source[6];
+    __be16        h_proto;
+} __attribute__((packed));
+
+struct iphdr {
+    __u8   ihl_ver;
+    __u8   tos;
+    __be16 tot_len;
+    __be16 id;
+    __be16 frag_off;
+    __u8   ttl;
+    __u8   protocol;
+    __be16 check;
+    __be32 saddr;
+    __be32 daddr;
+} __attribute__((packed));
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, 1);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+} prog_array SEC(".maps");
+
+/* static __noinline */
+static __attribute__((noinline))
+int parse_headers(struct xdp_md *ctx) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return -1;
+
+    if (eth->h_proto != __builtin_bswap16(ETH_P_IP))
+        return -1;
+
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return -1;
+
+    return ip->protocol;
+}
+
+/* global __noinline */
+__attribute__((noinline))
+int classify_packet(struct xdp_md *ctx) {
+    int proto = parse_headers(ctx);
+    if (proto == IPPROTO_ICMP)
+        return 2;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_leaf(struct xdp_md *ctx) {
+    return classify_packet(ctx);
+}
+
+SEC("xdp")
+int xdp_dispatcher(struct xdp_md *ctx) {
+    bpf_tail_call(ctx, &prog_array, 0);
+    return 2;
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_tc_subfunc.c -o /tmp/xdp_tc_subfunc.o
+```
+
+### 3.2 環境構築
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+# bpftool でロード（dispatcher と leaf を別プログラムとしてロード）
+sudo rm -rf /sys/fs/bpf/tctest
+sudo mkdir -p /sys/fs/bpf/tctest
+sudo bpftool prog loadall /tmp/xdp_tc_subfunc.o /sys/fs/bpf/tctest
+
+# プログラム ID を取得
+DISP_ID=$(sudo bpftool prog show pinned /sys/fs/bpf/tctest/xdp_dispatcher | head -1 | awk '{print $1}' | tr -d ':')
+LEAF_ID=$(sudo bpftool prog show pinned /sys/fs/bpf/tctest/xdp_leaf | head -1 | awk '{print $1}' | tr -d ':')
+echo "DISP_ID=$DISP_ID LEAF_ID=$LEAF_ID"
+
+# dispatcher をインターフェースにアタッチ
+sudo bpftool net attach xdp id "$DISP_ID" dev vtest0
+
+# prog_array を pin して tail call を設定
+MAP_ID=$(sudo bpftool prog show id "$DISP_ID" | grep -oP 'map_ids \K\d+')
+sudo bpftool map pin id "$MAP_ID" /sys/fs/bpf/tctest/prog_array
+sudo bpftool map update pinned /sys/fs/bpf/tctest/prog_array key 0 0 0 0 value id "$LEAF_ID"
+```
+
+疎通確認:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 3.3 `--list-progs` で tail call ツリーを確認
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-progs
+```
+
+期待出力:
+
+```
+id=XXXX   xdp_dispatcher
+id=YYYY   xdp_leaf (tailcall[0])
+```
+
+### 3.4 leaf のサブ関数一覧
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --list-funcs
+```
+
+### 3.5 fentry on サブ関数（tail call 経由で発火するか）
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --func classify_packet -v | tcpdump -n -r -
+```
+
+期待: ICMP パケットがキャプチャされる。
+tail call 先プログラム内の bpf2bpf call はトランポリンが正常に動作する。
+
+### 3.6 fexit on サブ関数
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID --func classify_packet --mode exit -v | tcpdump -n -r -
+```
+
+期待: キャプチャされる。
+
+### 3.7 tail call 先エントリ関数への直接アタッチ（発火しないケース）
+
+```bash
+sudo ./xdp-ninja -p $LEAF_ID -v -c 3 | tcpdump -n -r -
+```
+
+期待: `0 packets captured`。
+tail call は `jmp` でエントリのトランポリンをバイパスするため、
+エントリ関数への fentry は発火しない。
+一方、内部の bpf2bpf call は通常の関数呼び出しなのでトランポリンが動作する。
+
+### 3.8 クリーンアップ
+
+```bash
+sudo bpftool net detach xdp dev vtest0
+sudo rm -rf /sys/fs/bpf/tctest
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -69,6 +69,143 @@ func FindXDPProgram(ifaceName string) (*XDPInfo, error) {
 	}, nil
 }
 
+// TailCallTarget holds information about a program in a PROG_ARRAY map.
+type TailCallTarget struct {
+	Index    uint32
+	ProgID   uint32
+	ProgName string
+}
+
+// ListTailCallTargets finds all tail call targets reachable from the given program
+// by scanning its PROG_ARRAY maps.
+func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
+	info, err := prog.Info()
+	if err != nil {
+		return nil, fmt.Errorf("getting program info: %w", err)
+	}
+
+	mapIDs, ok := info.MapIDs()
+	if !ok {
+		return nil, nil
+	}
+
+	var targets []TailCallTarget
+	for _, mapID := range mapIDs {
+		m, err := ebpf.NewMapFromID(mapID)
+		if err != nil {
+			continue
+		}
+
+		mapInfo, err := m.Info()
+		if err != nil {
+			m.Close()
+			continue
+		}
+		if mapInfo.Type != ebpf.ProgramArray {
+			m.Close()
+			continue
+		}
+
+		// Iterate PROG_ARRAY entries
+		var key, val uint32
+		iter := m.Iterate()
+		for iter.Next(&key, &val) {
+			progID := val
+			targetProg, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
+			if err != nil {
+				continue
+			}
+
+			targetInfo, err := targetProg.Info()
+			if err != nil {
+				targetProg.Close()
+				continue
+			}
+
+			targets = append(targets, TailCallTarget{
+				Index:    key,
+				ProgID:   progID,
+				ProgName: targetInfo.Name,
+			})
+			targetProg.Close()
+		}
+		m.Close()
+	}
+
+	return targets, nil
+}
+
+// FuncInfo holds metadata about a BTF function in a BPF program.
+type FuncInfo struct {
+	Name    string
+	Linkage string // "static", "global", "extern"
+}
+
+// btfSpec opens the BTF handle for a loaded program and returns its spec.
+func btfSpec(prog *ebpf.Program) (*btf.Spec, error) {
+	handle, err := prog.Handle()
+	if err != nil {
+		return nil, fmt.Errorf("BTF unavailable: %w", err)
+	}
+	defer handle.Close()
+
+	spec, err := handle.Spec(nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading BTF: %w", err)
+	}
+	return spec, nil
+}
+
+// ListFuncs returns all BTF function entries found in the program.
+func ListFuncs(prog *ebpf.Program) ([]FuncInfo, error) {
+	spec, err := btfSpec(prog)
+	if err != nil {
+		return nil, err
+	}
+	return ListFuncsFromSpec(spec)
+}
+
+// ValidateSubfunc checks that the given function name exists in the program's BTF.
+// If the function is not found, the error message includes a list of available functions.
+func ValidateSubfunc(prog *ebpf.Program, progID uint32, funcName string) error {
+	spec, err := btfSpec(prog)
+	if err != nil {
+		return fmt.Errorf("program (id=%d): %w", progID, err)
+	}
+
+	var fn *btf.Func
+	if err := spec.TypeByName(funcName, &fn); err == nil {
+		return nil
+	}
+
+	funcs, _ := ListFuncsFromSpec(spec)
+	var names []string
+	for _, f := range funcs {
+		names = append(names, f.Name)
+	}
+	return fmt.Errorf(
+		"function %q not found in program (id=%d) BTF; available functions: %v",
+		funcName, progID, names,
+	)
+}
+
+// ListFuncsFromSpec collects function entries from a BTF spec.
+func ListFuncsFromSpec(spec *btf.Spec) ([]FuncInfo, error) {
+	var funcs []FuncInfo
+	for typ, err := range spec.All() {
+		if err != nil {
+			return funcs, err
+		}
+		if f, ok := typ.(*btf.Func); ok {
+			funcs = append(funcs, FuncInfo{
+				Name:    f.Name,
+				Linkage: f.Linkage.String(),
+			})
+		}
+	}
+	return funcs, nil
+}
+
 // resolveEntryFunc resolves the entry function name from the program's BTF.
 //
 // fentry/fexit requires BTF, so this function errors if BTF is unavailable

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -93,13 +93,13 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 	for _, mapID := range mapIDs {
 		m, err := ebpf.NewMapFromID(mapID)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("opening map %d: %w", mapID, err)
 		}
 
 		mapInfo, err := m.Info()
 		if err != nil {
 			_ = m.Close()
-			continue
+			return nil, fmt.Errorf("getting map %d info: %w", mapID, err)
 		}
 		if mapInfo.Type != ebpf.ProgramArray {
 			_ = m.Close()
@@ -113,13 +113,15 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 			progID := val
 			targetProg, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
 			if err != nil {
-				continue
+				_ = m.Close()
+				return nil, fmt.Errorf("opening tail call target (id=%d): %w", progID, err)
 			}
 
 			targetInfo, err := targetProg.Info()
 			if err != nil {
 				_ = targetProg.Close()
-				continue
+				_ = m.Close()
+				return nil, fmt.Errorf("getting tail call target info (id=%d): %w", progID, err)
 			}
 
 			targets = append(targets, TailCallTarget{
@@ -128,6 +130,10 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 				ProgName: targetInfo.Name,
 			})
 			_ = targetProg.Close()
+		}
+		if err := iter.Err(); err != nil {
+			_ = m.Close()
+			return nil, fmt.Errorf("iterating program array map %d: %w", mapID, err)
 		}
 		_ = m.Close()
 	}
@@ -178,7 +184,10 @@ func ValidateSubfunc(prog *ebpf.Program, progID uint32, funcName string) error {
 		return nil
 	}
 
-	funcs, _ := ListFuncsFromSpec(spec)
+	funcs, ferr := ListFuncsFromSpec(spec)
+	if ferr != nil {
+		return fmt.Errorf("function %q not found in program (id=%d) BTF (also failed to list functions: %v)", funcName, progID, ferr)
+	}
 	var names []string
 	for _, f := range funcs {
 		names = append(names, f.Name)

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -27,7 +27,7 @@ func FindXDPProgramByID(progID uint32) (*XDPInfo, error) {
 
 	funcName, err := resolveEntryFunc(prog, progID)
 	if err != nil {
-		prog.Close()
+		_ = prog.Close()
 		return nil, err
 	}
 
@@ -57,7 +57,7 @@ func FindXDPProgram(ifaceName string) (*XDPInfo, error) {
 
 	funcName, err := resolveEntryFunc(prog, xdp.ProgId)
 	if err != nil {
-		prog.Close()
+		_ = prog.Close()
 		return nil, err
 	}
 
@@ -98,11 +98,11 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 
 		mapInfo, err := m.Info()
 		if err != nil {
-			m.Close()
+			_ = m.Close()
 			continue
 		}
 		if mapInfo.Type != ebpf.ProgramArray {
-			m.Close()
+			_ = m.Close()
 			continue
 		}
 
@@ -118,7 +118,7 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 
 			targetInfo, err := targetProg.Info()
 			if err != nil {
-				targetProg.Close()
+				_ = targetProg.Close()
 				continue
 			}
 
@@ -127,9 +127,9 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 				ProgID:   progID,
 				ProgName: targetInfo.Name,
 			})
-			targetProg.Close()
+			_ = targetProg.Close()
 		}
-		m.Close()
+		_ = m.Close()
 	}
 
 	return targets, nil
@@ -147,7 +147,7 @@ func btfSpec(prog *ebpf.Program) (*btf.Spec, error) {
 	if err != nil {
 		return nil, fmt.Errorf("BTF unavailable: %w", err)
 	}
-	defer handle.Close()
+	defer func() { _ = handle.Close() }()
 
 	spec, err := handle.Spec(nil)
 	if err != nil {
@@ -228,7 +228,7 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("program %q (id=%d): BTF unavailable (required for fentry/fexit): %w", progName, progID, err)
 	}
-	defer handle.Close()
+	defer func() { _ = handle.Close() }()
 
 	spec, err := handle.Spec(nil)
 	if err != nil {

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -1,6 +1,7 @@
 package attach
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -8,5 +9,46 @@ func TestFindXDPProgramNoInterface(t *testing.T) {
 	_, err := FindXDPProgram("nonexistent_iface_xyz")
 	if err == nil {
 		t.Fatal("expected error for nonexistent interface, got nil")
+	}
+}
+
+func TestListFuncs(t *testing.T) {
+	prog := loadTestXDP(t)
+	funcs, err := ListFuncs(prog)
+	if err != nil {
+		t.Fatalf("ListFuncs: %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, f := range funcs {
+		found[f.Name] = true
+	}
+
+	if !found["xdp_subfunc_test"] {
+		t.Error("expected xdp_subfunc_test in function list")
+	}
+	if !found["process_packet"] {
+		t.Error("expected process_packet in function list")
+	}
+}
+
+func TestValidateSubfuncValid(t *testing.T) {
+	prog := loadTestXDP(t)
+	if err := ValidateSubfunc(prog, 0, "process_packet"); err != nil {
+		t.Fatalf("ValidateSubfunc for valid func: %v", err)
+	}
+}
+
+func TestValidateSubfuncNotFound(t *testing.T) {
+	prog := loadTestXDP(t)
+	err := ValidateSubfunc(prog, 0, "nonexistent_func")
+	if err == nil {
+		t.Fatal("expected error for nonexistent function, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "process_packet") {
+		t.Errorf("error should list available functions, got: %v", err)
 	}
 }

--- a/internal/attach/testutil_test.go
+++ b/internal/attach/testutil_test.go
@@ -45,7 +45,9 @@ func loadTestXDP(t *testing.T) *ebpf.Program {
 	dir := t.TempDir()
 	srcFile := filepath.Join(dir, "xdp.c")
 	objFile := filepath.Join(dir, "xdp.o")
-	os.WriteFile(srcFile, []byte(xdpSubfuncSource), 0644)
+	if err := os.WriteFile(srcFile, []byte(xdpSubfuncSource), 0644); err != nil {
+		t.Fatalf("writing source: %v", err)
+	}
 
 	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
 	if err != nil {
@@ -63,6 +65,6 @@ func loadTestXDP(t *testing.T) *ebpf.Program {
 	if err := spec.LoadAndAssign(&objs, nil); err != nil {
 		t.Fatalf("loading XDP program: %v", err)
 	}
-	t.Cleanup(func() { objs.Prog.Close() })
+	t.Cleanup(func() { _ = objs.Prog.Close() })
 	return objs.Prog
 }

--- a/internal/attach/testutil_test.go
+++ b/internal/attach/testutil_test.go
@@ -1,0 +1,68 @@
+package attach
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// xdpSubfuncSource has a __noinline subfunction that accesses ctx.
+// The body must be non-trivial; otherwise clang -O2 constant-folds
+// the call away and no bpf2bpf call survives in the bytecode.
+const xdpSubfuncSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int process_packet(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_subfunc_test(struct xdp_md *ctx) { return process_packet(ctx); }
+char _license[] SEC("license") = "GPL";
+`
+
+func skipIfNotRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("requires root")
+	}
+}
+
+// loadTestXDP compiles and loads an XDP program with a __noinline subfunction.
+func loadTestXDP(t *testing.T) *ebpf.Program {
+	t.Helper()
+	skipIfNotRoot(t)
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "xdp.c")
+	objFile := filepath.Join(dir, "xdp.o")
+	os.WriteFile(srcFile, []byte(xdpSubfuncSource), 0644)
+
+	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
+	if err != nil {
+		t.Skipf("clang not available: %v\n%s", err, out)
+	}
+
+	spec, err := ebpf.LoadCollectionSpec(objFile)
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"xdp_subfunc_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading XDP program: %v", err)
+	}
+	t.Cleanup(func() { objs.Prog.Close() })
+	return objs.Prog
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -47,7 +47,9 @@ func NewWriter(path string, mode string) (*Writer, error) {
 	}
 	if err != nil {
 		if w.file != nil {
-			w.file.Close()
+			if cerr := w.file.Close(); cerr != nil {
+				err = fmt.Errorf("%w (also failed to close file: %v)", err, cerr)
+			}
 		}
 		return nil, fmt.Errorf("creating pcap writer: %w", err)
 	}

--- a/internal/program/load_test.go
+++ b/internal/program/load_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestBpfEntryLoad verifies that the fentry program passes the verifier.
 func TestBpfEntryLoad(t *testing.T) {
-	probe := loadProbeOrFail(t, loadDummyXDP(t), "", false)
+	probe := loadProbeOrFail(t, loadDummyXDP(t), xdpFuncName, "", false)
 	if probe.EventsMap == nil {
 		t.Error("EventsMap is nil")
 	}
@@ -14,7 +14,7 @@ func TestBpfEntryLoad(t *testing.T) {
 
 // TestBpfExitLoad verifies that the fexit program passes the verifier.
 func TestBpfExitLoad(t *testing.T) {
-	probe := loadProbeOrFail(t, loadDummyXDP(t), "", true)
+	probe := loadProbeOrFail(t, loadDummyXDP(t), xdpFuncName, "", true)
 	if probe.EventsMap == nil {
 		t.Error("EventsMap is nil")
 	}
@@ -25,7 +25,7 @@ func TestBpfEntryWithFilter(t *testing.T) {
 	xdpProg := loadDummyXDP(t)
 	for _, expr := range []string{"arp", "icmp", "tcp port 80", "host 10.0.0.1"} {
 		t.Run(expr, func(t *testing.T) {
-			loadProbeOrFail(t, xdpProg, expr, false)
+			loadProbeOrFail(t, xdpProg, xdpFuncName, expr, false)
 		})
 	}
 }
@@ -35,7 +35,35 @@ func TestBpfExitWithFilter(t *testing.T) {
 	xdpProg := loadDummyXDP(t)
 	for _, expr := range []string{"arp", "icmp", "tcp port 80", "host 10.0.0.1"} {
 		t.Run(expr, func(t *testing.T) {
-			loadProbeOrFail(t, xdpProg, expr, true)
+			loadProbeOrFail(t, xdpProg, xdpFuncName, expr, true)
+		})
+	}
+}
+
+// TestBpfSubfuncEntryLoad verifies fentry on a __noinline subfunction passes the verifier.
+func TestBpfSubfuncEntryLoad(t *testing.T) {
+	xdpProg := loadDummyXDPWithSubfunc(t)
+	probe := loadProbeOrFail(t, xdpProg, xdpSubfuncName, "", false)
+	if probe.EventsMap == nil {
+		t.Error("EventsMap is nil")
+	}
+}
+
+// TestBpfSubfuncExitLoad verifies fexit on a __noinline subfunction passes the verifier.
+func TestBpfSubfuncExitLoad(t *testing.T) {
+	xdpProg := loadDummyXDPWithSubfunc(t)
+	probe := loadProbeOrFail(t, xdpProg, xdpSubfuncName, "", true)
+	if probe.EventsMap == nil {
+		t.Error("EventsMap is nil")
+	}
+}
+
+// TestBpfSubfuncEntryWithFilter verifies fentry on subfunc + filter passes the verifier.
+func TestBpfSubfuncEntryWithFilter(t *testing.T) {
+	xdpProg := loadDummyXDPWithSubfunc(t)
+	for _, expr := range []string{"arp", "icmp", "tcp port 80"} {
+		t.Run(expr, func(t *testing.T) {
+			loadProbeOrFail(t, xdpProg, xdpSubfuncName, expr, false)
 		})
 	}
 }

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -3,6 +3,7 @@
 package program
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cilium/ebpf"
@@ -23,16 +24,24 @@ type Probe struct {
 	link      link.Link
 }
 
-func (p *Probe) Close() {
+func (p *Probe) Close() error {
+	var errs []error
 	if p.link != nil {
-		p.link.Close()
+		if err := p.link.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	if p.prog != nil {
-		p.prog.Close()
+		if err := p.prog.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	for _, m := range p.maps {
-		m.Close()
+		if err := m.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return errors.Join(errs...)
 }
 
 // LoadEntry は fentry (前段) probe を作成してアタッチする。
@@ -84,7 +93,7 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, isF
 			KeySize: 4, ValueSize: scratchBufSize, MaxEntries: 1,
 		})
 		if err != nil {
-			probe.Close()
+			_ = probe.Close()
 			return nil, fmt.Errorf("creating scratch map: %w", err)
 		}
 		probe.maps = append(probe.maps, scratchMap)
@@ -98,14 +107,14 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, isF
 		Instructions: insns, License: "GPL",
 	})
 	if err != nil {
-		probe.Close()
+		_ = probe.Close()
 		return nil, fmt.Errorf("loading %s program: %w", label, err)
 	}
 	probe.prog = prog
 
 	l, err := link.AttachTracing(link.TracingOptions{Program: prog, AttachType: attachType})
 	if err != nil {
-		probe.Close()
+		_ = probe.Close()
 		return nil, fmt.Errorf("attaching %s: %w", label, err)
 	}
 	probe.link = l

--- a/internal/program/tailcall_fentry_test.go
+++ b/internal/program/tailcall_fentry_test.go
@@ -66,9 +66,9 @@ func loadTailcallCollection(t *testing.T) (dispatcher, leaf *ebpf.Program, progA
 		t.Fatalf("load: %v", err)
 	}
 	t.Cleanup(func() {
-		objs.Dispatcher.Close()
-		objs.Leaf.Close()
-		objs.ProgArray.Close()
+		_ = objs.Dispatcher.Close()
+		_ = objs.Leaf.Close()
+		_ = objs.ProgArray.Close()
 	})
 
 	if err := objs.ProgArray.Put(uint32(0), uint32(objs.Leaf.FD())); err != nil {
@@ -83,14 +83,14 @@ func setupVethWithXDP(t *testing.T, xdpProg *ebpf.Program) (ifaceName string) {
 	t.Helper()
 	const veth0, veth1 = "tcftest0", "tcftest1"
 
-	exec.Command("ip", "link", "del", veth0).Run()
+	_ = exec.Command("ip", "link", "del", veth0).Run()
 	if err := netlink.LinkAdd(&netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: veth0},
 		PeerName:  veth1,
 	}); err != nil {
 		t.Fatalf("veth add: %v", err)
 	}
-	t.Cleanup(func() { exec.Command("ip", "link", "del", veth0).Run() })
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", veth0).Run() })
 
 	nl0, err := netlink.LinkByName(veth0)
 	if err != nil {
@@ -116,7 +116,7 @@ func setupVethWithXDP(t *testing.T, xdpProg *ebpf.Program) (ifaceName string) {
 	if err := netlink.LinkSetXdpFd(nl0, xdpProg.FD()); err != nil {
 		t.Fatalf("XDP attach: %v", err)
 	}
-	t.Cleanup(func() { netlink.LinkSetXdpFd(nl0, -1) })
+	t.Cleanup(func() { _ = netlink.LinkSetXdpFd(nl0, -1) })
 
 	return veth0
 }
@@ -136,13 +136,13 @@ func countProbeEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface st
 	if err != nil {
 		t.Fatalf("load probe (%s): %v", funcName, err)
 	}
-	defer probe.Close()
+	defer func() { _ = probe.Close() }()
 
 	reader, err := perf.NewReader(probe.EventsMap, 64*1024)
 	if err != nil {
 		t.Fatalf("perf reader: %v", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	// Give the probe time to attach before sending packets.
 	time.Sleep(200 * time.Millisecond)
@@ -150,7 +150,7 @@ func countProbeEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface st
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		exec.Command("ping", "-c", "5", "-W", "1", "-I", iface, "10.99.0.2").CombinedOutput()
+		_, _ = exec.Command("ping", "-c", "5", "-W", "1", "-I", iface, "10.99.0.2").CombinedOutput()
 	}()
 	defer func() { <-done }()
 

--- a/internal/program/tailcall_fentry_test.go
+++ b/internal/program/tailcall_fentry_test.go
@@ -1,0 +1,213 @@
+package program
+
+import (
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"github.com/vishvananda/netlink"
+)
+
+// tailcallSubfuncSource sets up a tail call chain:
+//   xdp_dispatcher → tail call → xdp_leaf → bpf2bpf call → process_in_leaf
+const tailcallSubfuncSource = `
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, 1);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+} prog_array SEC(".maps");
+
+__attribute__((noinline))
+int process_in_leaf(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_leaf(struct xdp_md *ctx) {
+    return process_in_leaf(ctx);
+}
+
+SEC("xdp")
+int xdp_dispatcher(struct xdp_md *ctx) {
+    bpf_tail_call(ctx, &prog_array, 0);
+    return 2;
+}
+
+char _license[] SEC("license") = "GPL";
+`
+
+// loadTailcallCollection compiles and loads the tail call test programs.
+func loadTailcallCollection(t *testing.T) (dispatcher, leaf *ebpf.Program, progArray *ebpf.Map) {
+	t.Helper()
+	skipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(compileXDPObjFromSource(t, tailcallSubfuncSource))
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+
+	var objs struct {
+		Dispatcher *ebpf.Program `ebpf:"xdp_dispatcher"`
+		Leaf       *ebpf.Program `ebpf:"xdp_leaf"`
+		ProgArray  *ebpf.Map     `ebpf:"prog_array"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Cleanup(func() {
+		objs.Dispatcher.Close()
+		objs.Leaf.Close()
+		objs.ProgArray.Close()
+	})
+
+	if err := objs.ProgArray.Put(uint32(0), uint32(objs.Leaf.FD())); err != nil {
+		t.Fatalf("prog_array put: %v", err)
+	}
+
+	return objs.Dispatcher, objs.Leaf, objs.ProgArray
+}
+
+// setupVethWithXDP creates a veth pair and attaches the given XDP program.
+func setupVethWithXDP(t *testing.T, xdpProg *ebpf.Program) (ifaceName string) {
+	t.Helper()
+	const veth0, veth1 = "tcftest0", "tcftest1"
+
+	exec.Command("ip", "link", "del", veth0).Run()
+	if err := netlink.LinkAdd(&netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: veth0},
+		PeerName:  veth1,
+	}); err != nil {
+		t.Fatalf("veth add: %v", err)
+	}
+	t.Cleanup(func() { exec.Command("ip", "link", "del", veth0).Run() })
+
+	nl0, err := netlink.LinkByName(veth0)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", veth0, err)
+	}
+	nl1, err := netlink.LinkByName(veth1)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", veth1, err)
+	}
+	if err := netlink.LinkSetUp(nl0); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", veth0, err)
+	}
+	if err := netlink.LinkSetUp(nl1); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", veth1, err)
+	}
+	if err := netlink.AddrAdd(nl0, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.99.0.1"), Mask: net.CIDRMask(24, 32)}}); err != nil {
+		t.Fatalf("AddrAdd(%s): %v", veth0, err)
+	}
+	if err := netlink.AddrAdd(nl1, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.99.0.2"), Mask: net.CIDRMask(24, 32)}}); err != nil {
+		t.Fatalf("AddrAdd(%s): %v", veth1, err)
+	}
+
+	if err := netlink.LinkSetXdpFd(nl0, xdpProg.FD()); err != nil {
+		t.Fatalf("XDP attach: %v", err)
+	}
+	t.Cleanup(func() { netlink.LinkSetXdpFd(nl0, -1) })
+
+	return veth0
+}
+
+// countProbeEvents attaches fentry or fexit to funcName, sends packets,
+// and returns the number of perf events received.
+func countProbeEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface string, isFexit bool) int {
+	t.Helper()
+
+	var probe *Probe
+	var err error
+	if isFexit {
+		probe, err = LoadExit(targetProg, funcName, "")
+	} else {
+		probe, err = LoadEntry(targetProg, funcName, "")
+	}
+	if err != nil {
+		t.Fatalf("load probe (%s): %v", funcName, err)
+	}
+	defer probe.Close()
+
+	reader, err := perf.NewReader(probe.EventsMap, 64*1024)
+	if err != nil {
+		t.Fatalf("perf reader: %v", err)
+	}
+	defer reader.Close()
+
+	// Give the probe time to attach before sending packets.
+	time.Sleep(200 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		exec.Command("ping", "-c", "5", "-W", "1", "-I", iface, "10.99.0.2").CombinedOutput()
+	}()
+	defer func() { <-done }()
+
+	reader.SetDeadline(time.Now().Add(8 * time.Second))
+	count := 0
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			break
+		}
+		if record.LostSamples > 0 {
+			continue
+		}
+		count++
+		if count >= 5 {
+			break
+		}
+	}
+	return count
+}
+
+// TestBpfTailcallSubfunc verifies that fentry/fexit on a __noinline subfunction
+// fires even when the parent program is reached via tail call.
+//
+// Requires: root, clang, kernel 6.x+ with bpf2bpf + tail call coexistence.
+func TestBpfTailcallSubfunc(t *testing.T) {
+	dispatcher, leaf, _ := loadTailcallCollection(t)
+	iface := setupVethWithXDP(t, dispatcher)
+
+	t.Run("fentry/subfunc_in_leaf", func(t *testing.T) {
+		count := countProbeEvents(t, leaf, "process_in_leaf", iface, false)
+		if count == 0 {
+			t.Fatal("expected events from fentry on subfunc in tail-called program, got 0")
+		}
+		t.Logf("received %d events", count)
+	})
+
+	t.Run("fentry/leaf_entry", func(t *testing.T) {
+		count := countProbeEvents(t, leaf, "xdp_leaf", iface, false)
+		t.Logf("received %d events (expected 0 for tail call target entry)", count)
+	})
+
+	t.Run("fentry/dispatcher_direct", func(t *testing.T) {
+		count := countProbeEvents(t, dispatcher, "xdp_dispatcher", iface, false)
+		t.Logf("received %d events", count)
+	})
+
+	t.Run("fexit/subfunc_in_leaf", func(t *testing.T) {
+		count := countProbeEvents(t, leaf, "process_in_leaf", iface, true)
+		if count == 0 {
+			t.Fatal("expected events from fexit on subfunc in tail-called program, got 0")
+		}
+		t.Logf("received %d events", count)
+	})
+
+	t.Run("fexit/leaf_entry", func(t *testing.T) {
+		count := countProbeEvents(t, leaf, "xdp_leaf", iface, true)
+		t.Logf("received %d events (expected 0 for tail call target entry)", count)
+	})
+}

--- a/internal/program/testutil_test.go
+++ b/internal/program/testutil_test.go
@@ -57,7 +57,9 @@ func compileXDPObjFromSource(t *testing.T, source string) string {
 	dir := t.TempDir()
 	srcFile := filepath.Join(dir, "xdp.c")
 	objFile := filepath.Join(dir, "xdp.o")
-	os.WriteFile(srcFile, []byte(source), 0644)
+	if err := os.WriteFile(srcFile, []byte(source), 0644); err != nil {
+		t.Fatalf("writing source: %v", err)
+	}
 
 	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
 	if err != nil {
@@ -88,7 +90,7 @@ func loadDummyXDP(t *testing.T) *ebpf.Program {
 	if err := spec.LoadAndAssign(&objs, nil); err != nil {
 		t.Fatalf("loading XDP program: %v", err)
 	}
-	t.Cleanup(func() { objs.Prog.Close() })
+	t.Cleanup(func() { _ = objs.Prog.Close() })
 	return objs.Prog
 }
 
@@ -109,7 +111,7 @@ func loadDummyXDPWithSubfunc(t *testing.T) *ebpf.Program {
 	if err := spec.LoadAndAssign(&objs, nil); err != nil {
 		t.Fatalf("loading XDP program: %v", err)
 	}
-	t.Cleanup(func() { objs.Prog.Close() })
+	t.Cleanup(func() { _ = objs.Prog.Close() })
 	return objs.Prog
 }
 
@@ -130,6 +132,6 @@ func loadProbeOrFail(t *testing.T, xdpProg *ebpf.Program, funcName, filterExpr s
 		}
 		t.Fatalf("loading probe: %v", err)
 	}
-	t.Cleanup(func() { probe.Close() })
+	t.Cleanup(func() { _ = probe.Close() })
 	return probe
 }

--- a/internal/program/testutil_test.go
+++ b/internal/program/testutil_test.go
@@ -20,6 +20,29 @@ int xdp_pass_test(struct xdp_md *ctx) { return 2; }
 char _license[] SEC("license") = "GPL";
 `
 
+const xdpSubfuncName = "process_packet"
+
+// xdpSubfuncSource has a __noinline subfunction that accesses ctx.
+// The body must be non-trivial; otherwise clang -O2 constant-folds
+// the call away and no bpf2bpf call survives in the bytecode.
+const xdpSubfuncSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int process_packet(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_subfunc_test(struct xdp_md *ctx) { return process_packet(ctx); }
+char _license[] SEC("license") = "GPL";
+`
+
 func skipIfNotRoot(t *testing.T) {
 	t.Helper()
 	if os.Getuid() != 0 {
@@ -27,20 +50,26 @@ func skipIfNotRoot(t *testing.T) {
 	}
 }
 
-// compileXDPObj compiles the dummy XDP program with BTF.
+// compileXDPObjFromSource compiles a BPF C source string to an object file with BTF.
 // Skips the test if clang is not available.
-func compileXDPObj(t *testing.T) string {
+func compileXDPObjFromSource(t *testing.T, source string) string {
 	t.Helper()
 	dir := t.TempDir()
 	srcFile := filepath.Join(dir, "xdp.c")
 	objFile := filepath.Join(dir, "xdp.o")
-	os.WriteFile(srcFile, []byte(xdpPassSource), 0644)
+	os.WriteFile(srcFile, []byte(source), 0644)
 
 	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
 	if err != nil {
 		t.Skipf("clang not available: %v\n%s", err, out)
 	}
 	return objFile
+}
+
+// compileXDPObj compiles the dummy XDP program with BTF.
+func compileXDPObj(t *testing.T) string {
+	t.Helper()
+	return compileXDPObjFromSource(t, xdpPassSource)
 }
 
 // loadDummyXDP compiles and loads a minimal XDP_PASS program with BTF.
@@ -63,15 +92,36 @@ func loadDummyXDP(t *testing.T) *ebpf.Program {
 	return objs.Prog
 }
 
+// loadDummyXDPWithSubfunc compiles and loads an XDP program with a __noinline subfunction.
+// Returns the loaded program (entry = "xdp_subfunc_test", subfunction = "process_packet").
+func loadDummyXDPWithSubfunc(t *testing.T) *ebpf.Program {
+	t.Helper()
+	skipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(compileXDPObjFromSource(t, xdpSubfuncSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"xdp_subfunc_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading XDP program: %v", err)
+	}
+	t.Cleanup(func() { objs.Prog.Close() })
+	return objs.Prog
+}
+
 // loadProbeOrFail loads a probe and fails with verifier output on error.
-func loadProbeOrFail(t *testing.T, xdpProg *ebpf.Program, filterExpr string, exit bool) *Probe {
+func loadProbeOrFail(t *testing.T, xdpProg *ebpf.Program, funcName, filterExpr string, exit bool) *Probe {
 	t.Helper()
 	var probe *Probe
 	var err error
 	if exit {
-		probe, err = LoadExit(xdpProg, xdpFuncName, filterExpr)
+		probe, err = LoadExit(xdpProg, funcName, filterExpr)
 	} else {
-		probe, err = LoadEntry(xdpProg, xdpFuncName, filterExpr)
+		probe, err = LoadEntry(xdpProg, funcName, filterExpr)
 	}
 	if err != nil {
 		var ve *ebpf.VerifierError

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,91 @@
+---
+pre-commit:
+  parallel: true
+  commands:
+    trailing-whitespace:
+      glob: "**/*"
+      exclude:
+        - "*.md"
+        - "*.patch"
+        - "*.o"
+      run: |
+        for file in {staged_files}; do
+          if ! file --mime-type "$file" | grep -q "text/"; then
+            continue
+          fi
+          if grep -q '[[:space:]]$' "$file"; then
+            sed -i 's/[[:space:]]*$//' "$file"
+            echo "Fixed trailing whitespace in: $file"
+          fi
+        done
+
+    mixed-line-ending:
+      glob: "**/*"
+      run: |
+        for file in {staged_files}; do
+          if ! file --mime-type "$file" | grep -q "text/"; then
+            continue
+          fi
+          if command -v dos2unix >/dev/null 2>&1; then
+            dos2unix -q "$file"
+          fi
+        done
+
+    check-executables-have-shebangs:
+      glob: "**/*"
+      run: |
+        for file in {staged_files}; do
+          if ! file --mime-type "$file" | grep -q "text/"; then
+            continue
+          fi
+          if [ -x "$file" ] && [ -f "$file" ] && ! grep -q '^#!' "$file"; then
+            echo "Executable without shebang: $file"
+            exit 1
+          fi
+        done
+
+    yamllint:
+      glob: "**/*.{yml,yaml}"
+      run: yamllint -f colored {staged_files}
+
+    check-json:
+      glob: "**/*.json"
+      run: |
+        failed=0
+        for f in {staged_files}; do
+          if ! jq -e empty "$f" >/dev/null 2>&1; then
+            echo "JSON parse error in $f"
+            jq empty "$f"
+            failed=1
+          fi
+        done
+        exit $failed
+
+    go-vet:
+      glob: "**/*.go"
+      run: go vet ./...
+
+    golangci-lint:
+      glob: "**/*.go"
+      run: golangci-lint run --fix ./...
+
+    go-test:
+      glob: "**/*.go"
+      run: go test ./...
+
+    clang-format:
+      glob: "**/*.{c,h}"
+      run: clang-format -i {staged_files}
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: |
+        if ! grep -qE '^(hotfix|feat|fix|docs|style|refactor|perf|test|chore|ci)(\([^\)]*\))?!?:\s' {1}; then
+          echo "Commit message must follow conventional commits format."
+          echo "Format: <type>(<scope>): <description>"
+          echo "Types: feat, fix, docs, style, refactor, perf, test, chore, ci, hotfix"
+          exit 1
+        fi
+
+colors: true

--- a/scripts/install_lint_tools.sh
+++ b/scripts/install_lint_tools.sh
@@ -12,6 +12,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/libs/install_utils.sh"
 
 mkdir -p "${HOME}/.local/bin"
+export GOBIN="${HOME}/.local/bin"
+export PATH="${GOBIN}:${PATH}"
 
 echo "Updating package list..."
 sudo apt-get update -qq

--- a/scripts/install_lint_tools.sh
+++ b/scripts/install_lint_tools.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing lint tools required by lefthook..."
+
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "Error: This script requires apt-get (Debian-based systems only)"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/libs/install_utils.sh"
+
+mkdir -p "${HOME}/.local/bin"
+
+echo "Updating package list..."
+sudo apt-get update -qq
+
+install_tool "lefthook" "go install github.com/evilmartians/lefthook@latest"
+install_tool "yamllint" "sudo apt-get install -y yamllint"
+install_tool "jq" "sudo apt-get install -y jq"
+install_tool "dos2unix" "sudo apt-get install -y dos2unix"
+install_tool "clang-format" "sudo apt-get install -y clang-format"
+install_tool "golangci-lint" "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+
+echo ""
+echo "All lint tools have been installed."
+echo "Run 'lefthook install' to set up the git hooks."

--- a/scripts/libs/install_utils.sh
+++ b/scripts/libs/install_utils.sh
@@ -15,7 +15,7 @@ install_tool() {
     fi
 
     echo "Installing $tool..."
-    eval ${install_cmd}
+    bash -lc "$install_cmd"
     if command_exists "$tool"; then
         echo "  $tool installed successfully"
         return 0

--- a/scripts/libs/install_utils.sh
+++ b/scripts/libs/install_utils.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Library of installer helpers for lint tools
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+install_tool() {
+    local tool="$1"
+    local install_cmd="$2"
+
+    if command_exists "$tool"; then
+        echo "  $tool is already installed"
+        return 0
+    fi
+
+    echo "Installing $tool..."
+    eval ${install_cmd}
+    if command_exists "$tool"; then
+        echo "  $tool installed successfully"
+        return 0
+    fi
+
+    echo "  Failed to install $tool"
+    return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    exit 0
+fi

--- a/scripts/test/xdp_pass.c
+++ b/scripts/test/xdp_pass.c
@@ -3,9 +3,6 @@
 #define SEC(NAME) __attribute__((section(NAME), used))
 
 SEC("xdp")
-int xdp_pass(struct xdp_md *ctx)
-{
-	return 2; /* XDP_PASS */
-}
+int xdp_pass(struct xdp_md *ctx) { return 2; /* XDP_PASS */ }
 
 char _license[] SEC("license") = "GPL";

--- a/scripts/test/xdp_tailcall.c
+++ b/scripts/test/xdp_tailcall.c
@@ -6,27 +6,23 @@
 // Both programs are type XDP. The section names use "xdp" prefix so
 // libbpf/bpftool recognizes them as XDP programs.
 
-#include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include <linux/bpf.h>
 
 struct {
-	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-	__uint(max_entries, 1);
-	__uint(key_size, sizeof(__u32));
-	__uint(value_size, sizeof(__u32));
+  __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+  __uint(max_entries, 1);
+  __uint(key_size, sizeof(__u32));
+  __uint(value_size, sizeof(__u32));
 } prog_array SEC(".maps");
 
 SEC("xdp")
-int xdp_dispatcher(struct xdp_md *ctx)
-{
-	bpf_tail_call(ctx, &prog_array, 0);
-	return 2; /* XDP_PASS fallback */
+int xdp_dispatcher(struct xdp_md *ctx) {
+  bpf_tail_call(ctx, &prog_array, 0);
+  return 2; /* XDP_PASS fallback */
 }
 
 SEC("xdp")
-int xdp_prog_a(struct xdp_md *ctx)
-{
-	return 2; /* XDP_PASS */
-}
+int xdp_prog_a(struct xdp_md *ctx) { return 2; /* XDP_PASS */ }
 
 char _license[] SEC("license") = "GPL";


### PR DESCRIPTION
## Summary

- XDP プログラム内の `__noinline` サブ関数に fentry/fexit をアタッチしてパケットキャプチャできる `--func` フラグを追加
- ターゲットプログラムの BTF 関数一覧を表示する `--list-funcs`、tail call 先プログラムを発見する `--list-progs` を追加
- lefthook による pre-commit hooks（golangci-lint errcheck 含む）と lint CI workflow を整備

## New Features

### `--func <name>`
`__noinline` サブ関数名を指定して fentry/fexit をアタッチする。エントリ関数ではなく内部のサブ関数にプローブを挿入できる。

```bash
sudo xdp-ninja -i eth0 --func classify_packet | tcpdump -n -r -
```

### `--list-funcs`
ターゲットプログラムの BTF に含まれる関数一覧（linkage: global/static）を表示して終了する。

```bash
sudo xdp-ninja -p 42 --list-funcs
```

### `--list-progs`
ターゲットプログラムの PROG_ARRAY マップを走査し、tail call 先のプログラム ID と名前を表示する。`bpftool` なしで leaf プログラムを発見できる。

```bash
sudo xdp-ninja -i eth0 --list-progs
```

## note

- **Kernel 6.15**: tail call 先プログラム内の `__noinline` サブ関数に対して fentry/fexit が発火することを確認（エントリ関数は発火しない）
- **`static __noinline`**: body が非 trivial（`ctx->data` 等にアクセス）なら BTF に残り、global と同様にプローブ可能
- **Trivial bodyについてのメモ**: `return 2;` だけの `__noinline` 関数は `clang -O2` で定数畳み込みされ bpf2bpf call ごと消える

## Lint / CI

- lefthook pre-commit: go-vet, golangci-lint (errcheck), go-test, yamllint, clang-format, trailing-whitespace 等
- conventional commits チェック (commit-msg hook)
- `.github/workflows/lint.yaml`: push/PR で lefthook を変更ファイルに対して実行
- 全 Close() の errcheck 対応（データロスリスクのある箇所はエラーハンドリング、cleanup は `_ =` で明示）

## Test Plan

- [ ] `go test ./...` (unit tests)
- [ ] `sudo go test ./... -run TestBpf` (BPF load tests: subfunc fentry/fexit + tail call)
- [ ] `make lint` (全ファイル lint)
- [ ] ハンドテスト: `docs/ja/handtest-func-tailcall.md` の Part 1〜3 を実行