### PR TITLE
feat: add --arg-filter and --list-params for fentry/fexit argument filtering

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -153,31 +153,33 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	// --func: override target function name
+	// --func: override target function name.
+	// Open BTF once and share across validation and parameter extraction.
 	funcName := cmd.String("func")
+	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0
+	var params []attach.FuncParamInfo
 	if funcName != "" {
-		if err := attach.ValidateSubfunc(info.Program, info.ProgID, funcName); err != nil {
+		spec, err := attach.BTFSpec(info.Program)
+		if err != nil {
+			return fmt.Errorf("program (id=%d): %w", info.ProgID, err)
+		}
+		if err := attach.ValidateSubfuncFromSpec(spec, info.ProgID, funcName); err != nil {
 			return err
 		}
 		logVerbose(cmd, "overriding entry function with --func %q", funcName)
 		info.FuncName = funcName
-	}
 
-	// Resolve BTF params once for --list-params and --arg-filter (both require --func).
-	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0
-	var params []attach.FuncParamInfo
-	if needParams {
-		if funcName == "" {
-			if cmd.Bool("list-params") {
-				return fmt.Errorf("--list-params requires --func")
+		if needParams {
+			params, err = attach.GetFuncParamsFromSpec(spec, funcName)
+			if err != nil {
+				return err
 			}
-			return fmt.Errorf("--arg-filter requires --func")
 		}
-		var err error
-		params, err = attach.GetFuncParams(info.Program, funcName)
-		if err != nil {
-			return err
+	} else if needParams {
+		if cmd.Bool("list-params") {
+			return fmt.Errorf("--list-params requires --func")
 		}
+		return fmt.Errorf("--arg-filter requires --func")
 	}
 
 	// --list-params: show filterable parameters, then exit

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -247,7 +247,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if info.IfaceName != "" {
 		label = fmt.Sprintf("%s on %s", label, info.IfaceName)
 	}
-	fmt.Fprintf(os.Stderr, "capturing (%s, mode=%s)...\n", label, mode) // mode kept for display
+	fmt.Fprintf(os.Stderr, "capturing (%s, mode=%s)...\n", label, mode)
 
 	return captureLoop(cmd, reader, writer)
 }

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/takehaya/xdp-ninja/internal/attach"
 	"github.com/takehaya/xdp-ninja/internal/capture"
+	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/internal/output"
 	"github.com/takehaya/xdp-ninja/internal/program"
 )
@@ -58,6 +59,14 @@ var flags = []cli.Flag{
 		Name:  "list-progs",
 		Usage: "list tail call targets reachable from the target program and exit",
 	},
+	&cli.StringSliceFlag{
+		Name:  "arg-filter",
+		Usage: "filter by function argument value (requires --func); format: param=value, param>=val, param<=val, param=min..max",
+	},
+	&cli.BoolFlag{
+		Name:  "list-params",
+		Usage: "list filterable parameters for the target function (requires --func) and exit",
+	},
 	&cli.BoolFlag{
 		Name: "verbose", Aliases: []string{"v"},
 		Usage: "verbose output to stderr",
@@ -102,7 +111,12 @@ Examples:
 
 func run(ctx context.Context, cmd *cli.Command) error {
 	mode := cmd.String("mode")
-	if mode != "entry" && mode != "exit" {
+	var isFexit bool
+	switch mode {
+	case "entry":
+	case "exit":
+		isFexit = true
+	default:
 		return fmt.Errorf("invalid mode %q: must be entry or exit", mode)
 	}
 
@@ -140,12 +154,59 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	// --func: override target function name
-	if funcName := cmd.String("func"); funcName != "" {
+	funcName := cmd.String("func")
+	if funcName != "" {
 		if err := attach.ValidateSubfunc(info.Program, info.ProgID, funcName); err != nil {
 			return err
 		}
 		logVerbose(cmd, "overriding entry function with --func %q", funcName)
 		info.FuncName = funcName
+	}
+
+	// Resolve BTF params once for --list-params and --arg-filter (both require --func).
+	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0
+	var params []attach.FuncParamInfo
+	if needParams {
+		if funcName == "" {
+			if cmd.Bool("list-params") {
+				return fmt.Errorf("--list-params requires --func")
+			}
+			return fmt.Errorf("--arg-filter requires --func")
+		}
+		var err error
+		params, err = attach.GetFuncParams(info.Program, funcName)
+		if err != nil {
+			return err
+		}
+	}
+
+	// --list-params: show filterable parameters, then exit
+	if cmd.Bool("list-params") {
+		fmt.Fprintf(os.Stderr, "Filterable parameters for %s (id=%d):\n", funcName, info.ProgID)
+		if len(params) == 0 {
+			fmt.Fprintf(os.Stderr, "  (none - only integer parameters after the first argument are supported)\n")
+		}
+		for _, p := range params {
+			signStr := "unsigned"
+			if p.Signed {
+				signStr = "signed"
+			}
+			fmt.Fprintf(os.Stderr, "  %-20s [%d bytes, %s, arg index %d]\n", p.Name, p.Size, signStr, p.Index)
+		}
+		return nil
+	}
+
+	// --arg-filter: parse and validate argument filters
+	var argFilters []filter.ArgFilter
+	if argFilterExprs := cmd.StringSlice("arg-filter"); len(argFilterExprs) > 0 {
+		var err error
+		argFilters, err = filter.ParseAndValidateFilters(argFilterExprs, params)
+		if err != nil {
+			return err
+		}
+		for _, f := range argFilters {
+			logVerbose(cmd, "arg filter: %s", f.String())
+		}
 	}
 
 	filterExpr := strings.Join(cmd.Args().Slice(), " ")
@@ -154,7 +215,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		logVerbose(cmd, "filter: %s", filterExpr)
 	}
 
-	probe, err := loadProbe(mode, info, filterExpr)
+	probe, err := loadProbe(isFexit, info, filterExpr, argFilters)
 	if err != nil {
 		return err
 	}
@@ -164,7 +225,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 	}()
 
-	writer, err := output.NewWriter(cmd.String("write"), mode)
+	writer, err := output.NewWriter(cmd.String("write"), isFexit)
 	if err != nil {
 		return err
 	}
@@ -184,7 +245,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if info.IfaceName != "" {
 		label = fmt.Sprintf("%s on %s", label, info.IfaceName)
 	}
-	fmt.Fprintf(os.Stderr, "capturing (%s, mode=%s)...\n", label, mode)
+	fmt.Fprintf(os.Stderr, "capturing (%s, mode=%s)...\n", label, mode) // mode kept for display
 
 	return captureLoop(cmd, reader, writer)
 }
@@ -206,11 +267,11 @@ func findTarget(cmd *cli.Command) (*attach.XDPInfo, error) {
 	return attach.FindXDPProgram(ifaceName)
 }
 
-func loadProbe(mode string, info *attach.XDPInfo, filterExpr string) (*program.Probe, error) {
-	if mode == "exit" {
-		return program.LoadExit(info.Program, info.FuncName, filterExpr)
+func loadProbe(isFexit bool, info *attach.XDPInfo, filterExpr string, argFilters []filter.ArgFilter) (*program.Probe, error) {
+	if isFexit {
+		return program.LoadExit(info.Program, info.FuncName, filterExpr, argFilters)
 	}
-	return program.LoadEntry(info.Program, info.FuncName, filterExpr)
+	return program.LoadEntry(info.Program, info.FuncName, filterExpr, argFilters)
 }
 
 func captureLoop(cmd *cli.Command, reader *capture.Reader, writer *output.Writer) error {

--- a/docs/en/handtest.md
+++ b/docs/en/handtest.md
@@ -466,3 +466,163 @@ sudo rm -rf /sys/fs/bpf/tctest
 sudo ip link delete vtest0 2>/dev/null
 sudo ip netns delete nstest 2>/dev/null
 ```
+
+---
+
+## Part 4: Argument Filtering with `--arg-filter`
+
+Filter based on the values of function arguments specified with `--func`.
+Only integer parameters (excluding the first xdp_md pointer) are supported.
+
+### 4.1 Create Test Program
+
+```
+xdp_entry
+  └─ process_packet(ctx, tunnel_id)  [global __noinline, with u32 arg]
+```
+
+```bash
+cat > /tmp/xdp_argfilter.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+__attribute__((noinline))
+int process_packet(struct xdp_md *ctx, __u32 tunnel_id) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    volatile __u32 id = tunnel_id; /* prevent clang from optimizing away the arg */
+    return (id > 0) ? 2 : 1;
+}
+
+SEC("xdp")
+int xdp_entry(struct xdp_md *ctx) {
+    return process_packet(ctx, 42);
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_argfilter.c -o /tmp/xdp_argfilter.o
+```
+
+### 4.2 Set Up Environment
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_argfilter.o sec xdp
+```
+
+Verify connectivity:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 4.3 List Filterable Parameters with `--list-params`
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --list-params
+```
+
+Expected output:
+
+```
+Filterable parameters for process_packet (id=XXXX):
+  tunnel_id            [4 bytes, unsigned, arg index 1]
+```
+
+### 4.4 `--list-params` Without `--func` (Error)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-params
+```
+
+Expected: `--list-params requires --func` error.
+
+### 4.5 Exact Match Filter (Hit)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=42" -v | tcpdump -n -r -
+```
+
+Expected: Packets are captured since tunnel_id=42.
+
+### 4.6 Exact Match Filter (Miss)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=99" -v -c 3 | tcpdump -n -r -
+```
+
+Expected: `0 packets captured`.
+
+### 4.7 Range Filter
+
+```bash
+# Hit (42 is within 40..50)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=40..50" -v | tcpdump -n -r -
+
+# Miss (42 is outside 100..200)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=100..200" -v -c 3 | tcpdump -n -r -
+```
+
+### 4.8 Comparison Filters
+
+```bash
+# >= (42 >= 40 → hit)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id>=40" -v | tcpdump -n -r -
+
+# <= (42 <= 50 → hit)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id<=50" -v | tcpdump -n -r -
+
+# >= (42 >= 100 → miss)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id>=100" -v -c 3 | tcpdump -n -r -
+```
+
+### 4.9 Hexadecimal Values
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=0x2a" -v | tcpdump -n -r -
+```
+
+Expected: Packets are captured since 0x2a = 42.
+
+### 4.10 Combined with Packet Filter
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=42" "icmp" -v | tcpdump -n -r -
+```
+
+Expected: Only packets matching both the argument filter and the packet filter are captured.
+
+### 4.11 Non-existent Parameter Name (Error)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "no_such=42"
+```
+
+Expected: Error message listing available parameter names.
+
+### 4.12 `--arg-filter` Without `--func` (Error)
+
+```bash
+sudo ./xdp-ninja -i vtest0 --arg-filter "tunnel_id=42"
+```
+
+Expected: `--arg-filter requires --func` error.
+
+### 4.13 Cleanup
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```

--- a/docs/ja/handtest.md
+++ b/docs/ja/handtest.md
@@ -464,3 +464,163 @@ sudo rm -rf /sys/fs/bpf/tctest
 sudo ip link delete vtest0 2>/dev/null
 sudo ip netns delete nstest 2>/dev/null
 ```
+
+---
+
+## Part 4: `--arg-filter` による引数フィルタリング
+
+`--func` で指定したサブ関数の引数値でフィルタリングする。
+整数型の引数（最初の xdp_md ポインタを除く）が対象。
+
+### 4.1 テスト用プログラムの作成
+
+```
+xdp_entry
+  └─ process_packet(ctx, tunnel_id)  [global __noinline, u32 引数付き]
+```
+
+```bash
+cat > /tmp/xdp_argfilter.c << 'EOF'
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+__attribute__((noinline))
+int process_packet(struct xdp_md *ctx, __u32 tunnel_id) {
+    void *data     = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    volatile __u32 id = tunnel_id; /* 最適化で引数が消えるのを防止 */
+    return (id > 0) ? 2 : 1;
+}
+
+SEC("xdp")
+int xdp_entry(struct xdp_md *ctx) {
+    return process_packet(ctx, 42);
+}
+
+char _license[] SEC("license") = "GPL";
+EOF
+clang -O2 -g -target bpf -c /tmp/xdp_argfilter.c -o /tmp/xdp_argfilter.o
+```
+
+### 4.2 環境構築
+
+```bash
+sudo ip netns add nstest
+sudo ip link add vtest0 type veth peer name vtest1
+sudo ip link set vtest1 netns nstest
+sudo ip addr add 10.77.0.1/24 dev vtest0
+sudo ip netns exec nstest ip addr add 10.77.0.2/24 dev vtest1
+sudo ip link set vtest0 up
+sudo ip netns exec nstest ip link set vtest1 up
+sudo ip netns exec nstest ip link set lo up
+
+sudo ip link set dev vtest0 xdp obj /tmp/xdp_argfilter.o sec xdp
+```
+
+疎通確認:
+
+```bash
+sudo ip netns exec nstest ping -c 3 10.77.0.1
+```
+
+### 4.3 `--list-params` でフィルタ可能なパラメータを確認
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --list-params
+```
+
+期待出力:
+
+```
+Filterable parameters for process_packet (id=XXXX):
+  tunnel_id            [4 bytes, unsigned, arg index 1]
+```
+
+### 4.4 `--list-params` を `--func` なしで実行（エラー）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --list-params
+```
+
+期待: `--list-params requires --func` エラー。
+
+### 4.5 完全一致フィルタ（マッチ）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=42" -v | tcpdump -n -r -
+```
+
+期待: tunnel_id=42 なのでパケットがキャプチャされる。
+
+### 4.6 完全一致フィルタ（不一致）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=99" -v -c 3 | tcpdump -n -r -
+```
+
+期待: `0 packets captured`。
+
+### 4.7 範囲フィルタ
+
+```bash
+# マッチ (42 は 40..50 の範囲内)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=40..50" -v | tcpdump -n -r -
+
+# 不一致 (42 は 100..200 の範囲外)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=100..200" -v -c 3 | tcpdump -n -r -
+```
+
+### 4.8 比較フィルタ
+
+```bash
+# >= (42 >= 40 → マッチ)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id>=40" -v | tcpdump -n -r -
+
+# <= (42 <= 50 → マッチ)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id<=50" -v | tcpdump -n -r -
+
+# >= (42 >= 100 → 不一致)
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id>=100" -v -c 3 | tcpdump -n -r -
+```
+
+### 4.9 16進数値
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=0x2a" -v | tcpdump -n -r -
+```
+
+期待: 0x2a = 42 なのでキャプチャされる。
+
+### 4.10 パケットフィルタとの併用
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "tunnel_id=42" "icmp" -v | tcpdump -n -r -
+```
+
+期待: 引数フィルタとパケットフィルタの両方を満たすパケットのみキャプチャされる。
+
+### 4.11 存在しないパラメータ名（エラー）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --func process_packet --arg-filter "no_such=42"
+```
+
+期待: 利用可能なパラメータ名を含むエラーメッセージ。
+
+### 4.12 `--arg-filter` を `--func` なしで実行（エラー）
+
+```bash
+sudo ./xdp-ninja -i vtest0 --arg-filter "tunnel_id=42"
+```
+
+期待: `--arg-filter requires --func` エラー。
+
+### 4.13 クリーンアップ
+
+```bash
+sudo ip link set dev vtest0 xdp off
+sudo ip link delete vtest0 2>/dev/null
+sudo ip netns delete nstest 2>/dev/null
+```

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -159,7 +159,7 @@ type FuncParamInfo struct {
 // Only integer parameters (excluding the first xdp_md/xdp_buff pointer) are returned,
 // as those are the only types supported for argument filtering.
 func GetFuncParams(prog *ebpf.Program, funcName string) ([]FuncParamInfo, error) {
-	spec, err := btfSpec(prog)
+	spec, err := BTFSpec(prog)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,11 @@ func GetFuncParamsFromSpec(spec *btf.Spec, funcName string) ([]FuncParamInfo, er
 		// Unwrap qualifiers and typedefs to get the underlying type
 		underlying := btf.UnderlyingType(p.Type)
 
-		// Only support integer types for filtering
+		// Only support named integer types for filtering.
+		// Unnamed parameters can't be targeted by --arg-filter.
+		if p.Name == "" {
+			continue
+		}
 		intType, ok := underlying.(*btf.Int)
 		if !ok {
 			continue
@@ -205,8 +209,8 @@ func GetFuncParamsFromSpec(spec *btf.Spec, funcName string) ([]FuncParamInfo, er
 	return params, nil
 }
 
-// btfSpec opens the BTF handle for a loaded program and returns its spec.
-func btfSpec(prog *ebpf.Program) (*btf.Spec, error) {
+// BTFSpec opens the BTF handle for a loaded program and returns its spec.
+func BTFSpec(prog *ebpf.Program) (*btf.Spec, error) {
 	handle, err := prog.Handle()
 	if err != nil {
 		return nil, fmt.Errorf("BTF unavailable: %w", err)
@@ -222,7 +226,7 @@ func btfSpec(prog *ebpf.Program) (*btf.Spec, error) {
 
 // ListFuncs returns all BTF function entries found in the program.
 func ListFuncs(prog *ebpf.Program) ([]FuncInfo, error) {
-	spec, err := btfSpec(prog)
+	spec, err := BTFSpec(prog)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +236,7 @@ func ListFuncs(prog *ebpf.Program) ([]FuncInfo, error) {
 // ValidateSubfunc checks that the given function name exists in the program's BTF.
 // If the function is not found, the error message includes a list of available functions.
 func ValidateSubfunc(prog *ebpf.Program, progID uint32, funcName string) error {
-	spec, err := btfSpec(prog)
+	spec, err := BTFSpec(prog)
 	if err != nil {
 		return fmt.Errorf("program (id=%d): %w", progID, err)
 	}
@@ -295,7 +299,7 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 	}
 	progName := info.Name
 
-	spec, err := btfSpec(prog)
+	spec, err := BTFSpec(prog)
 	if err != nil {
 		return "", fmt.Errorf("program %q (id=%d): %w", progName, progID, err)
 	}

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -147,6 +147,64 @@ type FuncInfo struct {
 	Linkage string // "static", "global", "extern"
 }
 
+// FuncParamInfo holds metadata about a function parameter from BTF.
+type FuncParamInfo struct {
+	Name   string // Parameter name from BTF
+	Index  int    // 0-based index in the parameter list
+	Size   uint32 // Size in bytes
+	Signed bool   // true if signed integer
+}
+
+// GetFuncParams returns the function parameters for the given function from BTF.
+// Only integer parameters (excluding the first xdp_md/xdp_buff pointer) are returned,
+// as those are the only types supported for argument filtering.
+func GetFuncParams(prog *ebpf.Program, funcName string) ([]FuncParamInfo, error) {
+	spec, err := btfSpec(prog)
+	if err != nil {
+		return nil, err
+	}
+	return GetFuncParamsFromSpec(spec, funcName)
+}
+
+// GetFuncParamsFromSpec extracts function parameters from a BTF spec.
+func GetFuncParamsFromSpec(spec *btf.Spec, funcName string) ([]FuncParamInfo, error) {
+	var fn *btf.Func
+	if err := spec.TypeByName(funcName, &fn); err != nil {
+		return nil, fmt.Errorf("function %q not found in BTF: %w", funcName, err)
+	}
+
+	proto, ok := fn.Type.(*btf.FuncProto)
+	if !ok {
+		return nil, fmt.Errorf("function %q has unexpected type %T (expected FuncProto)", funcName, fn.Type)
+	}
+
+	var params []FuncParamInfo
+	for i, p := range proto.Params {
+		// Skip first parameter (xdp_md/xdp_buff pointer)
+		if i == 0 {
+			continue
+		}
+
+		// Unwrap qualifiers and typedefs to get the underlying type
+		underlying := btf.UnderlyingType(p.Type)
+
+		// Only support integer types for filtering
+		intType, ok := underlying.(*btf.Int)
+		if !ok {
+			continue
+		}
+
+		params = append(params, FuncParamInfo{
+			Name:   p.Name,
+			Index:  i,
+			Size:   intType.Size,
+			Signed: intType.Encoding == btf.Signed,
+		})
+	}
+
+	return params, nil
+}
+
 // btfSpec opens the BTF handle for a loaded program and returns its spec.
 func btfSpec(prog *ebpf.Program) (*btf.Spec, error) {
 	handle, err := prog.Handle()
@@ -178,7 +236,11 @@ func ValidateSubfunc(prog *ebpf.Program, progID uint32, funcName string) error {
 	if err != nil {
 		return fmt.Errorf("program (id=%d): %w", progID, err)
 	}
+	return ValidateSubfuncFromSpec(spec, progID, funcName)
+}
 
+// ValidateSubfuncFromSpec validates a subfunction name against a BTF spec.
+func ValidateSubfuncFromSpec(spec *btf.Spec, progID uint32, funcName string) error {
 	var fn *btf.Func
 	if err := spec.TypeByName(funcName, &fn); err == nil {
 		return nil
@@ -233,15 +295,9 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 	}
 	progName := info.Name
 
-	handle, err := prog.Handle()
+	spec, err := btfSpec(prog)
 	if err != nil {
-		return "", fmt.Errorf("program %q (id=%d): BTF unavailable (required for fentry/fexit): %w", progName, progID, err)
-	}
-	defer func() { _ = handle.Close() }()
-
-	spec, err := handle.Spec(nil)
-	if err != nil {
-		return "", fmt.Errorf("program %q (id=%d): reading BTF: %w", progName, progID, err)
+		return "", fmt.Errorf("program %q (id=%d): %w", progName, progID, err)
 	}
 
 	// 1. Exact match

--- a/internal/attach/testutil_test.go
+++ b/internal/attach/testutil_test.go
@@ -1,60 +1,18 @@
 package attach
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
 )
-
-// xdpSubfuncSource has a __noinline subfunction that accesses ctx.
-// The body must be non-trivial; otherwise clang -O2 constant-folds
-// the call away and no bpf2bpf call survives in the bytecode.
-const xdpSubfuncSource = `
-#include <linux/bpf.h>
-#define SEC(NAME) __attribute__((section(NAME), used))
-
-__attribute__((noinline))
-int process_packet(struct xdp_md *ctx) {
-    void *data = (void *)(long)ctx->data;
-    void *data_end = (void *)(long)ctx->data_end;
-    if (data + 1 > data_end)
-        return 1;
-    return 2;
-}
-
-SEC("xdp")
-int xdp_subfunc_test(struct xdp_md *ctx) { return process_packet(ctx); }
-char _license[] SEC("license") = "GPL";
-`
-
-func skipIfNotRoot(t *testing.T) {
-	t.Helper()
-	if os.Getuid() != 0 {
-		t.Skip("requires root")
-	}
-}
 
 // loadTestXDP compiles and loads an XDP program with a __noinline subfunction.
 func loadTestXDP(t *testing.T) *ebpf.Program {
 	t.Helper()
-	skipIfNotRoot(t)
+	testutil.SkipIfNotRoot(t)
 
-	dir := t.TempDir()
-	srcFile := filepath.Join(dir, "xdp.c")
-	objFile := filepath.Join(dir, "xdp.o")
-	if err := os.WriteFile(srcFile, []byte(xdpSubfuncSource), 0644); err != nil {
-		t.Fatalf("writing source: %v", err)
-	}
-
-	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
-	if err != nil {
-		t.Skipf("clang not available: %v\n%s", err, out)
-	}
-
-	spec, err := ebpf.LoadCollectionSpec(objFile)
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, testutil.XDPSubfuncSource))
 	if err != nil {
 		t.Fatalf("loading collection spec: %v", err)
 	}

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -95,9 +95,6 @@ func ParseArgFilter(expr string) (ParsedFilter, error) {
 	case "=":
 		if strings.Contains(valueStr, "..") {
 			parts := strings.SplitN(valueStr, "..", 2)
-			if len(parts) != 2 {
-				return ParsedFilter{}, fmt.Errorf("invalid range in %q: expected min..max", expr)
-			}
 			pf.Op = OpRange
 			v, err := parseValue(parts[0])
 			if err != nil {

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -185,6 +185,16 @@ func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]A
 			if err := validateValueRange(pf.MaxValue, param.Size, param.Signed, expr); err != nil {
 				return nil, err
 			}
+			// Re-check min <= max under the resolved signedness.
+			if param.Signed {
+				if int64(pf.Value) > int64(pf.MaxValue) {
+					return nil, fmt.Errorf("invalid range in %q: min (%d) > max (%d) for signed parameter", expr, int64(pf.Value), int64(pf.MaxValue))
+				}
+			} else {
+				if pf.Value > pf.MaxValue {
+					return nil, fmt.Errorf("invalid range in %q: min (%d) > max (%d)", expr, pf.Value, pf.MaxValue)
+				}
+			}
 		}
 
 		filters = append(filters, ArgFilter{

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -3,7 +3,6 @@ package filter
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -205,12 +204,9 @@ func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]A
 // validateValueRange checks that value fits within the given parameter size and signedness.
 func validateValueRange(value uint64, size uint32, signed bool, expr string) error {
 	if size >= 8 {
-		// For signed 64-bit, values > int64 max are out of range (they would
-		// wrap to negative in eBPF signed comparisons).
-		if signed && value > uint64(math.MaxInt64) {
-			return fmt.Errorf("value %d in %q is out of range for 64-bit signed parameter [%d, %d]",
-				value, expr, math.MinInt64, int64(math.MaxInt64))
-		}
+		// 64-bit values always fit. For signed parameters, parseValue encodes
+		// negatives as two's complement (e.g. -1 → 0xFFFFFFFFFFFFFFFF) which
+		// is a valid int64 bit pattern.
 		return nil
 	}
 	bits := size * 8

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -81,7 +81,7 @@ func ParseArgFilter(expr string) (ParsedFilter, error) {
 		} else {
 			pf.Op = OpLessEqual
 		}
-		v, err := parseUint64(valueStr)
+		v, err := parseValue(valueStr)
 		if err != nil {
 			return ParsedFilter{}, fmt.Errorf("invalid value in %q: %w", expr, err)
 		}
@@ -93,22 +93,24 @@ func ParseArgFilter(expr string) (ParsedFilter, error) {
 				return ParsedFilter{}, fmt.Errorf("invalid range in %q: expected min..max", expr)
 			}
 			pf.Op = OpRange
-			v, err := parseUint64(parts[0])
+			v, err := parseValue(parts[0])
 			if err != nil {
 				return ParsedFilter{}, fmt.Errorf("invalid min value in %q: %w", expr, err)
 			}
 			pf.Value = v
-			mv, err := parseUint64(parts[1])
+			mv, err := parseValue(parts[1])
 			if err != nil {
 				return ParsedFilter{}, fmt.Errorf("invalid max value in %q: %w", expr, err)
 			}
 			pf.MaxValue = mv
-			if pf.Value > pf.MaxValue {
-				return ParsedFilter{}, fmt.Errorf("invalid range in %q: min (%d) > max (%d)", expr, pf.Value, pf.MaxValue)
+			// Reject if min > max under both unsigned and signed interpretation.
+			// The correct signedness is resolved later in ParseAndValidateFilters.
+			if pf.Value > pf.MaxValue && int64(pf.Value) > int64(pf.MaxValue) {
+				return ParsedFilter{}, fmt.Errorf("invalid range in %q: min > max", expr)
 			}
 		} else {
 			pf.Op = OpEqual
-			v, err := parseUint64(valueStr)
+			v, err := parseValue(valueStr)
 			if err != nil {
 				return ParsedFilter{}, fmt.Errorf("invalid value in %q: %w", expr, err)
 			}
@@ -119,11 +121,21 @@ func ParseArgFilter(expr string) (ParsedFilter, error) {
 	return pf, nil
 }
 
-// parseUint64 parses a string as uint64, supporting hex (0x) and decimal.
-func parseUint64(s string) (uint64, error) {
+// parseValue parses a string as uint64, supporting hex (0x), decimal, and
+// negative values. Negative values are stored as their two's complement
+// bit pattern (e.g. -1 → 0xFFFFFFFFFFFFFFFF), which is the representation
+// used by the eBPF signed comparison instructions.
+func parseValue(s string) (uint64, error) {
 	s = strings.TrimSpace(s)
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
 		return strconv.ParseUint(s[2:], 16, 64)
+	}
+	if strings.HasPrefix(s, "-") {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(v), nil
 	}
 	return strconv.ParseUint(s, 10, 64)
 }
@@ -159,6 +171,16 @@ func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]A
 			return nil, fmt.Errorf("parameter %q not found; available parameters: %v", pf.ParamName, available)
 		}
 
+		// Validate that filter values fit within the parameter's bit width.
+		if err := validateValueRange(pf.Value, param.Size, param.Signed, expr); err != nil {
+			return nil, err
+		}
+		if pf.Op == OpRange {
+			if err := validateValueRange(pf.MaxValue, param.Size, param.Signed, expr); err != nil {
+				return nil, err
+			}
+		}
+
 		filters = append(filters, ArgFilter{
 			ParamName:  pf.ParamName,
 			ParamIndex: param.Index,
@@ -171,4 +193,26 @@ func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]A
 	}
 
 	return filters, nil
+}
+
+// validateValueRange checks that value fits within the given parameter size and signedness.
+func validateValueRange(value uint64, size uint32, signed bool, expr string) error {
+	if size >= 8 {
+		return nil // 64-bit: any value fits
+	}
+	bits := size * 8
+	if signed {
+		min := -(int64(1) << (bits - 1))          // e.g. -128 for int8
+		max := int64(1)<<(bits-1) - 1              // e.g. 127 for int8
+		sv := int64(value)
+		if sv < min || sv > max {
+			return fmt.Errorf("value %d in %q is out of range for %d-bit signed parameter [%d, %d]", sv, expr, bits, min, max)
+		}
+	} else {
+		max := uint64(1)<<bits - 1 // e.g. 255 for uint8
+		if value > max {
+			return fmt.Errorf("value %d in %q is out of range for %d-bit unsigned parameter [0, %d]", value, expr, bits, max)
+		}
+	}
+	return nil
 }

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -3,6 +3,7 @@ package filter
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,15 +34,21 @@ type ArgFilter struct {
 
 // String returns a human-readable representation of the filter.
 func (f *ArgFilter) String() string {
+	fmtVal := func(v uint64) string {
+		if f.Signed {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return fmt.Sprintf("%d", v)
+	}
 	switch f.Op {
 	case OpEqual:
-		return fmt.Sprintf("%s=%d", f.ParamName, f.Value)
+		return fmt.Sprintf("%s=%s", f.ParamName, fmtVal(f.Value))
 	case OpGreaterEqual:
-		return fmt.Sprintf("%s>=%d", f.ParamName, f.Value)
+		return fmt.Sprintf("%s>=%s", f.ParamName, fmtVal(f.Value))
 	case OpLessEqual:
-		return fmt.Sprintf("%s<=%d", f.ParamName, f.Value)
+		return fmt.Sprintf("%s<=%s", f.ParamName, fmtVal(f.Value))
 	case OpRange:
-		return fmt.Sprintf("%s=%d..%d", f.ParamName, f.Value, f.MaxValue)
+		return fmt.Sprintf("%s=%s..%s", f.ParamName, fmtVal(f.Value), fmtVal(f.MaxValue))
 	default:
 		return fmt.Sprintf("%s=?", f.ParamName)
 	}
@@ -198,7 +205,13 @@ func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]A
 // validateValueRange checks that value fits within the given parameter size and signedness.
 func validateValueRange(value uint64, size uint32, signed bool, expr string) error {
 	if size >= 8 {
-		return nil // 64-bit: any value fits
+		// For signed 64-bit, values > int64 max are out of range (they would
+		// wrap to negative in eBPF signed comparisons).
+		if signed && value > uint64(math.MaxInt64) {
+			return fmt.Errorf("value %d in %q is out of range for 64-bit signed parameter [%d, %d]",
+				value, expr, math.MinInt64, int64(math.MaxInt64))
+		}
+		return nil
 	}
 	bits := size * 8
 	if signed {

--- a/internal/filter/argfilter.go
+++ b/internal/filter/argfilter.go
@@ -1,0 +1,174 @@
+// Package filter provides argument filter parsing and validation for fentry/fexit probes.
+package filter
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+)
+
+// ArgFilterOp represents the comparison operator for an argument filter.
+type ArgFilterOp int
+
+const (
+	OpEqual        ArgFilterOp = iota // param=value (exact match)
+	OpGreaterEqual                    // param>=value
+	OpLessEqual                       // param<=value
+	OpRange                           // param=min..max
+)
+
+// ArgFilter represents a single argument filter condition.
+type ArgFilter struct {
+	ParamName  string      // Parameter name from BTF
+	ParamIndex int         // 0-based index in fentry args array (BTF index)
+	ParamSize  uint32      // Size in bytes (1, 2, 4, 8)
+	Signed     bool        // Whether the parameter is signed
+	Op         ArgFilterOp // Comparison operator
+	Value      uint64      // Value for exact/comparison (or min for range)
+	MaxValue   uint64      // Max value for range operator
+}
+
+// String returns a human-readable representation of the filter.
+func (f *ArgFilter) String() string {
+	switch f.Op {
+	case OpEqual:
+		return fmt.Sprintf("%s=%d", f.ParamName, f.Value)
+	case OpGreaterEqual:
+		return fmt.Sprintf("%s>=%d", f.ParamName, f.Value)
+	case OpLessEqual:
+		return fmt.Sprintf("%s<=%d", f.ParamName, f.Value)
+	case OpRange:
+		return fmt.Sprintf("%s=%d..%d", f.ParamName, f.Value, f.MaxValue)
+	default:
+		return fmt.Sprintf("%s=?", f.ParamName)
+	}
+}
+
+// ParsedFilter holds the result of parsing a filter expression (before BTF validation).
+type ParsedFilter struct {
+	ParamName string
+	Op        ArgFilterOp
+	Value     uint64
+	MaxValue  uint64 // only used for OpRange
+}
+
+// filterPattern matches: param=value, param>=value, param<=value, param=min..max
+var filterPattern = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)(=|>=|<=)(.+)$`)
+
+// ParseArgFilter parses a single filter expression string.
+// Supported formats:
+//   - "param=value"     - exact match
+//   - "param>=value"    - greater than or equal
+//   - "param<=value"    - less than or equal
+//   - "param=min..max"  - range (inclusive)
+func ParseArgFilter(expr string) (ParsedFilter, error) {
+	matches := filterPattern.FindStringSubmatch(expr)
+	if matches == nil {
+		return ParsedFilter{}, fmt.Errorf("invalid filter expression: %q (expected: param=value, param>=value, param<=value, or param=min..max)", expr)
+	}
+
+	pf := ParsedFilter{ParamName: matches[1]}
+	opStr := matches[2]
+	valueStr := matches[3]
+
+	switch opStr {
+	case ">=", "<=":
+		if opStr == ">=" {
+			pf.Op = OpGreaterEqual
+		} else {
+			pf.Op = OpLessEqual
+		}
+		v, err := parseUint64(valueStr)
+		if err != nil {
+			return ParsedFilter{}, fmt.Errorf("invalid value in %q: %w", expr, err)
+		}
+		pf.Value = v
+	case "=":
+		if strings.Contains(valueStr, "..") {
+			parts := strings.SplitN(valueStr, "..", 2)
+			if len(parts) != 2 {
+				return ParsedFilter{}, fmt.Errorf("invalid range in %q: expected min..max", expr)
+			}
+			pf.Op = OpRange
+			v, err := parseUint64(parts[0])
+			if err != nil {
+				return ParsedFilter{}, fmt.Errorf("invalid min value in %q: %w", expr, err)
+			}
+			pf.Value = v
+			mv, err := parseUint64(parts[1])
+			if err != nil {
+				return ParsedFilter{}, fmt.Errorf("invalid max value in %q: %w", expr, err)
+			}
+			pf.MaxValue = mv
+			if pf.Value > pf.MaxValue {
+				return ParsedFilter{}, fmt.Errorf("invalid range in %q: min (%d) > max (%d)", expr, pf.Value, pf.MaxValue)
+			}
+		} else {
+			pf.Op = OpEqual
+			v, err := parseUint64(valueStr)
+			if err != nil {
+				return ParsedFilter{}, fmt.Errorf("invalid value in %q: %w", expr, err)
+			}
+			pf.Value = v
+		}
+	}
+
+	return pf, nil
+}
+
+// parseUint64 parses a string as uint64, supporting hex (0x) and decimal.
+func parseUint64(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return strconv.ParseUint(s[2:], 16, 64)
+	}
+	return strconv.ParseUint(s, 10, 64)
+}
+
+// ParseAndValidateFilters parses filter expressions and validates them against BTF parameters.
+func ParseAndValidateFilters(exprs []string, params []attach.FuncParamInfo) ([]ArgFilter, error) {
+	if len(exprs) == 0 {
+		return nil, nil
+	}
+
+	// Build a map from parameter name to its info
+	paramMap := make(map[string]attach.FuncParamInfo)
+	for _, p := range params {
+		paramMap[p.Name] = p
+	}
+
+	var filters []ArgFilter
+	for _, expr := range exprs {
+		pf, err := ParseArgFilter(expr)
+		if err != nil {
+			return nil, err
+		}
+
+		param, ok := paramMap[pf.ParamName]
+		if !ok {
+			var available []string
+			for _, p := range params {
+				available = append(available, p.Name)
+			}
+			if len(available) == 0 {
+				return nil, fmt.Errorf("parameter %q not found; function has no filterable parameters (only integer types after the first argument are supported)", pf.ParamName)
+			}
+			return nil, fmt.Errorf("parameter %q not found; available parameters: %v", pf.ParamName, available)
+		}
+
+		filters = append(filters, ArgFilter{
+			ParamName:  pf.ParamName,
+			ParamIndex: param.Index,
+			ParamSize:  param.Size,
+			Signed:     param.Signed,
+			Op:         pf.Op,
+			Value:      pf.Value,
+			MaxValue:   pf.MaxValue,
+		})
+	}
+
+	return filters, nil
+}

--- a/internal/filter/argfilter_test.go
+++ b/internal/filter/argfilter_test.go
@@ -1,0 +1,221 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+)
+
+func TestParseArgFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		expr      string
+		wantParam string
+		wantOp    ArgFilterOp
+		wantVal   uint64
+		wantMax   uint64
+		wantErr   bool
+	}{
+		{
+			name:      "exact match decimal",
+			expr:      "id=42",
+			wantParam: "id",
+			wantOp:    OpEqual,
+			wantVal:   42,
+		},
+		{
+			name:      "exact match hex",
+			expr:      "teid=0x1234",
+			wantParam: "teid",
+			wantOp:    OpEqual,
+			wantVal:   0x1234,
+		},
+		{
+			name:      "greater equal",
+			expr:      "flags>=100",
+			wantParam: "flags",
+			wantOp:    OpGreaterEqual,
+			wantVal:   100,
+		},
+		{
+			name:      "less equal",
+			expr:      "count<=1000",
+			wantParam: "count",
+			wantOp:    OpLessEqual,
+			wantVal:   1000,
+		},
+		{
+			name:      "range",
+			expr:      "port=1024..65535",
+			wantParam: "port",
+			wantOp:    OpRange,
+			wantVal:   1024,
+			wantMax:   65535,
+		},
+		{
+			name:      "range with hex",
+			expr:      "id=0x10..0xFF",
+			wantParam: "id",
+			wantOp:    OpRange,
+			wantVal:   0x10,
+			wantMax:   0xFF,
+		},
+		{
+			name:      "underscore in name",
+			expr:      "my_param=123",
+			wantParam: "my_param",
+			wantOp:    OpEqual,
+			wantVal:   123,
+		},
+		{
+			name:    "invalid: no value",
+			expr:    "id=",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: no operator",
+			expr:    "id123",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: bad value",
+			expr:    "id=abc",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: range min > max",
+			expr:    "id=100..50",
+			wantErr: true,
+		},
+		{
+			name:    "invalid: incomplete range",
+			expr:    "id=100..",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pf, err := ParseArgFilter(tt.expr)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseArgFilter(%q) expected error, got nil", tt.expr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseArgFilter(%q) unexpected error: %v", tt.expr, err)
+			}
+
+			if pf.ParamName != tt.wantParam {
+				t.Errorf("ParamName = %q, want %q", pf.ParamName, tt.wantParam)
+			}
+			if pf.Op != tt.wantOp {
+				t.Errorf("Op = %v, want %v", pf.Op, tt.wantOp)
+			}
+			if pf.Value != tt.wantVal {
+				t.Errorf("Value = %d, want %d", pf.Value, tt.wantVal)
+			}
+			if pf.MaxValue != tt.wantMax {
+				t.Errorf("MaxValue = %d, want %d", pf.MaxValue, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestParseAndValidateFilters(t *testing.T) {
+	params := []attach.FuncParamInfo{
+		{Name: "id", Index: 1, Size: 4, Signed: false},
+		{Name: "flags", Index: 2, Size: 8, Signed: false},
+		{Name: "count", Index: 3, Size: 4, Signed: true},
+	}
+
+	tests := []struct {
+		name    string
+		exprs   []string
+		want    int // expected number of filters
+		wantErr bool
+	}{
+		{
+			name:  "empty",
+			exprs: nil,
+			want:  0,
+		},
+		{
+			name:  "single filter",
+			exprs: []string{"id=42"},
+			want:  1,
+		},
+		{
+			name:  "multiple filters",
+			exprs: []string{"id=42", "flags>=100"},
+			want:  2,
+		},
+		{
+			name:    "unknown parameter",
+			exprs:   []string{"unknown=42"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid expression",
+			exprs:   []string{"invalid"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filters, err := ParseAndValidateFilters(tt.exprs, params)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseAndValidateFilters() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseAndValidateFilters() unexpected error: %v", err)
+			}
+
+			if len(filters) != tt.want {
+				t.Errorf("got %d filters, want %d", len(filters), tt.want)
+			}
+		})
+	}
+}
+
+func TestArgFilterString(t *testing.T) {
+	tests := []struct {
+		filter ArgFilter
+		want   string
+	}{
+		{
+			filter: ArgFilter{ParamName: "id", Op: OpEqual, Value: 42},
+			want:   "id=42",
+		},
+		{
+			filter: ArgFilter{ParamName: "flags", Op: OpGreaterEqual, Value: 100},
+			want:   "flags>=100",
+		},
+		{
+			filter: ArgFilter{ParamName: "count", Op: OpLessEqual, Value: 1000},
+			want:   "count<=1000",
+		},
+		{
+			filter: ArgFilter{ParamName: "port", Op: OpRange, Value: 1024, MaxValue: 65535},
+			want:   "port=1024..65535",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.filter.String()
+			if got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/filter/argfilter_test.go
+++ b/internal/filter/argfilter_test.go
@@ -193,6 +193,16 @@ func TestParseAndValidateFilters(t *testing.T) {
 			exprs:   []string{"count>=3000000000"}, // exceeds int32 max
 			wantErr: true,
 		},
+		{
+			name:    "signed range inverted",
+			exprs:   []string{"count=10..-10"}, // min > max in signed domain
+			wantErr: true,
+		},
+		{
+			name:  "signed range valid negative",
+			exprs: []string{"count=-10..10"},
+			want:  1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/filter/argfilter_test.go
+++ b/internal/filter/argfilter_test.go
@@ -68,6 +68,21 @@ func TestParseArgFilter(t *testing.T) {
 			wantVal:   123,
 		},
 		{
+			name:      "negative value",
+			expr:      "temp>=-10",
+			wantParam: "temp",
+			wantOp:    OpGreaterEqual,
+			wantVal:   ^uint64(9), // two's complement of -10
+		},
+		{
+			name:      "negative range",
+			expr:      "offset=-100..100",
+			wantParam: "offset",
+			wantOp:    OpRange,
+			wantVal:   ^uint64(99), // two's complement of -100
+			wantMax:   100,
+		},
+		{
 			name:    "invalid: no value",
 			expr:    "id=",
 			wantErr: true,
@@ -161,6 +176,21 @@ func TestParseAndValidateFilters(t *testing.T) {
 		{
 			name:    "invalid expression",
 			exprs:   []string{"invalid"},
+			wantErr: true,
+		},
+		{
+			name:    "value out of range for u32",
+			exprs:   []string{"id=4294967296"}, // 2^32, exceeds u32 max
+			wantErr: true,
+		},
+		{
+			name:  "signed negative value in range",
+			exprs: []string{"count>=-100"},
+			want:  1,
+		},
+		{
+			name:    "signed value out of range",
+			exprs:   []string{"count>=3000000000"}, // exceeds int32 max
 			wantErr: true,
 		},
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -24,7 +24,7 @@ type Writer struct {
 // NewWriter creates a pcapng writer. If path is empty, writes to stdout.
 // In exit mode, creates one pcapng interface per XDP action so that
 // Wireshark displays the action as the interface name.
-func NewWriter(path string, mode string) (*Writer, error) {
+func NewWriter(path string, isFexit bool) (*Writer, error) {
 	var dest io.Writer
 	w := &Writer{}
 
@@ -40,7 +40,7 @@ func NewWriter(path string, mode string) (*Writer, error) {
 	}
 
 	var err error
-	if mode == "exit" {
+	if isFexit {
 		err = w.initExitMode(dest)
 	} else {
 		w.pcapWriter, err = pcapgo.NewNgWriter(dest, layers.LinkTypeEthernet)

--- a/internal/program/argfilter_test.go
+++ b/internal/program/argfilter_test.go
@@ -1,0 +1,244 @@
+package program
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/filter"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// argFilterTestSource defines a noinline function with an extra u32 parameter.
+// The parameter value is derived from packet data so we can control it via ping.
+const argFilterTestSource = `
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+// Test function called with filter_id=42. Filters matching 42 receive events.
+
+__attribute__((noinline))
+int process_with_id(struct xdp_md *ctx, __u32 filter_id) {
+    volatile __u32 id = filter_id; // prevent optimization
+    return (id > 0) ? 2 : 1;
+}
+
+SEC("xdp")
+int xdp_argfilter_test(struct xdp_md *ctx) {
+    // Always pass 42 as the filter_id
+    return process_with_id(ctx, 42);
+}
+
+char _license[] SEC("license") = "GPL";
+`
+
+func loadArgFilterTestCollection(t *testing.T) *ebpf.Program {
+	t.Helper()
+	testutil.SkipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, argFilterTestSource))
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+
+	var objs struct {
+		XDP *ebpf.Program `ebpf:"xdp_argfilter_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.XDP.Close() })
+
+	return objs.XDP
+}
+
+// setupVethForArgFilter creates a veth pair and attaches the given XDP program.
+func setupVethForArgFilter(t *testing.T, xdpProg *ebpf.Program) string {
+	t.Helper()
+	return setupVeth(t, xdpProg, "argtest0", "argtest1", "10.88.0.1", "10.88.0.2")
+}
+
+// countArgFilterEvents attaches fentry with arg filters, sends packets, and counts events.
+func countArgFilterEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface string, argFilters []filter.ArgFilter) int {
+	t.Helper()
+	return countEvents(t, targetProg, funcName, iface, "10.88.0.2", false, argFilters, 3, 3)
+}
+
+// TestArgFilter verifies that argument filtering works correctly.
+// The noinline function process_with_id is always called with filter_id=42.
+func TestArgFilter(t *testing.T) {
+	xdpProg := loadArgFilterTestCollection(t)
+	iface := setupVethForArgFilter(t, xdpProg)
+
+	// First verify we can get the function parameters
+	params, err := attach.GetFuncParams(xdpProg, "process_with_id")
+	if err != nil {
+		t.Fatalf("GetFuncParams: %v", err)
+	}
+	t.Logf("Found %d filterable parameters", len(params))
+	for _, p := range params {
+		t.Logf("  %s: index=%d, size=%d, signed=%v", p.Name, p.Index, p.Size, p.Signed)
+	}
+
+	if len(params) == 0 {
+		t.Skip("No filterable parameters found (BTF may not include parameter names)")
+	}
+
+	// Find the filter_id parameter
+	var filterIDParam *attach.FuncParamInfo
+	for i := range params {
+		if params[i].Name == "filter_id" {
+			filterIDParam = &params[i]
+			break
+		}
+	}
+	if filterIDParam == nil {
+		t.Skip("filter_id parameter not found in BTF")
+	}
+
+	t.Run("no_filter", func(t *testing.T) {
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, nil)
+		if count == 0 {
+			t.Fatal("expected events without filter, got 0")
+		}
+		t.Logf("received %d events (no filter)", count)
+	})
+
+	t.Run("exact_match_hit", func(t *testing.T) {
+		// filter_id=42 should match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpEqual,
+			Value:      42,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count == 0 {
+			t.Fatal("expected events with matching filter (filter_id=42), got 0")
+		}
+		t.Logf("received %d events (filter_id=42)", count)
+	})
+
+	t.Run("exact_match_miss", func(t *testing.T) {
+		// filter_id=99 should not match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpEqual,
+			Value:      99,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count != 0 {
+			t.Fatalf("expected 0 events with non-matching filter (filter_id=99), got %d", count)
+		}
+		t.Logf("received %d events (filter_id=99, expected 0)", count)
+	})
+
+	t.Run("range_hit", func(t *testing.T) {
+		// filter_id=40..50 should match (42 is in range)
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpRange,
+			Value:      40,
+			MaxValue:   50,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count == 0 {
+			t.Fatal("expected events with range filter (filter_id=40..50), got 0")
+		}
+		t.Logf("received %d events (filter_id=40..50)", count)
+	})
+
+	t.Run("range_miss", func(t *testing.T) {
+		// filter_id=100..200 should not match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpRange,
+			Value:      100,
+			MaxValue:   200,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count != 0 {
+			t.Fatalf("expected 0 events with non-matching range filter (filter_id=100..200), got %d", count)
+		}
+		t.Logf("received %d events (filter_id=100..200, expected 0)", count)
+	})
+
+	t.Run("greater_equal_hit", func(t *testing.T) {
+		// filter_id>=40 should match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpGreaterEqual,
+			Value:      40,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count == 0 {
+			t.Fatal("expected events with >= filter (filter_id>=40), got 0")
+		}
+		t.Logf("received %d events (filter_id>=40)", count)
+	})
+
+	t.Run("greater_equal_miss", func(t *testing.T) {
+		// filter_id>=100 should not match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpGreaterEqual,
+			Value:      100,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count != 0 {
+			t.Fatalf("expected 0 events with >= filter (filter_id>=100), got %d", count)
+		}
+		t.Logf("received %d events (filter_id>=100, expected 0)", count)
+	})
+
+	t.Run("less_equal_hit", func(t *testing.T) {
+		// filter_id<=50 should match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpLessEqual,
+			Value:      50,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count == 0 {
+			t.Fatal("expected events with <= filter (filter_id<=50), got 0")
+		}
+		t.Logf("received %d events (filter_id<=50)", count)
+	})
+
+	t.Run("less_equal_miss", func(t *testing.T) {
+		// filter_id<=10 should not match
+		filters := []filter.ArgFilter{{
+			ParamName:  "filter_id",
+			ParamIndex: filterIDParam.Index,
+			ParamSize:  filterIDParam.Size,
+			Signed:     filterIDParam.Signed,
+			Op:         filter.OpLessEqual,
+			Value:      10,
+		}}
+		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
+		if count != 0 {
+			t.Fatalf("expected 0 events with <= filter (filter_id<=10), got %d", count)
+		}
+		t.Logf("received %d events (filter_id<=10, expected 0)", count)
+	})
+}

--- a/internal/program/argfilter_test.go
+++ b/internal/program/argfilter_test.go
@@ -104,141 +104,47 @@ func TestArgFilter(t *testing.T) {
 		t.Logf("received %d events (no filter)", count)
 	})
 
-	t.Run("exact_match_hit", func(t *testing.T) {
-		// filter_id=42 should match
-		filters := []filter.ArgFilter{{
+	// makeFilter builds a single-element ArgFilter slice from filterIDParam.
+	makeFilter := func(op filter.ArgFilterOp, value uint64, maxValue ...uint64) []filter.ArgFilter {
+		f := filter.ArgFilter{
 			ParamName:  "filter_id",
 			ParamIndex: filterIDParam.Index,
 			ParamSize:  filterIDParam.Size,
 			Signed:     filterIDParam.Signed,
-			Op:         filter.OpEqual,
-			Value:      42,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count == 0 {
-			t.Fatal("expected events with matching filter (filter_id=42), got 0")
+			Op:         op,
+			Value:      value,
 		}
-		t.Logf("received %d events (filter_id=42)", count)
-	})
+		if len(maxValue) > 0 {
+			f.MaxValue = maxValue[0]
+		}
+		return []filter.ArgFilter{f}
+	}
 
-	t.Run("exact_match_miss", func(t *testing.T) {
-		// filter_id=99 should not match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpEqual,
-			Value:      99,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count != 0 {
-			t.Fatalf("expected 0 events with non-matching filter (filter_id=99), got %d", count)
-		}
-		t.Logf("received %d events (filter_id=99, expected 0)", count)
-	})
+	tests := []struct {
+		name    string
+		filters []filter.ArgFilter
+		wantHit bool // true = expect events, false = expect 0
+	}{
+		{"exact_match_hit", makeFilter(filter.OpEqual, 42), true},
+		{"exact_match_miss", makeFilter(filter.OpEqual, 99), false},
+		{"range_hit", makeFilter(filter.OpRange, 40, 50), true},
+		{"range_miss", makeFilter(filter.OpRange, 100, 200), false},
+		{"greater_equal_hit", makeFilter(filter.OpGreaterEqual, 40), true},
+		{"greater_equal_miss", makeFilter(filter.OpGreaterEqual, 100), false},
+		{"less_equal_hit", makeFilter(filter.OpLessEqual, 50), true},
+		{"less_equal_miss", makeFilter(filter.OpLessEqual, 10), false},
+	}
 
-	t.Run("range_hit", func(t *testing.T) {
-		// filter_id=40..50 should match (42 is in range)
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpRange,
-			Value:      40,
-			MaxValue:   50,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count == 0 {
-			t.Fatal("expected events with range filter (filter_id=40..50), got 0")
-		}
-		t.Logf("received %d events (filter_id=40..50)", count)
-	})
-
-	t.Run("range_miss", func(t *testing.T) {
-		// filter_id=100..200 should not match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpRange,
-			Value:      100,
-			MaxValue:   200,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count != 0 {
-			t.Fatalf("expected 0 events with non-matching range filter (filter_id=100..200), got %d", count)
-		}
-		t.Logf("received %d events (filter_id=100..200, expected 0)", count)
-	})
-
-	t.Run("greater_equal_hit", func(t *testing.T) {
-		// filter_id>=40 should match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpGreaterEqual,
-			Value:      40,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count == 0 {
-			t.Fatal("expected events with >= filter (filter_id>=40), got 0")
-		}
-		t.Logf("received %d events (filter_id>=40)", count)
-	})
-
-	t.Run("greater_equal_miss", func(t *testing.T) {
-		// filter_id>=100 should not match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpGreaterEqual,
-			Value:      100,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count != 0 {
-			t.Fatalf("expected 0 events with >= filter (filter_id>=100), got %d", count)
-		}
-		t.Logf("received %d events (filter_id>=100, expected 0)", count)
-	})
-
-	t.Run("less_equal_hit", func(t *testing.T) {
-		// filter_id<=50 should match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpLessEqual,
-			Value:      50,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count == 0 {
-			t.Fatal("expected events with <= filter (filter_id<=50), got 0")
-		}
-		t.Logf("received %d events (filter_id<=50)", count)
-	})
-
-	t.Run("less_equal_miss", func(t *testing.T) {
-		// filter_id<=10 should not match
-		filters := []filter.ArgFilter{{
-			ParamName:  "filter_id",
-			ParamIndex: filterIDParam.Index,
-			ParamSize:  filterIDParam.Size,
-			Signed:     filterIDParam.Signed,
-			Op:         filter.OpLessEqual,
-			Value:      10,
-		}}
-		count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, filters)
-		if count != 0 {
-			t.Fatalf("expected 0 events with <= filter (filter_id<=10), got %d", count)
-		}
-		t.Logf("received %d events (filter_id<=10, expected 0)", count)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count := countArgFilterEvents(t, xdpProg, "process_with_id", iface, tt.filters)
+			if tt.wantHit && count == 0 {
+				t.Fatalf("expected events with filter %v, got 0", tt.filters[0].String())
+			}
+			if !tt.wantHit && count != 0 {
+				t.Fatalf("expected 0 events with filter %v, got %d", tt.filters[0].String(), count)
+			}
+			t.Logf("received %d events (%s)", count, tt.filters[0].String())
+		})
+	}
 }

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudflare/cbpfc"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/takehaya/xdp-ninja/internal/filter"
 	"golang.org/x/net/bpf"
 )
 
@@ -45,16 +46,16 @@ func (p *Probe) Close() error {
 }
 
 // LoadEntry は fentry (前段) probe を作成してアタッチする。
-func LoadEntry(targetProg *ebpf.Program, funcName string, filterExpr string) (*Probe, error) {
-	return loadProbe(targetProg, funcName, filterExpr, false)
+func LoadEntry(targetProg *ebpf.Program, funcName string, filterExpr string, argFilters []filter.ArgFilter) (*Probe, error) {
+	return loadProbe(targetProg, funcName, filterExpr, argFilters, false)
 }
 
 // LoadExit は fexit (後段) probe を作成してアタッチする。
-func LoadExit(targetProg *ebpf.Program, funcName string, filterExpr string) (*Probe, error) {
-	return loadProbe(targetProg, funcName, filterExpr, true)
+func LoadExit(targetProg *ebpf.Program, funcName string, filterExpr string, argFilters []filter.ArgFilter) (*Probe, error) {
+	return loadProbe(targetProg, funcName, filterExpr, argFilters, true)
 }
 
-func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, isFexit bool) (*Probe, error) {
+func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, argFilters []filter.ArgFilter, isFexit bool) (*Probe, error) {
 	var filterInsns asm.Instructions
 	if filterExpr != "" {
 		fi, err := compileFilter(filterExpr)
@@ -100,7 +101,7 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, isF
 		scratchFD = scratchMap.FD()
 	}
 
-	insns := buildTracingInsns(filterInsns, eventsMap.FD(), scratchFD, isFexit)
+	insns := buildTracingInsns(filterInsns, argFilters, eventsMap.FD(), scratchFD, isFexit)
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Name: fmt.Sprintf("xdp_ninja_%s", label), Type: ebpf.Tracing, AttachType: attachType,
 		AttachTo: funcName, AttachTarget: targetProg,
@@ -175,10 +176,11 @@ const (
 
 const bpfFCurrentCPU int64 = 0xFFFFFFFF
 
-func buildTracingInsns(filter asm.Instructions, eventsFD, scratchFD int, isFexit bool) asm.Instructions {
+func buildTracingInsns(pktFilter asm.Instructions, argFilters []filter.ArgFilter, eventsFD, scratchFD int, isFexit bool) asm.Instructions {
 	var insns asm.Instructions
 	insns = append(insns, loadPacketPointers()...)
-	insns = append(insns, runFilter(filter, scratchFD)...)
+	insns = append(insns, buildArgFilter(argFilters)...)
+	insns = append(insns, runFilter(pktFilter, scratchFD)...)
 	insns = append(insns, captureWithXdpOutput(eventsFD, isFexit)...)
 	insns = append(insns, asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"), asm.Return())
 	return insns
@@ -194,10 +196,10 @@ func loadPacketPointers() asm.Instructions {
 		asm.LoadMem(asm.R6, asm.R1, 0, asm.DWord),     // R6 = args[0] = xdp_buff *
 
 		// xdp_buff の構造体フィールドを直接読む (trusted pointer)
-		asm.LoadMem(asm.R7, asm.R6, 0, asm.DWord),     // R7 = xdp_buff->data
-		asm.LoadMem(asm.R8, asm.R6, 8, asm.DWord),     // R8 = xdp_buff->data_end
+		asm.LoadMem(asm.R7, asm.R6, 0, asm.DWord), // R7 = xdp_buff->data
+		asm.LoadMem(asm.R8, asm.R6, 8, asm.DWord), // R8 = xdp_buff->data_end
 
-		asm.Mov.Reg(asm.R9, asm.R8),                    // R9 = pkt_len
+		asm.Mov.Reg(asm.R9, asm.R8), // R9 = pkt_len
 		asm.Sub.Reg(asm.R9, asm.R7),
 	}
 }
@@ -243,7 +245,8 @@ func runFilter(filter asm.Instructions, scratchFD int) asm.Instructions {
 // perf event に付加してくれるので、bpf_probe_read_kernel でのパケットコピーが不要。
 //
 // ユーザーランドで受け取る RawSample のフォーマット:
-//   [metadata (8B)] [パケットデータ (pkt_len バイト)]
+//
+//	[metadata (8B)] [パケットデータ (pkt_len バイト)]
 func captureWithXdpOutput(eventsFD int, isFexit bool) asm.Instructions {
 	insns := asm.Instructions{}
 
@@ -253,13 +256,13 @@ func captureWithXdpOutput(eventsFD int, isFexit bool) asm.Instructions {
 		insns = append(insns,
 			asm.LoadMem(asm.R2, asm.R10, -48, asm.DWord), // saved args ptr
 			asm.LoadMem(asm.R2, asm.R2, 8, asm.DWord),    // args[1] = XDP action
-			asm.StoreMem(asm.R10, -8, asm.R2, asm.Word),   // stack[-8] = action (u32)
-			asm.StoreImm(asm.R10, -4, 1, asm.Byte),        // stack[-4] = mode=1 (exit)
+			asm.StoreMem(asm.R10, -8, asm.R2, asm.Word),  // stack[-8] = action (u32)
+			asm.StoreImm(asm.R10, -4, 1, asm.Byte),       // stack[-4] = mode=1 (exit)
 		)
 	} else {
 		insns = append(insns,
-			asm.StoreImm(asm.R10, -8, 0, asm.Word),        // stack[-8] = action=0
-			asm.StoreImm(asm.R10, -4, 0, asm.Byte),        // stack[-4] = mode=0 (entry)
+			asm.StoreImm(asm.R10, -8, 0, asm.Word), // stack[-8] = action=0
+			asm.StoreImm(asm.R10, -4, 0, asm.Byte), // stack[-4] = mode=0 (entry)
 		)
 	}
 
@@ -276,24 +279,94 @@ func captureWithXdpOutput(eventsFD int, isFexit bool) asm.Instructions {
 	// R4 = &metadata (スタック上)
 	// R5 = sizeof(metadata)
 	insns = append(insns,
-		asm.Mov.Reg(asm.R1, asm.R6),                      // R1 = xdp_buff
-		asm.LoadMapPtr(asm.R2, eventsFD),                  // R2 = perf map
+		asm.Mov.Reg(asm.R1, asm.R6),      // R1 = xdp_buff
+		asm.LoadMapPtr(asm.R2, eventsFD), // R2 = perf map
 
 		// R3 = flags: (cap_len << 32) | BPF_F_CURRENT_CPU
 		// cap_len = min(pkt_len, 1500)
-		asm.Mov.Reg(asm.R3, asm.R9),                      // R3 = pkt_len
+		asm.Mov.Reg(asm.R3, asm.R9), // R3 = pkt_len
 		asm.JLE.Imm(asm.R3, maxCapLen, "xdp_out_cap_ok"),
 		asm.Mov.Imm(asm.R3, maxCapLen),
 		asm.LSh.Imm(asm.R3, 32).WithSymbol("xdp_out_cap_ok"), // R3 = cap_len << 32
-		asm.LoadImm(asm.R0, bpfFCurrentCPU, asm.DWord),   // R0 = BPF_F_CURRENT_CPU
-		asm.Or.Reg(asm.R3, asm.R0),                        // R3 = (cap_len << 32) | BPF_F_CURRENT_CPU
+		asm.LoadImm(asm.R0, bpfFCurrentCPU, asm.DWord),       // R0 = BPF_F_CURRENT_CPU
+		asm.Or.Reg(asm.R3, asm.R0),                           // R3 = (cap_len << 32) | BPF_F_CURRENT_CPU
 
-		asm.Mov.Reg(asm.R4, asm.R10),                     // R4 = &metadata
+		asm.Mov.Reg(asm.R4, asm.R10), // R4 = &metadata
 		asm.Add.Imm(asm.R4, -int32(metadataSize)),
-		asm.Mov.Imm(asm.R5, int32(metadataSize)),         // R5 = 8
+		asm.Mov.Imm(asm.R5, int32(metadataSize)), // R5 = 8
 
 		asm.FnXdpOutput.Call(),
 	)
 
 	return insns
+}
+
+// buildArgFilter generates eBPF instructions to filter based on function arguments.
+// Arguments are accessed from the fentry/fexit args array stored at stack[-48].
+//
+// The args array layout for fentry is:
+//
+//	args[0] = first parameter (xdp_buff *)
+//	args[1] = second parameter
+//	args[N] = N+1th parameter
+//
+// For each filter, we load the argument value and compare it.
+// If any filter doesn't match, we jump to "exit".
+func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
+	if len(filters) == 0 {
+		return nil
+	}
+
+	var insns asm.Instructions
+	// Load args pointer once — R2 is not clobbered by subsequent loads/compares.
+	insns = append(insns, asm.LoadMem(asm.R2, asm.R10, -48, asm.DWord))
+
+	for _, f := range filters {
+		offset := int16(f.ParamIndex * 8)
+
+		var loadSize asm.Size
+		switch f.ParamSize {
+		case 1:
+			loadSize = asm.Byte
+		case 2:
+			loadSize = asm.Half
+		case 4:
+			loadSize = asm.Word
+		default:
+			loadSize = asm.DWord
+		}
+		insns = append(insns, asm.LoadMem(asm.R3, asm.R2, offset, loadSize))
+
+		// Select unsigned or signed jump ops based on parameter signedness.
+		jLT, jGT := asm.JLT, asm.JGT
+		if f.Signed {
+			jLT, jGT = asm.JSLT, asm.JSGT
+		}
+
+		switch f.Op {
+		case filter.OpEqual:
+			insns = appendCmpJump(insns, asm.JNE, f.Value)
+		case filter.OpGreaterEqual:
+			insns = appendCmpJump(insns, jLT, f.Value)
+		case filter.OpLessEqual:
+			insns = appendCmpJump(insns, jGT, f.Value)
+		case filter.OpRange:
+			insns = appendCmpJump(insns, jLT, f.Value)
+			insns = appendCmpJump(insns, jGT, f.MaxValue)
+		}
+	}
+
+	return insns
+}
+
+// appendCmpJump appends a conditional jump-to-exit comparing R3 against value.
+// Uses an immediate operand when the value fits in int32, otherwise loads into R4.
+func appendCmpJump(insns asm.Instructions, op asm.JumpOp, value uint64) asm.Instructions {
+	if value <= 0x7FFFFFFF {
+		return append(insns, op.Imm(asm.R3, int32(value), "exit"))
+	}
+	return append(insns,
+		asm.LoadImm(asm.R4, int64(value), asm.DWord),
+		op.Reg(asm.R3, asm.R4, "exit"),
+	)
 }

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -337,6 +337,17 @@ func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
 		}
 		insns = append(insns, asm.LoadMem(asm.R3, asm.R2, offset, loadSize))
 
+		// Byte/Half/Word loads zero-extend into R3. For signed parameters we must
+		// sign-extend to 64-bit so that JSLT/JSGT comparisons work correctly
+		// (e.g. int8 -1 is loaded as 0xFF and must become 0xFFFFFFFFFFFFFFFF).
+		if f.Signed && f.ParamSize < 8 {
+			shift := int32((8 - f.ParamSize) * 8) // bits to shift
+			insns = append(insns,
+				asm.LSh.Imm(asm.R3, shift),
+				asm.ArSh.Imm(asm.R3, shift),
+			)
+		}
+
 		// Select unsigned or signed jump ops based on parameter signedness.
 		jLT, jGT := asm.JLT, asm.JGT
 		if f.Signed {

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -55,7 +55,7 @@ func TestBuildTracingInsns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// FD=0 は実際のmapではないが、命令生成のテストには十分
-			insns := buildTracingInsns(tt.filter, 0, 0, tt.isFexit)
+			insns := buildTracingInsns(tt.filter, nil, 0, 0, tt.isFexit)
 			if len(insns) == 0 {
 				t.Fatal("buildTracingInsns returned empty instructions")
 			}
@@ -71,7 +71,7 @@ func TestBuildTracingInsns(t *testing.T) {
 
 func TestBuildTracingInsnsLabels(t *testing.T) {
 	filter := dummyFilter()
-	insns := buildTracingInsns(filter, 0, 0, false)
+	insns := buildTracingInsns(filter, nil, 0, 0, false)
 
 	labels := map[string]bool{}
 	for _, insn := range insns {

--- a/internal/program/tailcall_fentry_test.go
+++ b/internal/program/tailcall_fentry_test.go
@@ -1,14 +1,10 @@
 package program
 
 import (
-	"net"
-	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/perf"
-	"github.com/vishvananda/netlink"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
 )
 
 // tailcallSubfuncSource sets up a tail call chain:
@@ -50,9 +46,9 @@ char _license[] SEC("license") = "GPL";
 // loadTailcallCollection compiles and loads the tail call test programs.
 func loadTailcallCollection(t *testing.T) (dispatcher, leaf *ebpf.Program, progArray *ebpf.Map) {
 	t.Helper()
-	skipIfNotRoot(t)
+	testutil.SkipIfNotRoot(t)
 
-	spec, err := ebpf.LoadCollectionSpec(compileXDPObjFromSource(t, tailcallSubfuncSource))
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, tailcallSubfuncSource))
 	if err != nil {
 		t.Fatalf("spec: %v", err)
 	}
@@ -81,95 +77,14 @@ func loadTailcallCollection(t *testing.T) (dispatcher, leaf *ebpf.Program, progA
 // setupVethWithXDP creates a veth pair and attaches the given XDP program.
 func setupVethWithXDP(t *testing.T, xdpProg *ebpf.Program) (ifaceName string) {
 	t.Helper()
-	const veth0, veth1 = "tcftest0", "tcftest1"
-
-	_ = exec.Command("ip", "link", "del", veth0).Run()
-	if err := netlink.LinkAdd(&netlink.Veth{
-		LinkAttrs: netlink.LinkAttrs{Name: veth0},
-		PeerName:  veth1,
-	}); err != nil {
-		t.Fatalf("veth add: %v", err)
-	}
-	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", veth0).Run() })
-
-	nl0, err := netlink.LinkByName(veth0)
-	if err != nil {
-		t.Fatalf("LinkByName(%s): %v", veth0, err)
-	}
-	nl1, err := netlink.LinkByName(veth1)
-	if err != nil {
-		t.Fatalf("LinkByName(%s): %v", veth1, err)
-	}
-	if err := netlink.LinkSetUp(nl0); err != nil {
-		t.Fatalf("LinkSetUp(%s): %v", veth0, err)
-	}
-	if err := netlink.LinkSetUp(nl1); err != nil {
-		t.Fatalf("LinkSetUp(%s): %v", veth1, err)
-	}
-	if err := netlink.AddrAdd(nl0, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.99.0.1"), Mask: net.CIDRMask(24, 32)}}); err != nil {
-		t.Fatalf("AddrAdd(%s): %v", veth0, err)
-	}
-	if err := netlink.AddrAdd(nl1, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.99.0.2"), Mask: net.CIDRMask(24, 32)}}); err != nil {
-		t.Fatalf("AddrAdd(%s): %v", veth1, err)
-	}
-
-	if err := netlink.LinkSetXdpFd(nl0, xdpProg.FD()); err != nil {
-		t.Fatalf("XDP attach: %v", err)
-	}
-	t.Cleanup(func() { _ = netlink.LinkSetXdpFd(nl0, -1) })
-
-	return veth0
+	return setupVeth(t, xdpProg, "tcftest0", "tcftest1", "10.99.0.1", "10.99.0.2")
 }
 
 // countProbeEvents attaches fentry or fexit to funcName, sends packets,
 // and returns the number of perf events received.
 func countProbeEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface string, isFexit bool) int {
 	t.Helper()
-
-	var probe *Probe
-	var err error
-	if isFexit {
-		probe, err = LoadExit(targetProg, funcName, "")
-	} else {
-		probe, err = LoadEntry(targetProg, funcName, "")
-	}
-	if err != nil {
-		t.Fatalf("load probe (%s): %v", funcName, err)
-	}
-	defer func() { _ = probe.Close() }()
-
-	reader, err := perf.NewReader(probe.EventsMap, 64*1024)
-	if err != nil {
-		t.Fatalf("perf reader: %v", err)
-	}
-	defer func() { _ = reader.Close() }()
-
-	// Give the probe time to attach before sending packets.
-	time.Sleep(200 * time.Millisecond)
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_, _ = exec.Command("ping", "-c", "5", "-W", "1", "-I", iface, "10.99.0.2").CombinedOutput()
-	}()
-	defer func() { <-done }()
-
-	reader.SetDeadline(time.Now().Add(8 * time.Second))
-	count := 0
-	for {
-		record, err := reader.Read()
-		if err != nil {
-			break
-		}
-		if record.LostSamples > 0 {
-			continue
-		}
-		count++
-		if count >= 5 {
-			break
-		}
-	}
-	return count
+	return countEvents(t, targetProg, funcName, iface, "10.99.0.2", isFexit, nil, 5, 5)
 }
 
 // TestBpfTailcallSubfunc verifies that fentry/fexit on a __noinline subfunction

--- a/internal/program/testutil_test.go
+++ b/internal/program/testutil_test.go
@@ -2,12 +2,17 @@ package program
 
 import (
 	"errors"
-	"os"
+	"fmt"
+	"net"
 	"os/exec"
-	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+	"github.com/takehaya/xdp-ninja/internal/filter"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+	"github.com/vishvananda/netlink"
 )
 
 const xdpFuncName = "xdp_pass_test"
@@ -22,64 +27,12 @@ char _license[] SEC("license") = "GPL";
 
 const xdpSubfuncName = "process_packet"
 
-// xdpSubfuncSource has a __noinline subfunction that accesses ctx.
-// The body must be non-trivial; otherwise clang -O2 constant-folds
-// the call away and no bpf2bpf call survives in the bytecode.
-const xdpSubfuncSource = `
-#include <linux/bpf.h>
-#define SEC(NAME) __attribute__((section(NAME), used))
-
-__attribute__((noinline))
-int process_packet(struct xdp_md *ctx) {
-    void *data = (void *)(long)ctx->data;
-    void *data_end = (void *)(long)ctx->data_end;
-    if (data + 1 > data_end)
-        return 1;
-    return 2;
-}
-
-SEC("xdp")
-int xdp_subfunc_test(struct xdp_md *ctx) { return process_packet(ctx); }
-char _license[] SEC("license") = "GPL";
-`
-
-func skipIfNotRoot(t *testing.T) {
-	t.Helper()
-	if os.Getuid() != 0 {
-		t.Skip("requires root")
-	}
-}
-
-// compileXDPObjFromSource compiles a BPF C source string to an object file with BTF.
-// Skips the test if clang is not available.
-func compileXDPObjFromSource(t *testing.T, source string) string {
-	t.Helper()
-	dir := t.TempDir()
-	srcFile := filepath.Join(dir, "xdp.c")
-	objFile := filepath.Join(dir, "xdp.o")
-	if err := os.WriteFile(srcFile, []byte(source), 0644); err != nil {
-		t.Fatalf("writing source: %v", err)
-	}
-
-	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
-	if err != nil {
-		t.Skipf("clang not available: %v\n%s", err, out)
-	}
-	return objFile
-}
-
-// compileXDPObj compiles the dummy XDP program with BTF.
-func compileXDPObj(t *testing.T) string {
-	t.Helper()
-	return compileXDPObjFromSource(t, xdpPassSource)
-}
-
 // loadDummyXDP compiles and loads a minimal XDP_PASS program with BTF.
 func loadDummyXDP(t *testing.T) *ebpf.Program {
 	t.Helper()
-	skipIfNotRoot(t)
+	testutil.SkipIfNotRoot(t)
 
-	spec, err := ebpf.LoadCollectionSpec(compileXDPObj(t))
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, xdpPassSource))
 	if err != nil {
 		t.Fatalf("loading collection spec: %v", err)
 	}
@@ -98,9 +51,9 @@ func loadDummyXDP(t *testing.T) *ebpf.Program {
 // Returns the loaded program (entry = "xdp_subfunc_test", subfunction = "process_packet").
 func loadDummyXDPWithSubfunc(t *testing.T) *ebpf.Program {
 	t.Helper()
-	skipIfNotRoot(t)
+	testutil.SkipIfNotRoot(t)
 
-	spec, err := ebpf.LoadCollectionSpec(compileXDPObjFromSource(t, xdpSubfuncSource))
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, testutil.XDPSubfuncSource))
 	if err != nil {
 		t.Fatalf("loading collection spec: %v", err)
 	}
@@ -115,15 +68,107 @@ func loadDummyXDPWithSubfunc(t *testing.T) *ebpf.Program {
 	return objs.Prog
 }
 
+// setupVeth creates a veth pair, assigns IPs, attaches the XDP program, and registers cleanup.
+func setupVeth(t *testing.T, xdpProg *ebpf.Program, veth0, veth1, ip0, ip1 string) string {
+	t.Helper()
+
+	_ = exec.Command("ip", "link", "del", veth0).Run()
+	if err := netlink.LinkAdd(&netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: veth0},
+		PeerName:  veth1,
+	}); err != nil {
+		t.Fatalf("veth add: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", veth0).Run() })
+
+	nl0, err := netlink.LinkByName(veth0)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", veth0, err)
+	}
+	nl1, err := netlink.LinkByName(veth1)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", veth1, err)
+	}
+	if err := netlink.LinkSetUp(nl0); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", veth0, err)
+	}
+	if err := netlink.LinkSetUp(nl1); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", veth1, err)
+	}
+	if err := netlink.AddrAdd(nl0, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP(ip0), Mask: net.CIDRMask(24, 32)}}); err != nil {
+		t.Fatalf("AddrAdd(%s): %v", veth0, err)
+	}
+	if err := netlink.AddrAdd(nl1, &netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP(ip1), Mask: net.CIDRMask(24, 32)}}); err != nil {
+		t.Fatalf("AddrAdd(%s): %v", veth1, err)
+	}
+
+	if err := netlink.LinkSetXdpFd(nl0, xdpProg.FD()); err != nil {
+		t.Fatalf("XDP attach: %v", err)
+	}
+	t.Cleanup(func() { _ = netlink.LinkSetXdpFd(nl0, -1) })
+
+	return veth0
+}
+
+// countEvents attaches a probe, sends ping traffic, and returns the number of perf events received.
+func countEvents(t *testing.T, targetProg *ebpf.Program, funcName, iface, pingTarget string, isFexit bool, argFilters []filter.ArgFilter, pingCount, maxEvents int) int {
+	t.Helper()
+
+	var probe *Probe
+	var err error
+	if isFexit {
+		probe, err = LoadExit(targetProg, funcName, "", argFilters)
+	} else {
+		probe, err = LoadEntry(targetProg, funcName, "", argFilters)
+	}
+	if err != nil {
+		t.Fatalf("load probe (%s): %v", funcName, err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	reader, err := perf.NewReader(probe.EventsMap, 64*1024)
+	if err != nil {
+		t.Fatalf("perf reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	// Give the probe time to attach before sending packets.
+	time.Sleep(200 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = exec.Command("ping", "-c", fmt.Sprintf("%d", pingCount), "-W", "1", "-I", iface, pingTarget).CombinedOutput()
+	}()
+	defer func() { <-done }()
+
+	reader.SetDeadline(time.Now().Add(time.Duration(pingCount+5) * time.Second))
+	count := 0
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			break
+		}
+		if record.LostSamples > 0 {
+			continue
+		}
+		count++
+		if count >= maxEvents {
+			break
+		}
+	}
+	return count
+}
+
 // loadProbeOrFail loads a probe and fails with verifier output on error.
 func loadProbeOrFail(t *testing.T, xdpProg *ebpf.Program, funcName, filterExpr string, exit bool) *Probe {
 	t.Helper()
 	var probe *Probe
 	var err error
 	if exit {
-		probe, err = LoadExit(xdpProg, funcName, filterExpr)
+		probe, err = LoadExit(xdpProg, funcName, filterExpr, nil)
 	} else {
-		probe, err = LoadEntry(xdpProg, funcName, filterExpr)
+		probe, err = LoadEntry(xdpProg, funcName, filterExpr, nil)
 	}
 	if err != nil {
 		var ve *ebpf.VerifierError

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,56 @@
+// Package testutil provides shared test helpers for BPF/XDP integration tests.
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// SkipIfNotRoot skips the test if not running as root.
+func SkipIfNotRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("requires root")
+	}
+}
+
+// CompileBPFSource compiles a BPF C source string to an object file with BTF.
+// Skips the test if clang is not available.
+func CompileBPFSource(t *testing.T, source string) string {
+	t.Helper()
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "xdp.c")
+	objFile := filepath.Join(dir, "xdp.o")
+	if err := os.WriteFile(srcFile, []byte(source), 0644); err != nil {
+		t.Fatalf("writing source: %v", err)
+	}
+
+	out, err := exec.Command("clang", "-O2", "-g", "-target", "bpf", "-c", srcFile, "-o", objFile).CombinedOutput()
+	if err != nil {
+		t.Skipf("clang not available: %v\n%s", err, out)
+	}
+	return objFile
+}
+
+// XDPSubfuncSource is a BPF C program with a __noinline subfunction that accesses ctx.
+// The body must be non-trivial; otherwise clang -O2 constant-folds
+// the call away and no bpf2bpf call survives in the bytecode.
+const XDPSubfuncSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int process_packet(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int xdp_subfunc_test(struct xdp_md *ctx) { return process_packet(ctx); }
+char _license[] SEC("license") = "GPL";
+`

--- a/scripts/install_lint_tools.sh
+++ b/scripts/install_lint_tools.sh
@@ -23,7 +23,7 @@ install_tool "yamllint" "sudo apt-get install -y yamllint"
 install_tool "jq" "sudo apt-get install -y jq"
 install_tool "dos2unix" "sudo apt-get install -y dos2unix"
 install_tool "clang-format" "sudo apt-get install -y clang-format"
-install_tool "golangci-lint" "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+install_tool "golangci-lint" "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"
 
 echo ""
 echo "All lint tools have been installed."


### PR DESCRIPTION
## Summary
- Add `--arg-filter` flag to filter packet captures by function argument values (exact match, range, comparison operators, hex values)
- Add `--list-params` flag to discover filterable BTF parameters for a `--func` target
- Generate eBPF instructions for argument filtering with proper signed/unsigned comparison support
- Refactor and simplify probe loading API, BTF handling, mode passing, and test utilities

## New CLI flags

```
--arg-filter "param=value"       exact match (decimal or 0x hex)
--arg-filter "param>=val"        greater than or equal
--arg-filter "param<=val"        less than or equal
--arg-filter "param=min..max"    inclusive range
--list-params                    show filterable parameters and exit
```

Both require `--func` to specify the target function.

## Code improvements
- Collapse 4 `Load*` functions into 2 (`LoadEntry`/`LoadExit` with optional `argFilters`)
- Extract `appendCmpJump` helper to deduplicate eBPF comparison instruction generation
- Use `JSLT`/`JSGT` for signed parameters, `JLT`/`JGT` for unsigned
- Convert `mode` string to `isFexit` bool at validation boundary
- Open BTF spec once and share across `ValidateSubfunc` and `GetFuncParams`
- Unify duplicate test helpers into `internal/testutil` shared package

## Test plan
- [ ] `go test ./...` passes (unit tests)
- [ ] `sudo go test ./internal/program/ -run TestArgFilter` passes individual subtests
- [ ] Manual test: `--list-params` shows parameters for a `--func` target
- [ ] Manual test: `--arg-filter "param=42"` captures matching packets
- [ ] Manual test: `--arg-filter "param=99"` filters out non-matching packets
- [ ] Manual test: range and comparison operators work as expected
- [ ] Manual test: error cases (`--arg-filter` without `--func`, unknown param name)