### PR TITLE
feat: drive kunai vocab from .p4 instead of Go-side hardcodes

### DIFF
--- a/docs/ja/dsl-followups.md
+++ b/docs/ja/dsl-followups.md
@@ -58,6 +58,7 @@ F15   TC adapter             `pkg/kunai/host/tc/` 新規 (host/xdp の peer)。 
 R32   dynamic scratch        per-filter `FilterMinPrefix` で in-kernel scratch read を 512 B → 必要分のみに動的縮小。 fentry filter cost を 0.7→14.5 Mpps に解消 (paper §6 R32)
 R22   sharded ringbuf hoist  per-CPU ringbuf を `ARRAY_OF_MAPS` で entry/exit/xdp の全 attach mode に統一。 capture 出力は `path.pcap.cpuN` shards に分散
 SnapA snaplen Option A       `capture` 句なし = `capture all` の sugar (= MaxCapLen=0 → host DefaultCapLen=1500 fallback)。 tcpdump 互換 UX を優先、 ringbuf 予約縮小は `capture headers` 等で opt-in
+V4    P4 vocab-driven layout `codegen/parser_trail.go::knownVariableTails` ハードコード map + `resolve/where.go::optionsSegment` 予約名を完全削除。SRv6 は native `pkt.advance` で表現、ipv6_ext_h は `@kunai_variable_tail` + `@kunai_writeback` で表現、byte offset 6 (ipv6.next_header) は ipv6.p4 の field layout から動的解決。declare-only top-level aux stack は `@kunai_layout[after=primary|<stack>]` 必須化 (alias bug 防止)、chain 解決 + cycle 検出付き。filterset_test 30 sub-test insn count 全 byte-for-byte 維持、`p4c --parse-only` 通過
 ```
 
 ### ⚠️ Breaking changes since v0.x (master 投入時に release notes へ)

--- a/docs/ja/dsl-followups.md
+++ b/docs/ja/dsl-followups.md
@@ -61,6 +61,49 @@ SnapA snaplen Option A       `capture` 句なし = `capture all` の sugar (= Ma
 V4    P4 vocab-driven layout `codegen/parser_trail.go::knownVariableTails` ハードコード map + `resolve/where.go::optionsSegment` 予約名 + `codegen/where.go::stackCountSource` の srv6-specific 分岐を全削除。SRv6 は native `pkt.advance` で表現、ipv6_ext_h は `@kunai_variable_tail` + `@kunai_writeback` で表現、byte offset 6 (ipv6.next_header) は ipv6.p4 の field layout から動的解決。declare-only top-level aux stack は `@kunai_layout[after=primary|<stack>]` 必須化 (alias bug 防止)、chain 解決 + cycle 検出付き。SRv6 segments の runtime iteration count は `@kunai_stack_count[field=last_entry, offset=1]` から動的解決。filterset_test 30 sub-test insn count 全 byte-for-byte 維持、`p4c --parse-only` 通過
 ```
 
+### V4 intentional non-violations (= `.p4` 駆動化せず Go に残した hardcode)
+
+V4 migration で「`.p4` 1 個 drop で新規 protocol を足せる」 を建前として 4 件の
+protocol-specific hardcode を `.p4` 側に逃したが、 同 survey で見つかった残り
+2 件は **意図的に Go 側に残置** した。 将来の audit 担当者がこれを「未解決の
+違反」 と誤解して再対応しないよう、 判断根拠を残す。
+
+**violation D: `pkg/kunai/vocab/loader.go::classifyConsts` の命名規約 regex**
+
+dispatch const を `<SELF>_<PARENT>_<FIELD>` 等の正規表現マッチで分類してる箇所
+(`reField`, `reChainEnd`, `reNoCheck`, `reSanityName`)。 形式上「`.p4` 1 個
+drop で済む」 を破るが、 これは **cross-file consistency の load-bearing
+mechanism**:
+
+- 全 16+ プロトコルが同じ命名規約に従う事で typo / 誤分類が起こりにくい
+  (= `TCP_IPV4_NEXT_HEADER` のような pattern が全 protocol で統一)
+- annotation 化すると uniformity が weakening、 各 `.p4` が独自にカテゴリ宣言
+  できてしまう
+- 新規 protocol が命名規約に従わない場合は **明示エラーで loader が弾く** 方が
+  silent miscompile より遥かに安全 (= 規約破りは設計者の意図と離れた事を
+  示唆するシグナルとして機能する)
+
+つまりこの regex は「強制的な API contract」 であって、 `.p4` 側に annotation
+として落とすと API contract が緩むだけで何も得しない。 残置で正解。
+
+**violation E: `pkg/kunai/vocab/loader.go::maxDepthCap = 64`**
+
+全 protocol 共通の MAX_DEPTH 上限 64。 `.p4` 側で `<SELF>_MAX_DEPTH = N` を
+declare できるが、 **64 を超える値は Go 側で reject** する hard ceiling。
+
+これは **BPF verifier の 1M insn limit に対する安全弁**:
+
+- N を大きく超える depth (例: 4096) を `.p4` で declare すると、 codegen が
+  4096 × 1 iteration あたり数十命令 → 1M insn 制限を踏む
+- vocab author が知らずに巨大値を書くと load 時には通っても compile 時に
+  cryptic な verifier reject が出る、 デバッグ困難
+- 64 は経験的に妥当な上限 (現存 vocab は max が 32 = TCP_PARSER_MAX_DEPTH)
+- annotation 化して vocab 側 override を許すと事故母体になる ROI 釣り合わず
+
+protocol 別の安全弁として残置で正解。 もし将来 verifier の 1M 上限が緩和
+されたら (Linux 6.20+ で state-ID coalescing が入る話 = B-2a 関連) この cap も
+再評価候補。
+
 ### ⚠️ Breaking changes since v0.x (master 投入時に release notes へ)
 
 - **SnapA (snaplen Option A)**: `capture` 句なしの payload default が「filter

--- a/docs/ja/dsl-followups.md
+++ b/docs/ja/dsl-followups.md
@@ -58,7 +58,7 @@ F15   TC adapter             `pkg/kunai/host/tc/` 新規 (host/xdp の peer)。 
 R32   dynamic scratch        per-filter `FilterMinPrefix` で in-kernel scratch read を 512 B → 必要分のみに動的縮小。 fentry filter cost を 0.7→14.5 Mpps に解消 (paper §6 R32)
 R22   sharded ringbuf hoist  per-CPU ringbuf を `ARRAY_OF_MAPS` で entry/exit/xdp の全 attach mode に統一。 capture 出力は `path.pcap.cpuN` shards に分散
 SnapA snaplen Option A       `capture` 句なし = `capture all` の sugar (= MaxCapLen=0 → host DefaultCapLen=1500 fallback)。 tcpdump 互換 UX を優先、 ringbuf 予約縮小は `capture headers` 等で opt-in
-V4    P4 vocab-driven layout `codegen/parser_trail.go::knownVariableTails` ハードコード map + `resolve/where.go::optionsSegment` 予約名を完全削除。SRv6 は native `pkt.advance` で表現、ipv6_ext_h は `@kunai_variable_tail` + `@kunai_writeback` で表現、byte offset 6 (ipv6.next_header) は ipv6.p4 の field layout から動的解決。declare-only top-level aux stack は `@kunai_layout[after=primary|<stack>]` 必須化 (alias bug 防止)、chain 解決 + cycle 検出付き。filterset_test 30 sub-test insn count 全 byte-for-byte 維持、`p4c --parse-only` 通過
+V4    P4 vocab-driven layout `codegen/parser_trail.go::knownVariableTails` ハードコード map + `resolve/where.go::optionsSegment` 予約名 + `codegen/where.go::stackCountSource` の srv6-specific 分岐を全削除。SRv6 は native `pkt.advance` で表現、ipv6_ext_h は `@kunai_variable_tail` + `@kunai_writeback` で表現、byte offset 6 (ipv6.next_header) は ipv6.p4 の field layout から動的解決。declare-only top-level aux stack は `@kunai_layout[after=primary|<stack>]` 必須化 (alias bug 防止)、chain 解決 + cycle 検出付き。SRv6 segments の runtime iteration count は `@kunai_stack_count[field=last_entry, offset=1]` から動的解決。filterset_test 30 sub-test insn count 全 byte-for-byte 維持、`p4c --parse-only` 通過
 ```
 
 ### ⚠️ Breaking changes since v0.x (master 投入時に release notes へ)

--- a/docs/ja/dsl-internals.md
+++ b/docs/ja/dsl-internals.md
@@ -870,7 +870,7 @@ DSL での `gtp.opt.exists` は「`parse_opt` state に到達したか」を run
 
 #### Mechanism 4: aux header stack (SRv6 タイプ、パターン B/C)
 
-P4 の header stack `H[N]` を使う:
+P4 の header stack `H[N]` を使う。bundled SRv6 は extract せず `pkt.advance` で trailer を一発スキップし、stack の bytes は scratch 上で静的アドレス算出から読む形 (`@kunai_layout[after=primary]` で base 明示):
 
 ```p4
 // srv6.p4
@@ -879,25 +879,23 @@ header srv6_seg_h { bit<128> addr; }
 
 parser SRv6Parser(packet_in pkt,
                     out srv6_h        hdr,
+                    @kunai_layout[after=primary]
                     out srv6_seg_h[8] segments) {
     state start {
         pkt.extract(hdr);
         transition select(hdr.routing_type) {
-            4:       parse_segments;
+            4:       skip_segments;
             default: reject;
         }
     }
-    state parse_segments {
-        pkt.extract(segments.next);
-        transition select(/* iter < hdr.last_entry+1 を表す */) {
-            ...: parse_segments;
-            ...: accept;
-        }
+    state skip_segments {
+        pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6);
+        transition accept;
     }
 }
 ```
 
-stack の reservation 数 (上の例では 8) は **verifier-safe な loop 上限** として codegen が利用する。実 packet では `hdr.last_entry+1` 個まで使われる。
+stack の reservation 数 (上の例では 8) は **verifier-safe な loop 上限** として codegen が利用する。DSL の `srv6.segments[N].addr` は `layer_entry + 8 (primary) + N × 16 + 0` の静的アドレス算出でロードされる (実 segment 数を実行時に数えない設計)。マスク `0x0F` は `pkt.advance` 後の R4 が scratch buffer を超えない静的上限を verifier に与えるためのキャップ。
 
 #### Mechanism 7: TLV options walk (TCP options タイプ、パターン C 可変)
 

--- a/pkg/kunai/codegen/parser_loop.go
+++ b/pkg/kunai/codegen/parser_loop.go
@@ -735,7 +735,7 @@ func (c *pmCtx) emitSelfLoopCallback(state *vocab.ParseState, stateIdx int, cbSy
 			asm.Add.Imm(asm.R3, int32(hs)),
 			asm.StoreMem(asm.R2, bpfLoopCbCtxOffsetField, asm.R3, asm.DWord),
 		)
-		if vt, ok := knownVariableTails[ex.HeaderName]; ok {
+		if vt, ok := variableTailFor(c.spec, ex.HeaderName); ok {
 			if state.Trans.Kind == vocab.TransSelect {
 				// Callback ABI: R0/R1 are free here (R1 = bpf_loop idx
 				// is already past use), R3 = current offset, R4/R5 =

--- a/pkg/kunai/codegen/parser_state.go
+++ b/pkg/kunai/codegen/parser_state.go
@@ -288,7 +288,7 @@ func (c *pmCtx) emitStateBody(state *vocab.ParseState, stateIdx int, isEntry boo
 		hs := ex.HeaderSize / 8
 		insns = append(insns, emitAdvance(hs))
 		fixedHs += hs
-		if vt, ok := knownVariableTails[ex.HeaderName]; ok {
+		if vt, ok := variableTailFor(c.spec, ex.HeaderName); ok {
 			if state.Trans.Kind == vocab.TransSelect {
 				// Inline ABI: R0/R1 are scratch_start/end, R4 is the
 				// running offset (offsetBase). Use R3 as the load

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -5,6 +5,8 @@ import (
 	"math/bits"
 
 	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab"
 )
 
 
@@ -56,24 +58,35 @@ type writeBackOp struct {
 	ParentByteOff int // byte offset in the parent layer's header
 }
 
-// knownVariableTails enumerates the headers whose extracts pull a
-// variable trailer past the byte-aligned minimum prefix.
-//
-//   - ipv6_ext_h: per-iteration HBH/Fragment/DestOpt walking. The
-//     write-back keeps ipv6.next_header in sync with the chain tail
-//     so the next layer's dispatch (TCP_IPV6_NEXT_HEADER etc.) sees
-//     the inner protocol rather than the first ext type.
-var knownVariableTails = map[string]variableTailSkip{
-	"ipv6_ext_h": {
-		LenFieldByteOff: 1,
-		Scale:           8,
-		Base:            0,
-		LenMask:         0x03,
-		WriteBack: &writeBackOp{
-			SourceByteOff: 0,
-			ParentByteOff: 6,
-		},
-	},
+// variableTailFor lowers a vocab.HeaderAnnotations entry into the
+// codegen-internal variableTailSkip the trail emit consumes. Returns
+// ok=false when the header has no @kunai_variable_tail annotation.
+// Every header that used to live in the hand-curated knownVariableTails
+// table (srv6_h, ipv6_ext_h) now drives its trailer through this
+// path — either via @kunai_variable_tail on the header or via a
+// pkt.advance lowered to AdvanceOp upstream.
+func variableTailFor(spec *vocab.ProtocolSpec, headerName string) (variableTailSkip, bool) {
+	if spec == nil || spec.HeaderAnnotations == nil {
+		return variableTailSkip{}, false
+	}
+	ann, ok := spec.HeaderAnnotations[headerName]
+	if !ok || ann == nil || ann.VariableTail == nil {
+		return variableTailSkip{}, false
+	}
+	vt := variableTailSkip{
+		LenFieldByteOff: ann.VariableTail.LenFieldByteOff,
+		Scale:           ann.VariableTail.Scale,
+		Base:            ann.VariableTail.Base,
+		LenMask:         ann.VariableTail.LenMask,
+		LenShift:        ann.VariableTail.LenShift,
+	}
+	if ann.WriteBack != nil {
+		vt.WriteBack = &writeBackOp{
+			SourceByteOff: ann.WriteBack.SourceByteOff,
+			ParentByteOff: ann.WriteBack.ParentByteOff,
+		}
+	}
+	return vt, true
 }
 
 // log2PowerOfTwo returns log2(n) when n is a positive power of two,

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -63,11 +63,6 @@ type writeBackOp struct {
 //     write-back keeps ipv6.next_header in sync with the chain tail
 //     so the next layer's dispatch (TCP_IPV6_NEXT_HEADER etc.) sees
 //     the inner protocol rather than the first ext type.
-//
-// srv6_h was migrated to a native pkt.advance in srv6.p4's
-// skip_segments state; the trail params (Scale=8, Mask=0x0F, etc.)
-// now flow through the existing AdvanceOp path that emits the same
-// variableTailSkip via state.Advances in parser_state.go.
 var knownVariableTails = map[string]variableTailSkip{
 	"ipv6_ext_h": {
 		LenFieldByteOff: 1,

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -60,11 +60,9 @@ type writeBackOp struct {
 
 // variableTailFor lowers a vocab.HeaderAnnotations entry into the
 // codegen-internal variableTailSkip the trail emit consumes. Returns
-// ok=false when the header has no @kunai_variable_tail annotation.
-// Every header that used to live in the hand-curated knownVariableTails
-// table (srv6_h, ipv6_ext_h) now drives its trailer through this
-// path — either via @kunai_variable_tail on the header or via a
-// pkt.advance lowered to AdvanceOp upstream.
+// ok=false when the header has no @kunai_variable_tail annotation
+// (the common case — headers whose trailer is expressed natively via
+// pkt.advance flow through state.Advances upstream).
 func variableTailFor(spec *vocab.ProtocolSpec, headerName string) (variableTailSkip, bool) {
 	if spec == nil || spec.HeaderAnnotations == nil {
 		return variableTailSkip{}, false

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -79,6 +79,9 @@ func variableTailFor(spec *vocab.ProtocolSpec, headerName string) (variableTailS
 		LenShift:        ann.VariableTail.LenShift,
 	}
 	if ann.WriteBack != nil {
+		if !ann.WriteBack.Resolved {
+			panic(fmt.Sprintf("codegen: WriteBackSpec for header %q referenced before resolveHeaderWritebackTargets ran (vocab loader bug — call vocab.Load not loadFile in isolation)", headerName))
+		}
 		vt.WriteBack = &writeBackOp{
 			SourceByteOff: ann.WriteBack.SourceByteOff,
 			ParentByteOff: ann.WriteBack.ParentByteOff,

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -63,10 +63,11 @@ type writeBackOp struct {
 //     write-back keeps ipv6.next_header in sync with the chain tail
 //     so the next layer's dispatch (TCP_IPV6_NEXT_HEADER etc.) sees
 //     the inner protocol rather than the first ext type.
-//   - srv6_h: an IPv6 Routing extension whose segment list lives in
-//     the variable region. SRv6's own next_header byte (offset 0)
-//     identifies the inner protocol, so child dispatches can read it
-//     directly via the layerEntry slot — no write-back needed.
+//
+// srv6_h was migrated to a native pkt.advance in srv6.p4's
+// skip_segments state; the trail params (Scale=8, Mask=0x0F, etc.)
+// now flow through the existing AdvanceOp path that emits the same
+// variableTailSkip via state.Advances in parser_state.go.
 var knownVariableTails = map[string]variableTailSkip{
 	"ipv6_ext_h": {
 		LenFieldByteOff: 1,
@@ -77,16 +78,6 @@ var knownVariableTails = map[string]variableTailSkip{
 			SourceByteOff: 0,
 			ParentByteOff: 6,
 		},
-	},
-	"srv6_h": {
-		LenFieldByteOff: 1,
-		Scale:           8,
-		Base:            0,
-		// LenMask 0x0F = up to 15*8 = 120 bytes, covering the full
-		// `srv6_seg_h[8]` capacity (7 segments + 8B TLV) declared in
-		// srv6.p4. A tighter mask would let `srv6.segments[N]` reads
-		// land on non-segment bytes when hdr_ext_len exceeds the cap.
-		LenMask: 0x0F,
 	},
 }
 

--- a/pkg/kunai/codegen/parser_trail_test.go
+++ b/pkg/kunai/codegen/parser_trail_test.go
@@ -1,0 +1,52 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab"
+)
+
+// TestVariableTailForPanicsOnUnresolvedWriteBack pins the loader-bug
+// guard at variableTailFor: a WriteBackSpec whose Resolved flag is
+// false (= the loader's pass-2 didn't run) must panic with a clear
+// "vocab loader bug" message rather than silently treating
+// ParentByteOff=0 as a real first-byte target.
+func TestVariableTailForPanicsOnUnresolvedWriteBack(t *testing.T) {
+	spec := &vocab.ProtocolSpec{
+		Name:       "fake",
+		HeaderName: "fake_h",
+		HeaderAnnotations: map[string]*vocab.HeaderAnnotations{
+			"fake_ext_h": {
+				VariableTail: &vocab.VariableTailSpec{
+					LenFieldByteOff: 1,
+					LenMask:         0x03,
+					LenShift:        0,
+					Scale:           8,
+				},
+				WriteBack: &vocab.WriteBackSpec{
+					SourceField:   "next_header",
+					ParentProto:   "fake",
+					ParentField:   "next_header",
+					SourceByteOff: 0,
+					ParentByteOff: 0,
+					Resolved:      false, // simulating loader-bypass bug
+				},
+			},
+		},
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on unresolved WriteBackSpec, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value is %T, want string", r)
+		}
+		if !strings.Contains(msg, "vocab loader bug") {
+			t.Errorf("panic %q should mention vocab loader bug", msg)
+		}
+	}()
+	_, _ = variableTailFor(spec, "fake_ext_h")
+}

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -406,12 +406,13 @@ type quantCountSource struct {
 }
 
 // stackCountSource derives a runtime count for the quantifier
-// target's stack. SRv6 segments use the primary-header path
-// (last_entry + 1); option-internal arrays (B-4 SACK blocks) use
-// the owner-slot path with the option's length byte. Other stacks
-// return nil so the unroll runs over the full Capacity (which is
-// safe for self-flag chains where the parser has already walked
-// every entry).
+// target's stack. Option-internal arrays (B-4 SACK blocks) use the
+// owner-slot path with the option's length byte. Declare-only aux
+// stacks with a @kunai_stack_count annotation use the primary-header
+// path (Spec.StackCounts entry; SRv6 segments are the canonical
+// example via `field=last_entry, offset=1`). Other stacks return nil
+// so the unroll runs over the full Capacity (which is safe for
+// self-flag chains where the parser has already walked every entry).
 func stackCountSource(w *ir.Condition) (*quantCountSource, error) {
 	target := w.QuantTarget
 	var iterRef *ir.FieldRef
@@ -444,10 +445,14 @@ func stackCountSource(w *ir.Condition) (*quantCountSource, error) {
 			RShAfter:  shift,
 		}, nil
 	}
-	if iterRef.Layer.Spec.Name == "srv6" && target.OutParam == "segments" {
-		// last_entry is byte 4 of srv6_h. count = last_entry + 1.
-		return &quantCountSource{Layer: iterRef.Layer, ByteOff: 4, Offset: 1}, nil
+	if cnt := iterRef.Layer.Spec.StackCounts[target.OutParam]; cnt != nil {
+		return &quantCountSource{
+			Layer:   iterRef.Layer,
+			ByteOff: cnt.ByteOff,
+			Offset:  cnt.Offset,
+		}, nil
 	}
+	// No @kunai_stack_count → caller unrolls over the static Capacity.
 	return nil, nil
 }
 

--- a/pkg/kunai/dsltest/builders.go
+++ b/pkg/kunai/dsltest/builders.go
@@ -442,7 +442,7 @@ type SRv6Opts struct {
 // BuildSRv6 builds Ethernet+IPv6(NH=43)+SRH+inner-TCP. The number
 // of segments = len(opts.Segments); SRH.last_entry = N-1; SRH bytes
 // after the fixed 8 = N * 16. Codegen consumes these via the
-// variable trail (knownVariableTails["srv6_h"]).
+// variable trail declared by srv6.p4's skip_segments state.
 func BuildSRv6(t testing.TB, opts SRv6Opts) []byte {
 	t.Helper()
 	if opts.Src == nil {

--- a/pkg/kunai/protocols/ipv6.p4
+++ b/pkg/kunai/protocols/ipv6.p4
@@ -46,9 +46,9 @@ const bit<8>  IPV6_IPV6_NEXT_HEADER = 41;
 // Cap the ext-header chain depth. Real frames almost never carry
 // more than 2 ext headers (HBH + DestOpt is the typical maximum);
 // the verifier needs the loop times the per-iteration max growth
-// (8 fixed + ≤24 variable per iter, see knownVariableTails) to stay
-// within the 256-byte scratch buffer, so 4 iterations is the
-// conservative ceiling.
+// (8 fixed + ≤24 variable per iter from @kunai_variable_tail on
+// ipv6_ext_h above) to stay within the 256-byte scratch buffer, so
+// 4 iterations is the conservative ceiling.
 const bit<8> IPV6_MAX_DEPTH = 4;
 
 // Self-validating parser: the start state's tuple-select rejects on

--- a/pkg/kunai/protocols/ipv6.p4
+++ b/pkg/kunai/protocols/ipv6.p4
@@ -12,9 +12,16 @@ header ipv6_h {
 
 // Extension header (RFC 8200). The first 8 bytes of every chained
 // IPv6 ext header share this fixed shape; the variable-length tail
-// is `hdr_ext_len * 8` more bytes (codegen handles that advance).
+// is `hdr_ext_len * 8` more bytes consumed by @kunai_variable_tail.
 // Fragment (44) is the lone exception with hdr_ext_len always 0,
-// keeping the fixed-formula valid.
+// keeping the fixed-formula valid. Mask 0x03 caps the runtime advance
+// at 24 bytes per iteration so the verifier sees a static upper
+// bound; well-formed HBH/Fragment/DestOpt stay under that cap.
+// @kunai_writeback keeps ipv6.next_header in sync with the chain
+// tail's next_header so the next layer's dispatch (tcp/udp/icmp6/...)
+// sees the inner protocol rather than the first ext type.
+@kunai_variable_tail[len_field=hdr_ext_len, scale=8, mask=0x03]
+@kunai_writeback[source=next_header, parent=ipv6.next_header]
 header ipv6_ext_h {
     bit<8>  next_header;
     bit<8>  hdr_ext_len;

--- a/pkg/kunai/protocols/srv6.p4
+++ b/pkg/kunai/protocols/srv6.p4
@@ -39,6 +39,7 @@ const bit<8> SRV6_IPV6_NEXT_HEADER = 43;
 parser SRv6Parser(packet_in pkt,
                     out srv6_h        hdr,
                     @kunai_layout[after=primary]
+                    @kunai_stack_count[field=last_entry, offset=1]
                     out srv6_seg_h[8] segments) {
     state start {
         pkt.extract(hdr);

--- a/pkg/kunai/protocols/srv6.p4
+++ b/pkg/kunai/protocols/srv6.p4
@@ -2,17 +2,20 @@
 //
 // SRH is an IPv6 Routing extension header (next_header=43 in IPv6,
 // routing_type=4 in SRH itself). Total wire size = 8 + hdr_ext_len*8
-// — codegen handles the variable trail uniformly via the
-// knownVariableTails table; segment entries (16 bytes each) and any
+// — the `skip_segments` state below skips the variable region via
+// `pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6)`. The
+// mask 0x0F caps the runtime advance to (15 * 8 = 120) bytes so the
+// verifier sees a static upper bound; well-formed SRv6 frames stay
+// well under this cap. Segment entries (16 bytes each) and any
 // trailing TLVs ride inside the variable region as opaque bytes.
 //
 // `segments` is declared as an aux header stack so the resolver can
 // expose `srv6.segments[N].addr` to predicate / where codegen. The
-// parser does NOT push entries to this stack: the variable trail
-// handler in parser_machine codegen advances R4 past all segments in
-// one statically-bounded skip, and segment-N reads use that base
-// offset (= primary header size). Stack capacity 8 caps verifier
-// loop iterations identically to gtp.exts / ipv6.exts.
+// parser does NOT push entries to this stack: the variable advance
+// in `skip_segments` moves R4 past all segments in one statically-
+// bounded skip, and segment-N reads use that base offset (= primary
+// header size). Stack capacity 8 caps verifier loop iterations
+// identically to gtp.exts / ipv6.exts.
 header srv6_h {
     bit<8>  next_header;
     bit<8>  hdr_ext_len;     // in 8-byte units, excluding the first 8
@@ -43,8 +46,17 @@ parser SRv6Parser(packet_in pkt,
         // p4lite's match grammar only accepts integer literals so the
         // value is inlined here.
         transition select(hdr.routing_type) {
-            4:       accept;
+            4:       skip_segments;
             default: reject;
         }
+    }
+    // Variable trail: skip the (hdr_ext_len * 8)-byte region holding
+    // segments + TLVs. p4lite lowers `(hdr.F & MASK) << S` to the
+    // verifier-friendly HeaderLength tuple {LenByteOff=1, LenMask=0x0F,
+    // LenShift=0, Scale=8, Base=0} — equivalent to the legacy
+    // codegen/parser_trail.go::knownVariableTails["srv6_h"] entry.
+    state skip_segments {
+        pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6);
+        transition accept;
     }
 }

--- a/pkg/kunai/protocols/srv6.p4
+++ b/pkg/kunai/protocols/srv6.p4
@@ -38,6 +38,7 @@ const bit<8> SRV6_IPV6_NEXT_HEADER = 43;
 
 parser SRv6Parser(packet_in pkt,
                     out srv6_h        hdr,
+                    @kunai_layout[after=primary]
                     out srv6_seg_h[8] segments) {
     state start {
         pkt.extract(hdr);

--- a/pkg/kunai/protocols/srv6.p4
+++ b/pkg/kunai/protocols/srv6.p4
@@ -51,10 +51,9 @@ parser SRv6Parser(packet_in pkt,
         }
     }
     // Variable trail: skip the (hdr_ext_len * 8)-byte region holding
-    // segments + TLVs. p4lite lowers `(hdr.F & MASK) << S` to the
-    // verifier-friendly HeaderLength tuple {LenByteOff=1, LenMask=0x0F,
-    // LenShift=0, Scale=8, Base=0} — equivalent to the legacy
-    // codegen/parser_trail.go::knownVariableTails["srv6_h"] entry.
+    // segments + TLVs. Mask 0x0F caps the runtime advance at 120 bytes
+    // so the verifier sees a static upper bound; well-formed SRv6
+    // frames stay well under this cap.
     state skip_segments {
         pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6);
         transition accept;

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -587,13 +587,16 @@ func stackBaseOffsetInLayer(spec *vocab.ProtocolSpec, stackName string, fp *ast.
 	if offset >= 0 {
 		return offset, nil
 	}
-	// No state pushes the stack: the stack lives in the protocol's
-	// variable trail and starts immediately after the primary header.
-	primaryBits := vocab.SumBits(spec.Fields)
-	if primaryBits%8 != 0 {
-		return 0, errorf(fp.Pos, "primary header of %q is %d bits (not byte-aligned); cannot locate stack %q", spec.Name, primaryBits, stackName)
+	// No state pushes the stack: the spec must carry a @kunai_layout
+	// annotation that anchored the base at load-time. Otherwise the
+	// vocab loader's validateDeclareOnlyStacks would have rejected
+	// the spec — reaching here without an entry would be a loader
+	// bug, so error loudly rather than fall back to a possibly-
+	// aliased "after primary" guess.
+	if layout, ok := spec.StackLayouts[stackName]; ok {
+		return layout.BaseByteOff, nil
 	}
-	return primaryBits / 8, nil
+	return 0, errorf(fp.Pos, "stack %q in protocol %q has no @kunai_layout annotation; declare-only aux stacks queried via the 3-part top-level path need an explicit base anchor", stackName, spec.Name)
 }
 
 // resolveStackIndex turns an ast.IndexExpr into ir.StackIndex,

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -8,11 +8,6 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab"
 )
 
-// optionsSegment is the reserved second segment that routes 4-part
-// field paths (`<proto>.options.<NAME>.<field>`) into the option-walk
-// resolver instead of the aux-stack / single-aux paths.
-const optionsSegment = "options"
-
 // resolveWhere converts an ast.WhereExpr tree to ir.Condition, binding
 // field references inside arithmetic atoms to layers via FieldRef.
 func (r *resolver) resolveWhere(w *ast.WhereExpr) (*ir.Condition, error) {
@@ -299,16 +294,18 @@ func (r *resolver) resolveQualifiedFieldNoSlice(fp *ast.FieldPath) (*ir.FieldRef
 	// any/all; iterator form (no index) is permitted only inside a
 	// quantifier.
 	if len(fp.Parts) == 5 {
-		if fp.Parts[1] != optionsSegment {
-			return nil, errorf(fp.Pos, "5-part field path requires the second segment to be %q (got %q)", optionsSegment, fp.Parts[1])
+		if fp.Parts[1] != layer.Spec.OptionSegment {
+			return nil, errorf(fp.Pos, "5-part field path requires the second segment to be %q (got %q)", layer.Spec.OptionSegment, fp.Parts[1])
 		}
 		return r.resolveOptionStackField(layer, fp.Parts[2], fp.Parts[3], indexAt(fp, 3), fp.Parts[4], fp)
 	}
-	// 4-part: `<qualifier>.options.<NAME>.<field|exists>` routes to
-	// the protocol's declared OptionWalk.
+	// 4-part: `<qualifier>.<option_segment>.<NAME>.<field|exists>` routes to
+	// the protocol's declared OptionWalk. `<option_segment>` defaults
+	// to `options` but can be overridden per-protocol via
+	// @kunai_option_segment on the parser block.
 	if len(fp.Parts) == 4 {
-		if fp.Parts[1] != optionsSegment {
-			return nil, errorf(fp.Pos, "4-part field path requires the second segment to be %q (got %q)", optionsSegment, fp.Parts[1])
+		if fp.Parts[1] != layer.Spec.OptionSegment {
+			return nil, errorf(fp.Pos, "4-part field path requires the second segment to be %q (got %q)", layer.Spec.OptionSegment, fp.Parts[1])
 		}
 		return resolveOptionField(layer, fp.Parts[2], fp.Parts[3], fp)
 	}

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -6,6 +6,15 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab/p4lite"
 )
 
+// Annotation names recognised by the loader. Hoisting these to
+// constants makes a rename grep-safe across `.p4` files and Go code,
+// and surfaces typos at compile time inside the loader itself.
+const (
+	annKunaiVariableTail = "kunai_variable_tail"
+	annKunaiWriteback    = "kunai_writeback"
+	annKunaiOptionSeg    = "kunai_option_segment"
+)
+
 // readParserOptionSegment scans the parser block's @-decorators for
 // @kunai_option_segment[name=IDENT]. Returns the declared segment
 // name or the empty string when no override exists; the loader treats
@@ -17,7 +26,7 @@ func readParserOptionSegment(file *p4lite.File, source string) (string, error) {
 	allowed := map[string]bool{"name": true}
 	for _, par := range file.Parsers {
 		for _, ann := range par.Annotations {
-			if ann.Name != "kunai_option_segment" {
+			if ann.Name != annKunaiOptionSeg {
 				continue
 			}
 			if err := requireKnownKeys(ann, allowed, source); err != nil {
@@ -54,7 +63,7 @@ func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*Header
 	for _, h := range file.Headers {
 		for _, ann := range h.Annotations {
 			switch ann.Name {
-			case "kunai_variable_tail":
+			case annKunaiVariableTail:
 				vt, err := lowerKunaiVariableTail(ann, h, source)
 				if err != nil {
 					return nil, err
@@ -64,7 +73,7 @@ func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*Header
 					return nil, fmt.Errorf("%s:%s: header %q declares @kunai_variable_tail twice", source, ann.Pos, h.Name)
 				}
 				entry.VariableTail = vt
-			case "kunai_writeback":
+			case annKunaiWriteback:
 				wb, err := lowerKunaiWriteback(ann, h, source)
 				if err != nil {
 					return nil, err

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -13,7 +13,146 @@ const (
 	annKunaiVariableTail = "kunai_variable_tail"
 	annKunaiWriteback    = "kunai_writeback"
 	annKunaiOptionSeg    = "kunai_option_segment"
+	annKunaiLayout       = "kunai_layout"
 )
+
+// stackLayoutAfterPrimary is the magic identifier the @kunai_layout
+// annotation uses to anchor an aux stack at the end of the primary
+// header. Future extension: `after=<other_stack>` walks the chain to
+// support multiple concurrent declare-only stacks.
+const stackLayoutAfterPrimary = "primary"
+
+// readParserParamLayouts walks the parser block's parameter list and
+// lowers each @kunai_layout decorator into a StackLayoutSpec keyed by
+// the parameter name. Only declare-only aux stacks (= `out X[N] name`
+// parameters never pushed inside a parser state) need this; the
+// caller filters by the "is this stack pushed somewhere?" criterion
+// after both `readParserParamLayouts` and the parser-machine pass
+// have run.
+//
+// The annotation grammar is `@kunai_layout[after=<IDENT>]` where the
+// identifier is either the literal `primary` (= anchor at the primary
+// header's byte end) or another stack's parameter name (chain — not
+// yet supported; reserved for a follow-up that walks dependencies).
+func readParserParamLayouts(file *p4lite.File, source string) (map[string]*StackLayoutSpec, error) {
+	if file == nil {
+		return nil, nil
+	}
+	allowed := map[string]bool{"after": true}
+	out := make(map[string]*StackLayoutSpec)
+	for _, par := range file.Parsers {
+		for _, prm := range par.Params {
+			for _, ann := range prm.Annotations {
+				if ann.Name != annKunaiLayout {
+					continue
+				}
+				if err := requireKnownKeys(ann, allowed, source); err != nil {
+					return nil, err
+				}
+				afterVal, ok := ann.KVs["after"]
+				if !ok {
+					return nil, fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `after`", source, ann.Pos, annKunaiLayout, prm.VarName)
+				}
+				if afterVal.Kind != p4lite.AnnotationIdent {
+					return nil, fmt.Errorf("%s:%s: @%s.after must be an identifier (got %v)", source, ann.Pos, annKunaiLayout, afterVal.Kind)
+				}
+				if !prm.IsOut || !prm.IsArray {
+					return nil, fmt.Errorf("%s:%s: @%s only applies to `out X[N] name` parameters (got %q)", source, ann.Pos, annKunaiLayout, prm.VarName)
+				}
+				if _, exists := out[prm.VarName]; exists {
+					return nil, fmt.Errorf("%s:%s: parameter %q has multiple @%s annotations", source, ann.Pos, prm.VarName, annKunaiLayout)
+				}
+				out[prm.VarName] = &StackLayoutSpec{After: afterVal.Ident}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// resolveStackLayouts fills BaseByteOff on each StackLayoutSpec. Must
+// run after primary header bit width is known. `after=primary` is the
+// only currently-supported anchor; future chained forms
+// (`after=<other_stack>`) will walk dependencies here.
+func resolveStackLayouts(spec *ProtocolSpec) error {
+	if len(spec.StackLayouts) == 0 {
+		return nil
+	}
+	primaryBits := SumBits(spec.Fields)
+	if primaryBits%8 != 0 {
+		return fmt.Errorf("%s: primary header of %q is %d bits (not byte-aligned); cannot resolve @kunai_layout base", spec.Source, spec.Name, primaryBits)
+	}
+	primaryBytes := primaryBits / 8
+	for name, layout := range spec.StackLayouts {
+		switch layout.After {
+		case stackLayoutAfterPrimary:
+			layout.BaseByteOff = primaryBytes
+		default:
+			return fmt.Errorf("%s: @kunai_layout on %q references unsupported anchor %q (only %q is implemented in MVP; chained `after=<stack>` is reserved for future work)", spec.Source, name, layout.After, stackLayoutAfterPrimary)
+		}
+	}
+	return nil
+}
+
+// validateDeclareOnlyStacks ensures every top-level declare-only aux
+// stack carries a @kunai_layout annotation. "Top-level" excludes
+// owner-bound stacks (e.g. TCP SACK blocks, IPv4 RR addrs) — those are
+// reached via 5-part option-walk paths whose resolver uses the option
+// dispatch's slot prelude for the base, not stackBaseOffsetInLayer.
+// Only stacks queried via the 3-part `<proto>.<stack>[N].<field>`
+// path are at risk of aliasing in resolveStackLayouts/where.go, so the
+// annotation requirement is scoped to them.
+func validateDeclareOnlyStacks(spec *ProtocolSpec) error {
+	if spec.File == nil {
+		return nil
+	}
+	pushed := pushedStackNames(spec)
+	owned := ownerBoundStackNames(spec)
+	for _, par := range spec.File.Parsers {
+		for _, prm := range par.Params {
+			if !prm.IsOut || !prm.IsArray {
+				continue
+			}
+			if pushed[prm.VarName] || owned[prm.VarName] {
+				continue
+			}
+			if spec.StackLayouts == nil || spec.StackLayouts[prm.VarName] == nil {
+				return fmt.Errorf("%s:%s: top-level declare-only aux stack %q has no @kunai_layout annotation (required so multiple un-pushed stacks don't alias onto the same byte offset; use @kunai_layout[after=primary] for SRv6-style segment lists)", spec.Source, prm.Pos, prm.VarName)
+			}
+		}
+	}
+	return nil
+}
+
+func pushedStackNames(spec *ProtocolSpec) map[string]bool {
+	out := make(map[string]bool)
+	if spec.ParseStateMachine == nil {
+		return out
+	}
+	for _, st := range spec.ParseStateMachine.States {
+		for _, ex := range st.Extracts {
+			if ex.IsStackPush {
+				out[ex.StackName] = true
+			}
+		}
+	}
+	return out
+}
+
+func ownerBoundStackNames(spec *ProtocolSpec) map[string]bool {
+	out := make(map[string]bool)
+	if spec.ParseStateMachine == nil {
+		return out
+	}
+	for name, stack := range spec.ParseStateMachine.StackRefs {
+		if stack.OwnerOption != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
 
 // readParserOptionSegment scans the parser block's @-decorators for
 // @kunai_option_segment[name=IDENT]. Returns the declared segment

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -551,6 +551,7 @@ func resolveHeaderWritebackTargets(specs map[string]*ProtocolSpec) error {
 				return fmt.Errorf("%s: @kunai_writeback on %q targets non-byte-aligned field %s.%s (bit offset %d)", spec.Source, hname, wb.ParentProto, wb.ParentField, bitOff)
 			}
 			wb.ParentByteOff = bitOff / 8
+			wb.Resolved = true
 		}
 	}
 	return nil

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -72,10 +72,15 @@ func readParserParamLayouts(file *p4lite.File, source string) (map[string]*Stack
 	return out, nil
 }
 
-// resolveStackLayouts fills BaseByteOff on each StackLayoutSpec. Must
-// run after primary header bit width is known. `after=primary` is the
-// only currently-supported anchor; future chained forms
-// (`after=<other_stack>`) will walk dependencies here.
+// resolveStackLayouts fills BaseByteOff on each StackLayoutSpec.
+// `after=primary` anchors at the primary header's byte end;
+// `after=<other_stack>` references another aux stack and resolves to
+// (upstream.BaseByteOff + upstream_capacity * upstream_elem_bytes).
+//
+// Chains are resolved iteratively (fixed-point) so declaration order
+// doesn't matter. A cycle aborts with a clear diagnostic; an unknown
+// anchor (= referenced name is neither "primary" nor a declared
+// stack) also errors loudly.
 func resolveStackLayouts(spec *ProtocolSpec) error {
 	if len(spec.StackLayouts) == 0 {
 		return nil
@@ -85,15 +90,96 @@ func resolveStackLayouts(spec *ProtocolSpec) error {
 		return fmt.Errorf("%s: primary header of %q is %d bits (not byte-aligned); cannot resolve @kunai_layout base", spec.Source, spec.Name, primaryBits)
 	}
 	primaryBytes := primaryBits / 8
-	for name, layout := range spec.StackLayouts {
-		switch layout.After {
-		case stackLayoutAfterPrimary:
-			layout.BaseByteOff = primaryBytes
-		default:
-			return fmt.Errorf("%s: @kunai_layout on %q references unsupported anchor %q (only %q is implemented in MVP; chained `after=<stack>` is reserved for future work)", spec.Source, name, layout.After, stackLayoutAfterPrimary)
+
+	resolved := make(map[string]bool, len(spec.StackLayouts))
+	pending := make(map[string]bool, len(spec.StackLayouts))
+	for name := range spec.StackLayouts {
+		pending[name] = true
+	}
+
+	progress := true
+	for len(pending) > 0 && progress {
+		progress = false
+		for name := range pending {
+			layout := spec.StackLayouts[name]
+			switch {
+			case layout.After == stackLayoutAfterPrimary:
+				layout.BaseByteOff = primaryBytes
+				resolved[name] = true
+				delete(pending, name)
+				progress = true
+			case spec.StackLayouts[layout.After] != nil:
+				if !resolved[layout.After] {
+					continue
+				}
+				upstream := spec.StackLayouts[layout.After]
+				span, err := stackSpanBytes(spec, layout.After)
+				if err != nil {
+					return fmt.Errorf("%s: @kunai_layout on %q (after=%q): %w", spec.Source, name, layout.After, err)
+				}
+				layout.BaseByteOff = upstream.BaseByteOff + span
+				resolved[name] = true
+				delete(pending, name)
+				progress = true
+			default:
+				return fmt.Errorf("%s: @kunai_layout on %q references unknown anchor %q (must be %q or another parser-parameter stack name)", spec.Source, name, layout.After, stackLayoutAfterPrimary)
+			}
 		}
 	}
+	if len(pending) > 0 {
+		names := make([]string, 0, len(pending))
+		for n := range pending {
+			names = append(names, n)
+		}
+		return fmt.Errorf("%s: @kunai_layout chain has a cycle or forward reference among %v", spec.Source, names)
+	}
 	return nil
+}
+
+// stackSpanBytes returns the on-wire byte span of a parser-parameter
+// stack: capacity × sizeof(its header type). The parser parameter
+// list is the source of truth for capacity (= [N]), and file.Headers
+// for the per-element bit width.
+func stackSpanBytes(spec *ProtocolSpec, stackName string) (int, error) {
+	if spec.File == nil {
+		return 0, fmt.Errorf("spec %q has no parsed file; cannot compute span of %q", spec.Name, stackName)
+	}
+	var prm *p4lite.Param
+	for _, par := range spec.File.Parsers {
+		for i := range par.Params {
+			if par.Params[i].VarName == stackName {
+				prm = &par.Params[i]
+				break
+			}
+		}
+		if prm != nil {
+			break
+		}
+	}
+	if prm == nil {
+		return 0, fmt.Errorf("stack %q is not a parser parameter", stackName)
+	}
+	if !prm.IsArray {
+		return 0, fmt.Errorf("stack %q is not an array parameter (`out X[N]`)", stackName)
+	}
+	var hdr *p4lite.Header
+	for _, h := range spec.File.Headers {
+		if h.Name == prm.TypeName {
+			hdr = h
+			break
+		}
+	}
+	if hdr == nil {
+		return 0, fmt.Errorf("stack %q references unknown header type %q", stackName, prm.TypeName)
+	}
+	bits := 0
+	for _, f := range hdr.Fields {
+		bits += f.Bits
+	}
+	if bits%8 != 0 {
+		return 0, fmt.Errorf("header %q is %d bits (not byte-aligned); element size for stack %q is undefined", prm.TypeName, bits, stackName)
+	}
+	return prm.ArraySize * (bits / 8), nil
 }
 
 // validateDeclareOnlyStacks ensures every top-level declare-only aux

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -1,0 +1,262 @@
+package vocab
+
+import (
+	"fmt"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab/p4lite"
+)
+
+// readHeaderAnnotations walks every header declaration in file and
+// lowers kunai-recognised @-decorators into HeaderAnnotations entries
+// keyed by header name. Unrecognised annotation names are tolerated so
+// authors can pin future-reserved hints without a parser flag day; the
+// keys of every recognised annotation are checked strictly so a typo
+// fails loudly rather than silently no-op'ing.
+//
+// Cross-protocol field references inside @kunai_writeback are parsed
+// but not resolved — the loader's pass-2 fills SourceByteOff /
+// ParentByteOff once every spec is in scope.
+func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*HeaderAnnotations, error) {
+	if file == nil {
+		return nil, nil
+	}
+	out := make(map[string]*HeaderAnnotations)
+	for _, h := range file.Headers {
+		for _, ann := range h.Annotations {
+			switch ann.Name {
+			case "kunai_variable_tail":
+				vt, err := lowerKunaiVariableTail(ann, h, source)
+				if err != nil {
+					return nil, err
+				}
+				entry := getOrCreateHeaderAnnotations(out, h.Name)
+				if entry.VariableTail != nil {
+					return nil, fmt.Errorf("%s:%s: header %q declares @kunai_variable_tail twice", source, ann.Pos, h.Name)
+				}
+				entry.VariableTail = vt
+			case "kunai_writeback":
+				wb, err := lowerKunaiWriteback(ann, h, source)
+				if err != nil {
+					return nil, err
+				}
+				entry := getOrCreateHeaderAnnotations(out, h.Name)
+				if entry.WriteBack != nil {
+					return nil, fmt.Errorf("%s:%s: header %q declares @kunai_writeback twice", source, ann.Pos, h.Name)
+				}
+				entry.WriteBack = wb
+			default:
+				continue
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func getOrCreateHeaderAnnotations(m map[string]*HeaderAnnotations, name string) *HeaderAnnotations {
+	if e, ok := m[name]; ok {
+		return e
+	}
+	e := &HeaderAnnotations{}
+	m[name] = e
+	return e
+}
+
+// lowerKunaiVariableTail validates and projects an
+// @kunai_variable_tail[len_field=F, scale=S, mask=M, shift=N, base=B]
+// decorator into VariableTailSpec. Required keys: len_field, scale.
+// Optional keys: mask (defaults to the full field extraction mask),
+// shift (defaults to 0), base (defaults to 0). The named field's
+// declared bit layout drives the LenFieldByteOff / LenShift /
+// field-extraction-mask intersection so authors don't repeat what
+// the header schema already states.
+func lowerKunaiVariableTail(ann p4lite.Annotation, h *p4lite.Header, source string) (*VariableTailSpec, error) {
+	allowed := map[string]bool{"len_field": true, "scale": true, "mask": true, "shift": true, "base": true}
+	if err := requireKnownKeys(ann, allowed, source); err != nil {
+		return nil, err
+	}
+	lenFieldVal, ok := ann.KVs["len_field"]
+	if !ok {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail on header %q is missing required key `len_field`", source, ann.Pos, h.Name)
+	}
+	if lenFieldVal.Kind != p4lite.AnnotationIdent {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.len_field must be an identifier (got %v)", source, ann.Pos, lenFieldVal.Kind)
+	}
+	bitOff, fieldBits, ok := findHeaderFieldWindow(h, lenFieldVal.Ident)
+	if !ok {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.len_field references unknown field %q in header %q", source, ann.Pos, lenFieldVal.Ident, h.Name)
+	}
+	if (bitOff%8)+fieldBits > 8 {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.len_field %q crosses a byte boundary (bits [%d,%d) — only single-byte fields are supported)", source, ann.Pos, lenFieldVal.Ident, bitOff, bitOff+fieldBits)
+	}
+	scale, err := readIntAnnotation(ann, "scale", source)
+	if err != nil {
+		return nil, err
+	}
+	if scale <= 0 {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.scale must be positive (got %d)", source, ann.Pos, scale)
+	}
+	if !isPowerOfTwo(scale) {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.scale must be a power of two (got %d)", source, ann.Pos, scale)
+	}
+	bitInByte := bitOff % 8
+	lsbShift := 8 - bitInByte - fieldBits
+	fieldExtractionMask := ((1 << fieldBits) - 1) << lsbShift
+	mask := fieldExtractionMask
+	if mTok, ok := ann.KVs["mask"]; ok {
+		if mTok.Kind != p4lite.AnnotationInt {
+			return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.mask must be an int literal", source, ann.Pos)
+		}
+		if mTok.Int == 0 {
+			return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.mask=0 makes the trail length always zero — unintended", source, ann.Pos)
+		}
+		if mTok.Int >= (1 << fieldBits) {
+			return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.mask=0x%x exceeds the %d-bit field %q (max 0x%x)", source, ann.Pos, mTok.Int, fieldBits, lenFieldVal.Ident, (1<<fieldBits)-1)
+		}
+		mask = int(mTok.Int) << lsbShift
+	}
+	shift := lsbShift
+	if sTok, ok := ann.KVs["shift"]; ok {
+		if sTok.Kind != p4lite.AnnotationInt {
+			return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.shift must be an int literal", source, ann.Pos)
+		}
+		shift = int(sTok.Int)
+	}
+	base := 0
+	if bTok, ok := ann.KVs["base"]; ok {
+		if bTok.Kind != p4lite.AnnotationInt {
+			return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.base must be an int literal", source, ann.Pos)
+		}
+		base = int(bTok.Int)
+	}
+	return &VariableTailSpec{
+		LenFieldByteOff: bitOff / 8,
+		LenMask:         mask,
+		LenShift:        shift,
+		Scale:           scale,
+		Base:            base,
+	}, nil
+}
+
+// lowerKunaiWriteback validates @kunai_writeback[source=F, parent=P.F]
+// and resolves SourceByteOff against the chained header's layout.
+// ParentByteOff is left zero — the loader's pass-2 fills it after
+// every protocol's primary header is in scope.
+func lowerKunaiWriteback(ann p4lite.Annotation, h *p4lite.Header, source string) (*WriteBackSpec, error) {
+	allowed := map[string]bool{"source": true, "parent": true}
+	if err := requireKnownKeys(ann, allowed, source); err != nil {
+		return nil, err
+	}
+	srcVal, ok := ann.KVs["source"]
+	if !ok {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback on header %q is missing required key `source`", source, ann.Pos, h.Name)
+	}
+	if srcVal.Kind != p4lite.AnnotationIdent {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback.source must be an identifier", source, ann.Pos)
+	}
+	bitOff, fieldBits, ok := findHeaderFieldWindow(h, srcVal.Ident)
+	if !ok {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback.source references unknown field %q in header %q", source, ann.Pos, srcVal.Ident, h.Name)
+	}
+	if fieldBits != 8 || bitOff%8 != 0 {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback.source field %q is not a byte-aligned 8-bit field (writeback is a single byte copy)", source, ann.Pos, srcVal.Ident)
+	}
+	parentVal, ok := ann.KVs["parent"]
+	if !ok {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback on header %q is missing required key `parent`", source, ann.Pos, h.Name)
+	}
+	if parentVal.Kind != p4lite.AnnotationFieldRef {
+		return nil, fmt.Errorf("%s:%s: @kunai_writeback.parent must be a `proto.field` reference (e.g. `ipv6.next_header`)", source, ann.Pos)
+	}
+	return &WriteBackSpec{
+		SourceField:   srcVal.Ident,
+		ParentProto:   parentVal.Proto,
+		ParentField:   parentVal.Field,
+		SourceByteOff: bitOff / 8,
+	}, nil
+}
+
+// requireKnownKeys errors when an annotation carries a key the
+// recognised set doesn't accept. This catches `@kunai_writeback[srce=...]`
+// typos at load time instead of silently no-op'ing them.
+func requireKnownKeys(ann p4lite.Annotation, allowed map[string]bool, source string) error {
+	for k := range ann.KVs {
+		if !allowed[k] {
+			return fmt.Errorf("%s:%s: @%s does not accept key %q", source, ann.Pos, ann.Name, k)
+		}
+	}
+	return nil
+}
+
+func readIntAnnotation(ann p4lite.Annotation, key string, source string) (int, error) {
+	v, ok := ann.KVs[key]
+	if !ok {
+		return 0, fmt.Errorf("%s:%s: @%s is missing required int key %q", source, ann.Pos, ann.Name, key)
+	}
+	if v.Kind != p4lite.AnnotationInt {
+		return 0, fmt.Errorf("%s:%s: @%s.%s must be an int literal", source, ann.Pos, ann.Name, key)
+	}
+	return int(v.Int), nil
+}
+
+func findHeaderFieldWindow(h *p4lite.Header, name string) (bitOff, bits int, ok bool) {
+	off := 0
+	for _, f := range h.Fields {
+		if f.Name == name {
+			return off, f.Bits, true
+		}
+		off += f.Bits
+	}
+	return 0, 0, false
+}
+
+func isPowerOfTwo(n int) bool {
+	if n <= 0 {
+		return false
+	}
+	return n&(n-1) == 0
+}
+
+// resolveHeaderWritebackTargets fills ParentByteOff on every
+// WriteBackSpec across the spec set. Run after every protocol's
+// primary header is loaded so cross-protocol field references can be
+// satisfied. The field must live in the parent's primary header and
+// be a byte-aligned 8-bit slot for the codegen byte copy to land
+// without extra masking.
+func resolveHeaderWritebackTargets(specs map[string]*ProtocolSpec) error {
+	for _, spec := range specs {
+		for hname, hann := range spec.HeaderAnnotations {
+			wb := hann.WriteBack
+			if wb == nil {
+				continue
+			}
+			parent, ok := specs[wb.ParentProto]
+			if !ok {
+				return fmt.Errorf("%s: @kunai_writeback on %q references unknown protocol %q", spec.Source, hname, wb.ParentProto)
+			}
+			bitOff, found := bitOffsetInFields(parent.Fields, wb.ParentField)
+			if !found {
+				return fmt.Errorf("%s: @kunai_writeback on %q references unknown field %q in protocol %q", spec.Source, hname, wb.ParentField, wb.ParentProto)
+			}
+			if bitOff%8 != 0 {
+				return fmt.Errorf("%s: @kunai_writeback on %q targets non-byte-aligned field %s.%s (bit offset %d)", spec.Source, hname, wb.ParentProto, wb.ParentField, bitOff)
+			}
+			wb.ParentByteOff = bitOff / 8
+		}
+	}
+	return nil
+}
+
+func bitOffsetInFields(fields []Field, name string) (int, bool) {
+	off := 0
+	for _, f := range fields {
+		if f.Name == name {
+			return off, true
+		}
+		off += f.Bits
+	}
+	return 0, false
+}
+

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -14,6 +14,7 @@ const (
 	annKunaiWriteback    = "kunai_writeback"
 	annKunaiOptionSeg    = "kunai_option_segment"
 	annKunaiLayout       = "kunai_layout"
+	annKunaiStackCount   = "kunai_stack_count"
 )
 
 // stackLayoutAfterPrimary is the magic identifier the @kunai_layout
@@ -238,6 +239,71 @@ func ownerBoundStackNames(spec *ProtocolSpec) map[string]bool {
 		}
 	}
 	return out
+}
+
+// stackCountAllowedKeys is the @kunai_stack_count key set, hoisted to
+// package scope so the no-annotation common case (= every protocol
+// except srv6 today) doesn't allocate a transient map per loadFile.
+var stackCountAllowedKeys = map[string]bool{"field": true, "offset": true}
+
+// readParserParamCounts lowers each @kunai_stack_count decorator on a
+// parser parameter into a StackCountSpec keyed by parameter name.
+// The annotation names a primary-header field whose byte value (plus
+// an optional integer offset) gives the stack's runtime element count
+// for `any/all` quantifiers. Resolution requires the primary header's
+// field layout, so the caller supplies the parsed `[]Field` slice.
+func readParserParamCounts(file *p4lite.File, primaryFields []Field, source string) (map[string]*StackCountSpec, error) {
+	if file == nil {
+		return nil, nil
+	}
+	var out map[string]*StackCountSpec
+	for _, par := range file.Parsers {
+		for _, prm := range par.Params {
+			for _, ann := range prm.Annotations {
+				if ann.Name != annKunaiStackCount {
+					continue
+				}
+				if err := requireKnownKeys(ann, stackCountAllowedKeys, source); err != nil {
+					return nil, err
+				}
+				if !prm.IsOut || !prm.IsArray {
+					return nil, fmt.Errorf("%s:%s: @%s only applies to `out X[N] name` parameters (got %q)", source, ann.Pos, annKunaiStackCount, prm.VarName)
+				}
+				fieldVal, ok := ann.KVs["field"]
+				if !ok {
+					return nil, fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `field`", source, ann.Pos, annKunaiStackCount, prm.VarName)
+				}
+				if fieldVal.Kind != p4lite.AnnotationIdent {
+					return nil, fmt.Errorf("%s:%s: @%s.field must be an identifier (got %v)", source, ann.Pos, annKunaiStackCount, fieldVal.Kind)
+				}
+				bitOff, bits, found := BitOffsetIn(primaryFields, fieldVal.Ident)
+				if !found {
+					return nil, fmt.Errorf("%s:%s: @%s.field references unknown field %q in primary header", source, ann.Pos, annKunaiStackCount, fieldVal.Ident)
+				}
+				if bits != 8 || bitOff%8 != 0 {
+					return nil, fmt.Errorf("%s:%s: @%s.field %q must be a byte-aligned 8-bit field (got bit offset %d, %d bits wide)", source, ann.Pos, annKunaiStackCount, fieldVal.Ident, bitOff, bits)
+				}
+				offset := 0
+				if oVal, ok := ann.KVs["offset"]; ok {
+					if oVal.Kind != p4lite.AnnotationInt {
+						return nil, fmt.Errorf("%s:%s: @%s.offset must be an int literal", source, ann.Pos, annKunaiStackCount)
+					}
+					offset = int(oVal.Int)
+				}
+				if _, exists := out[prm.VarName]; exists {
+					return nil, fmt.Errorf("%s:%s: parameter %q has multiple @%s annotations", source, ann.Pos, prm.VarName, annKunaiStackCount)
+				}
+				if out == nil {
+					out = make(map[string]*StackCountSpec)
+				}
+				out[prm.VarName] = &StackCountSpec{
+					ByteOff: bitOff / 8,
+					Offset:  offset,
+				}
+			}
+		}
+	}
+	return out, nil
 }
 
 // readParserOptionSegment scans the parser block's @-decorators for

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -16,6 +16,36 @@ import (
 // Cross-protocol field references inside @kunai_writeback are parsed
 // but not resolved — the loader's pass-2 fills SourceByteOff /
 // ParentByteOff once every spec is in scope.
+// readParserOptionSegment scans the parser block's @-decorators for
+// @kunai_option_segment[name=IDENT]. Returns the declared segment
+// name or the empty string when no override exists; the loader treats
+// empty as "use the default of 'options'".
+func readParserOptionSegment(file *p4lite.File, source string) (string, error) {
+	if file == nil {
+		return "", nil
+	}
+	allowed := map[string]bool{"name": true}
+	for _, par := range file.Parsers {
+		for _, ann := range par.Annotations {
+			if ann.Name != "kunai_option_segment" {
+				continue
+			}
+			if err := requireKnownKeys(ann, allowed, source); err != nil {
+				return "", err
+			}
+			v, ok := ann.KVs["name"]
+			if !ok {
+				return "", fmt.Errorf("%s:%s: @kunai_option_segment is missing required key `name`", source, ann.Pos)
+			}
+			if v.Kind != p4lite.AnnotationIdent {
+				return "", fmt.Errorf("%s:%s: @kunai_option_segment.name must be an identifier", source, ann.Pos)
+			}
+			return v.Ident, nil
+		}
+	}
+	return "", nil
+}
+
 func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*HeaderAnnotations, error) {
 	if file == nil {
 		return nil, nil

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -6,16 +6,6 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab/p4lite"
 )
 
-// readHeaderAnnotations walks every header declaration in file and
-// lowers kunai-recognised @-decorators into HeaderAnnotations entries
-// keyed by header name. Unrecognised annotation names are tolerated so
-// authors can pin future-reserved hints without a parser flag day; the
-// keys of every recognised annotation are checked strictly so a typo
-// fails loudly rather than silently no-op'ing.
-//
-// Cross-protocol field references inside @kunai_writeback are parsed
-// but not resolved — the loader's pass-2 fills SourceByteOff /
-// ParentByteOff once every spec is in scope.
 // readParserOptionSegment scans the parser block's @-decorators for
 // @kunai_option_segment[name=IDENT]. Returns the declared segment
 // name or the empty string when no override exists; the loader treats
@@ -46,6 +36,16 @@ func readParserOptionSegment(file *p4lite.File, source string) (string, error) {
 	return "", nil
 }
 
+// readHeaderAnnotations walks every header declaration in file and
+// lowers kunai-recognised @-decorators into HeaderAnnotations entries
+// keyed by header name. Unrecognised annotation names are tolerated
+// so authors can pin future-reserved hints without a parser flag day;
+// the keys of every recognised annotation are checked strictly so a
+// typo fails loudly rather than silently no-op'ing.
+//
+// Cross-protocol field references inside @kunai_writeback are parsed
+// but not resolved — the loader's pass-2 fills ParentByteOff once
+// every spec is in scope.
 func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*HeaderAnnotations, error) {
 	if file == nil {
 		return nil, nil
@@ -74,8 +74,6 @@ func readHeaderAnnotations(file *p4lite.File, source string) (map[string]*Header
 					return nil, fmt.Errorf("%s:%s: header %q declares @kunai_writeback twice", source, ann.Pos, h.Name)
 				}
 				entry.WriteBack = wb
-			default:
-				continue
 			}
 		}
 	}
@@ -114,7 +112,7 @@ func lowerKunaiVariableTail(ann p4lite.Annotation, h *p4lite.Header, source stri
 	if lenFieldVal.Kind != p4lite.AnnotationIdent {
 		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.len_field must be an identifier (got %v)", source, ann.Pos, lenFieldVal.Kind)
 	}
-	bitOff, fieldBits, ok := findHeaderFieldWindow(h, lenFieldVal.Ident)
+	bitOff, fieldBits, ok := findFieldBitWindow(h, lenFieldVal.Ident)
 	if !ok {
 		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.len_field references unknown field %q in header %q", source, ann.Pos, lenFieldVal.Ident, h.Name)
 	}
@@ -125,11 +123,8 @@ func lowerKunaiVariableTail(ann p4lite.Annotation, h *p4lite.Header, source stri
 	if err != nil {
 		return nil, err
 	}
-	if scale <= 0 {
-		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.scale must be positive (got %d)", source, ann.Pos, scale)
-	}
-	if !isPowerOfTwo(scale) {
-		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.scale must be a power of two (got %d)", source, ann.Pos, scale)
+	if scale <= 0 || scale&(scale-1) != 0 {
+		return nil, fmt.Errorf("%s:%s: @kunai_variable_tail.scale must be a positive power of two (got %d)", source, ann.Pos, scale)
 	}
 	bitInByte := bitOff % 8
 	lsbShift := 8 - bitInByte - fieldBits
@@ -186,7 +181,7 @@ func lowerKunaiWriteback(ann p4lite.Annotation, h *p4lite.Header, source string)
 	if srcVal.Kind != p4lite.AnnotationIdent {
 		return nil, fmt.Errorf("%s:%s: @kunai_writeback.source must be an identifier", source, ann.Pos)
 	}
-	bitOff, fieldBits, ok := findHeaderFieldWindow(h, srcVal.Ident)
+	bitOff, fieldBits, ok := findFieldBitWindow(h, srcVal.Ident)
 	if !ok {
 		return nil, fmt.Errorf("%s:%s: @kunai_writeback.source references unknown field %q in header %q", source, ann.Pos, srcVal.Ident, h.Name)
 	}
@@ -231,24 +226,6 @@ func readIntAnnotation(ann p4lite.Annotation, key string, source string) (int, e
 	return int(v.Int), nil
 }
 
-func findHeaderFieldWindow(h *p4lite.Header, name string) (bitOff, bits int, ok bool) {
-	off := 0
-	for _, f := range h.Fields {
-		if f.Name == name {
-			return off, f.Bits, true
-		}
-		off += f.Bits
-	}
-	return 0, 0, false
-}
-
-func isPowerOfTwo(n int) bool {
-	if n <= 0 {
-		return false
-	}
-	return n&(n-1) == 0
-}
-
 // resolveHeaderWritebackTargets fills ParentByteOff on every
 // WriteBackSpec across the spec set. Run after every protocol's
 // primary header is loaded so cross-protocol field references can be
@@ -266,7 +243,7 @@ func resolveHeaderWritebackTargets(specs map[string]*ProtocolSpec) error {
 			if !ok {
 				return fmt.Errorf("%s: @kunai_writeback on %q references unknown protocol %q", spec.Source, hname, wb.ParentProto)
 			}
-			bitOff, found := bitOffsetInFields(parent.Fields, wb.ParentField)
+			bitOff, _, found := BitOffsetIn(parent.Fields, wb.ParentField)
 			if !found {
 				return fmt.Errorf("%s: @kunai_writeback on %q references unknown field %q in protocol %q", spec.Source, hname, wb.ParentField, wb.ParentProto)
 			}
@@ -279,14 +256,4 @@ func resolveHeaderWritebackTargets(specs map[string]*ProtocolSpec) error {
 	return nil
 }
 
-func bitOffsetInFields(fields []Field, name string) (int, bool) {
-	off := 0
-	for _, f := range fields {
-		if f.Name == name {
-			return off, true
-		}
-		off += f.Bits
-	}
-	return 0, false
-}
 

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -44,6 +44,9 @@ func Load(fsys fs.FS, root string) (map[string]*ProtocolSpec, error) {
 		}
 		out[spec.Name] = spec
 	}
+	if err := resolveHeaderWritebackTargets(out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
@@ -103,6 +106,10 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	headerAnnotations, err := readHeaderAnnotations(file, p)
+	if err != nil {
+		return nil, err
+	}
 	spec := &ProtocolSpec{
 		Name:              protoName,
 		HeaderName:        primary.Name,
@@ -113,6 +120,7 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 		FlagTriggers:      triggers,
 		FlagsByteOffset:   flagsOff,
 		ParseStateMachine: machine,
+		HeaderAnnotations: headerAnnotations,
 		File:              file,
 		Source:            p,
 	}

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -117,6 +117,10 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 	if optionSegment == "" {
 		optionSegment = "options"
 	}
+	stackLayouts, err := readParserParamLayouts(file, p)
+	if err != nil {
+		return nil, err
+	}
 	spec := &ProtocolSpec{
 		Name:              protoName,
 		HeaderName:        primary.Name,
@@ -128,9 +132,16 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 		FlagsByteOffset:   flagsOff,
 		ParseStateMachine: machine,
 		HeaderAnnotations: headerAnnotations,
+		StackLayouts:      stackLayouts,
 		OptionSegment:     optionSegment,
 		File:              file,
 		Source:            p,
+	}
+	if err := resolveStackLayouts(spec); err != nil {
+		return nil, err
+	}
+	if err := validateDeclareOnlyStacks(spec); err != nil {
+		return nil, err
 	}
 	if res.ChainEnd != nil {
 		// Validate the field exists in the primary header now; the

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -110,6 +110,13 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	optionSegment, err := readParserOptionSegment(file, p)
+	if err != nil {
+		return nil, err
+	}
+	if optionSegment == "" {
+		optionSegment = "options"
+	}
 	spec := &ProtocolSpec{
 		Name:              protoName,
 		HeaderName:        primary.Name,
@@ -121,6 +128,7 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 		FlagsByteOffset:   flagsOff,
 		ParseStateMachine: machine,
 		HeaderAnnotations: headerAnnotations,
+		OptionSegment:     optionSegment,
 		File:              file,
 		Source:            p,
 	}

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -121,6 +121,10 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 	if err != nil {
 		return nil, err
 	}
+	stackCounts, err := readParserParamCounts(file, fields, p)
+	if err != nil {
+		return nil, err
+	}
 	spec := &ProtocolSpec{
 		Name:              protoName,
 		HeaderName:        primary.Name,
@@ -133,6 +137,7 @@ func loadFile(fsys fs.FS, p string) (*ProtocolSpec, error) {
 		ParseStateMachine: machine,
 		HeaderAnnotations: headerAnnotations,
 		StackLayouts:      stackLayouts,
+		StackCounts:       stackCounts,
 		OptionSegment:     optionSegment,
 		File:              file,
 		Source:            p,

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -1059,6 +1059,43 @@ func TestParserBlockAdvanceLowersToHeaderLength(t *testing.T) {
 			}`,
 			HeaderLength{LenByteOff: 0, LenMask: 0x0F, LenShift: 0, Scale: 4, Base: 20},
 		},
+		{
+			// SRv6 shape: hdr_ext_len (bit<8>) at byte 1, masked with
+			// 0x0F (= LenMask cap so verifier sees a static upper bound),
+			// scale 8 bytes/unit (= S=6 in bits: << 6 means << 3 in bytes
+			// after the scaleBytes = 1 << (S-3) normalisation), base 0.
+			"srv6_hdr_ext_len_mask",
+			`header foo_h { bit<8> next_header; bit<8> hdr_ext_len; bit<48> tail; }
+			parser P(packet_in pkt, out foo_h hdr) {
+				state start {
+					pkt.extract(hdr);
+					transition skip;
+				}
+				state skip {
+					pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6);
+					transition accept;
+				}
+			}`,
+			HeaderLength{LenByteOff: 1, LenMask: 0x0F, LenShift: 0, Scale: 8, Base: 0},
+		},
+		{
+			// IPv6 ext header shape: hdr_ext_len (bit<8>) at byte 1,
+			// masked with 0x03 (tighter cap than SRv6 — IPv6 ext headers
+			// are typically ≤ 32 bytes in well-formed traffic), scale 8.
+			"ipv6_ext_hdr_ext_len_mask",
+			`header foo_h { bit<8> next_header; bit<8> hdr_ext_len; bit<48> tail; }
+			parser P(packet_in pkt, out foo_h hdr) {
+				state start {
+					pkt.extract(hdr);
+					transition skip;
+				}
+				state skip {
+					pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x03)) << 6);
+					transition accept;
+				}
+			}`,
+			HeaderLength{LenByteOff: 1, LenMask: 0x03, LenShift: 0, Scale: 8, Base: 0},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -771,6 +771,105 @@ func TestParseStateMachineSrv6(t *testing.T) {
 	}
 }
 
+// TestSRv6SegmentsStackCount pins that the SRv6 segments aux stack
+// resolves its runtime iteration count from the @kunai_stack_count
+// annotation on the parser parameter (= byte 4 of srv6_h, the
+// last_entry field, plus 1 per the SRv6 spec).
+func TestSRv6SegmentsStackCount(t *testing.T) {
+	specs := loadBundled(t)
+	srv6 := specs["srv6"]
+	if srv6 == nil {
+		t.Fatal("missing srv6 spec")
+	}
+	cnt, ok := srv6.StackCounts["segments"]
+	if !ok || cnt == nil {
+		t.Fatal("srv6.StackCounts[segments] missing — @kunai_stack_count not consumed")
+	}
+	// srv6_h layout: next_header(8) + hdr_ext_len(8) + routing_type(8)
+	// + segments_left(8) + last_entry(8) ...  → last_entry at byte 4.
+	if cnt.ByteOff != 4 {
+		t.Errorf("ByteOff = %d, want 4 (= byte position of srv6_h.last_entry)", cnt.ByteOff)
+	}
+	if cnt.Offset != 1 {
+		t.Errorf("Offset = %d, want 1 (= last_entry + 1 SRv6 spec formula)", cnt.Offset)
+	}
+}
+
+// TestStackCountUnknownField pins that @kunai_stack_count[field=X]
+// errors at load time when X is not a primary-header field name.
+func TestStackCountUnknownField(t *testing.T) {
+	src := `header foo_h { bit<8> a; bit<8> b; }
+header seg_h { bit<128> addr; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=primary]
+         @kunai_stack_count[field=does_not_exist, offset=0]
+         out seg_h[8] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected unknown-field error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown field") {
+		t.Errorf("error %q should mention unknown field", err.Error())
+	}
+}
+
+// TestStackCountNonByteAlignedField pins that @kunai_stack_count rejects
+// a field that isn't a byte-aligned 8-bit slot, since the codegen
+// emits a single-byte LDX for the count load.
+func TestStackCountNonByteAlignedField(t *testing.T) {
+	src := `header foo_h { bit<4> high; bit<4> low; }
+header seg_h { bit<128> addr; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=primary]
+         @kunai_stack_count[field=high]
+         out seg_h[8] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected byte-alignment error, got nil")
+	}
+	if !strings.Contains(err.Error(), "byte-aligned") {
+		t.Errorf("error %q should mention byte-aligned", err.Error())
+	}
+}
+
+// TestStackCountOnNonArrayParam pins that @kunai_stack_count rejects
+// non-array parameters — the count semantic only makes sense for
+// `out X[N] name`, not for a single header `out X name`.
+func TestStackCountOnNonArrayParam(t *testing.T) {
+	src := `header foo_h { bit<8> a; bit<8> b; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_stack_count[field=b]
+         out foo_h other) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected non-array-param error, got nil")
+	}
+	if !strings.Contains(err.Error(), "out X[N] name") {
+		t.Errorf("error %q should mention `out X[N] name`", err.Error())
+	}
+}
+
 // TestSRv6SegmentsLayoutAnnotation pins that the SRv6 segments aux
 // stack (= the bundled Mode B / declare-only example) resolves its
 // base byte offset from the parser-parameter @kunai_layout decorator

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -1029,6 +1029,7 @@ func TestIPv6ExtHeaderAnnotations(t *testing.T) {
 		ParentField:   "next_header",
 		SourceByteOff: 0, // first field of ipv6_ext_h
 		ParentByteOff: 6, // ipv6_h: version(4) + traffic_class(8) + flow_label(20) + payload_length(16) = 48 bits, then next_header
+		Resolved:      true,
 	}
 	if ann.WriteBack == nil || *ann.WriteBack != *wantWB {
 		t.Errorf("WriteBack = %+v, want %+v", ann.WriteBack, wantWB)

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -802,6 +802,42 @@ func TestIPv6ExtHeaderAnnotations(t *testing.T) {
 	}
 }
 
+// TestOptionSegmentDefault pins the default routing name for 4-/5-part
+// field paths. Every bundled protocol must yield OptionSegment="options"
+// when no @kunai_option_segment overrides it so the legacy
+// `<proto>.options.<NAME>.<field>` shape keeps resolving.
+func TestOptionSegmentDefault(t *testing.T) {
+	specs := loadBundled(t)
+	for name, spec := range specs {
+		if spec.OptionSegment != "options" {
+			t.Errorf("protocol %q: OptionSegment=%q, want %q", name, spec.OptionSegment, "options")
+		}
+	}
+}
+
+// TestOptionSegmentOverride pins @kunai_option_segment[name=IDENT] as
+// the channel a protocol uses to expose its option walk under a name
+// other than "options" — e.g. a TLV-style protocol that reads as
+// "<proto>.tlvs.<NAME>.<field>".
+func TestOptionSegmentOverride(t *testing.T) {
+	src := `header foo_h { bit<8> a; }
+@kunai_option_segment[name=tlvs]
+parser P(packet_in pkt, out foo_h hdr) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	specs, err := Load(fsys, "vocab")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if specs["foo"].OptionSegment != "tlvs" {
+		t.Errorf("OptionSegment=%q, want %q", specs["foo"].OptionSegment, "tlvs")
+	}
+}
+
 func TestParseStateMachineRejectsMultiStateCycle(t *testing.T) {
 	fsys := fstest.MapFS{
 		"vocab/foo.p4": &fstest.MapFile{Data: []byte(`

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -734,18 +734,42 @@ func auxLayoutNames(m map[string]*AuxLayout) []string {
 }
 
 func TestParseStateMachineSrv6(t *testing.T) {
+	// srv6.p4 now has 2 states: `start` extracts the SRH primary and
+	// transitions to `skip_segments` on routing_type==4 (reject
+	// otherwise); `skip_segments` runs the variable trail via
+	// pkt.advance and accepts. This replaced the legacy single-state
+	// shape where the variable trail came from a Go-side
+	// knownVariableTails entry keyed on srv6_h.
 	specs := loadBundled(t)
 	srv6 := specs["srv6"]
 	if srv6 == nil || srv6.ParseStateMachine == nil {
-		t.Fatal("expected srv6 to have a non-trivial ParseStateMachine (single state with a routing_type select)")
+		t.Fatal("expected srv6 to have a non-trivial ParseStateMachine")
 	}
 	machine := srv6.ParseStateMachine
-	if len(machine.States) != 1 {
-		t.Fatalf("srv6 state count = %d, want 1", len(machine.States))
+	if len(machine.States) != 2 {
+		t.Fatalf("srv6 state count = %d, want 2 (start + skip_segments)", len(machine.States))
 	}
-	state := machine.States[0]
-	if state.Trans.Kind != TransSelect {
-		t.Errorf("srv6 transition kind = %v, want TransSelect (routing_type guard)", state.Trans.Kind)
+	start := machine.States[0]
+	if start.Name != "start" {
+		t.Errorf("states[0].Name = %q, want %q", start.Name, "start")
+	}
+	if start.Trans.Kind != TransSelect {
+		t.Errorf("start transition kind = %v, want TransSelect (routing_type guard)", start.Trans.Kind)
+	}
+	skip := machine.States[1]
+	if skip.Name != "skip_segments" {
+		t.Errorf("states[1].Name = %q, want %q", skip.Name, "skip_segments")
+	}
+	if len(skip.Advances) != 1 {
+		t.Fatalf("skip_segments advance count = %d, want 1", len(skip.Advances))
+	}
+	adv := skip.Advances[0]
+	if adv.Kind != AdvanceOpField {
+		t.Errorf("advance kind = %v, want AdvanceOpField", adv.Kind)
+	}
+	want := HeaderLength{LenByteOff: 1, LenMask: 0x0F, LenShift: 0, Scale: 8, Base: 0}
+	if adv.Skip == nil || *adv.Skip != want {
+		t.Errorf("skip = %+v, want %+v", adv.Skip, want)
 	}
 }
 
@@ -891,10 +915,12 @@ func specNames(s map[string]*ProtocolSpec) []string {
 // (`pkt.advance(((bit<32>)(hdr.ihl - 5)) << 5)`) but moved to
 // Mechanism 8 (ParserCounter byte-bounded walk) when option-aware
 // extraction landed. TCP is the lone remaining Mechanism-1 user
-// for its data_offset-driven trailer skip.
+// for its data_offset-driven trailer skip. SRv6 now declares its
+// variable trail through pkt.advance in srv6.p4's skip_segments
+// state, so it's omitted here too.
 func TestVariableTrailAbsentForFixedProtocols(t *testing.T) {
 	specs := loadBundled(t)
-	for _, name := range []string{"eth", "ipv4", "ipv6", "udp", "gtp", "srv6", "vlan", "qinq", "mpls", "gre", "vxlan", "geneve", "icmp", "icmp6", "cw"} {
+	for _, name := range []string{"eth", "ipv4", "ipv6", "udp", "gtp", "vlan", "qinq", "mpls", "gre", "vxlan", "geneve", "icmp", "icmp6", "cw"} {
 		if vs := specs[name].PrimaryAdvanceSkip(); vs != nil {
 			t.Errorf("%s should not declare a variable trailer (got %+v)", name, *vs)
 		}

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -772,10 +772,9 @@ func TestParseStateMachineSrv6(t *testing.T) {
 }
 
 // TestIPv6ExtHeaderAnnotations pins the kunai-specific annotations
-// on ipv6_ext_h: the variable-trail params replace the legacy
-// codegen/parser_trail.go::knownVariableTails entry, and the writeback
-// resolves ipv6.next_header to the correct byte offset (6) so the
-// chain tail's next_header propagates to the parent layer.
+// on ipv6_ext_h: the variable-trail params and the writeback resolve
+// ipv6.next_header to byte offset 6 so the chain tail's next_header
+// propagates to the parent layer.
 func TestIPv6ExtHeaderAnnotations(t *testing.T) {
 	specs := loadBundled(t)
 	ipv6 := specs["ipv6"]

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -818,6 +818,94 @@ parser P(packet_in pkt,
 	}
 }
 
+// TestStackLayoutChainResolves pins that chained @kunai_layout
+// (`after=<other_stack>`) resolves each stack's base offset against
+// the upstream stack's end, walking the dependency chain iteratively
+// regardless of declaration order in the .p4 file.
+func TestStackLayoutChainResolves(t *testing.T) {
+	src := `header foo_h { bit<8> a; bit<8> b; }
+header seg_h { bit<128> addr; }
+header tlv_h { bit<32> value; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=segments]
+         out tlv_h[2] tlvs,
+         @kunai_layout[after=primary]
+         out seg_h[4] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	specs, err := Load(fsys, "vocab")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	layouts := specs["foo"].StackLayouts
+	// primary = (8+8)/8 = 2 bytes
+	// segments base = 2; span = 4 * (128/8) = 64
+	// tlvs base = segments base + segments span = 2 + 64 = 66
+	if got := layouts["segments"].BaseByteOff; got != 2 {
+		t.Errorf("segments base = %d, want 2", got)
+	}
+	if got := layouts["tlvs"].BaseByteOff; got != 66 {
+		t.Errorf("tlvs base = %d, want 66 (= 2 + 4*16)", got)
+	}
+}
+
+// TestStackLayoutChainCycle pins that a cyclic @kunai_layout chain
+// (foo→bar→foo) errors at load time rather than spinning the
+// fixed-point resolver indefinitely.
+func TestStackLayoutChainCycle(t *testing.T) {
+	src := `header foo_h { bit<8> a; }
+header seg_h { bit<128> addr; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=bar]
+         out seg_h[4] foo,
+         @kunai_layout[after=foo]
+         out seg_h[4] bar) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle or forward reference") {
+		t.Errorf("error %q should mention cycle", err.Error())
+	}
+}
+
+// TestStackLayoutChainUnknown pins that @kunai_layout[after=X] where
+// X is neither "primary" nor a declared parameter stack errors with a
+// clear "unknown anchor" diagnostic.
+func TestStackLayoutChainUnknown(t *testing.T) {
+	src := `header foo_h { bit<8> a; }
+header seg_h { bit<128> addr; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=does_not_exist]
+         out seg_h[4] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected unknown-anchor error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown anchor") {
+		t.Errorf("error %q should mention unknown anchor", err.Error())
+	}
+}
+
 // TestIPv6ExtHeaderAnnotations pins the kunai-specific annotations
 // on ipv6_ext_h: the variable-trail params and the writeback resolve
 // ipv6.next_header to byte offset 6 so the chain tail's next_header

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -771,6 +771,37 @@ func TestParseStateMachineSrv6(t *testing.T) {
 	}
 }
 
+// TestIPv6ExtHeaderAnnotations pins the kunai-specific annotations
+// on ipv6_ext_h: the variable-trail params replace the legacy
+// codegen/parser_trail.go::knownVariableTails entry, and the writeback
+// resolves ipv6.next_header to the correct byte offset (6) so the
+// chain tail's next_header propagates to the parent layer.
+func TestIPv6ExtHeaderAnnotations(t *testing.T) {
+	specs := loadBundled(t)
+	ipv6 := specs["ipv6"]
+	if ipv6 == nil {
+		t.Fatal("missing ipv6 spec")
+	}
+	ann, ok := ipv6.HeaderAnnotations["ipv6_ext_h"]
+	if !ok || ann == nil {
+		t.Fatal("ipv6_ext_h has no HeaderAnnotations")
+	}
+	wantVT := &VariableTailSpec{LenFieldByteOff: 1, LenMask: 0x03, LenShift: 0, Scale: 8, Base: 0}
+	if ann.VariableTail == nil || *ann.VariableTail != *wantVT {
+		t.Errorf("VariableTail = %+v, want %+v", ann.VariableTail, wantVT)
+	}
+	wantWB := &WriteBackSpec{
+		SourceField:   "next_header",
+		ParentProto:   "ipv6",
+		ParentField:   "next_header",
+		SourceByteOff: 0, // first field of ipv6_ext_h
+		ParentByteOff: 6, // ipv6_h: version(4) + traffic_class(8) + flow_label(20) + payload_length(16) = 48 bits, then next_header
+	}
+	if ann.WriteBack == nil || *ann.WriteBack != *wantWB {
+		t.Errorf("WriteBack = %+v, want %+v", ann.WriteBack, wantWB)
+	}
+}
+
 func TestParseStateMachineRejectsMultiStateCycle(t *testing.T) {
 	fsys := fstest.MapFS{
 		"vocab/foo.p4": &fstest.MapFile{Data: []byte(`

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -771,6 +771,53 @@ func TestParseStateMachineSrv6(t *testing.T) {
 	}
 }
 
+// TestSRv6SegmentsLayoutAnnotation pins that the SRv6 segments aux
+// stack (= the bundled Mode B / declare-only example) resolves its
+// base byte offset from the parser-parameter @kunai_layout decorator
+// rather than the legacy implicit "primary directly after" fallback.
+func TestSRv6SegmentsLayoutAnnotation(t *testing.T) {
+	specs := loadBundled(t)
+	srv6 := specs["srv6"]
+	if srv6 == nil {
+		t.Fatal("missing srv6 spec")
+	}
+	layout, ok := srv6.StackLayouts["segments"]
+	if !ok || layout == nil {
+		t.Fatal("srv6.StackLayouts[segments] missing — @kunai_layout not consumed")
+	}
+	if layout.After != "primary" {
+		t.Errorf("layout.After = %q, want primary", layout.After)
+	}
+	if layout.BaseByteOff != 8 {
+		t.Errorf("layout.BaseByteOff = %d, want 8 (= sizeof(srv6_h) primary)", layout.BaseByteOff)
+	}
+}
+
+// TestDeclareOnlyStackRequiresLayoutAnnotation pins that a top-level
+// declare-only aux stack without @kunai_layout fails at load time,
+// preventing the historical alias bug where multiple un-annotated
+// stacks would collapse onto the same byte offset.
+func TestDeclareOnlyStackRequiresLayoutAnnotation(t *testing.T) {
+	src := `header foo_h { bit<8> a; bit<8> b; }
+header seg_h { bit<128> addr; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         out seg_h[8] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	if err == nil {
+		t.Fatal("expected error for un-annotated declare-only stack, got nil")
+	}
+	if !strings.Contains(err.Error(), "@kunai_layout") {
+		t.Errorf("error %q should mention @kunai_layout", err.Error())
+	}
+}
+
 // TestIPv6ExtHeaderAnnotations pins the kunai-specific annotations
 // on ipv6_ext_h: the variable-trail params and the writeback resolve
 // ipv6.next_header to byte offset 6 so the chain tail's next_header
@@ -1379,7 +1426,10 @@ header seg_h { bit<128> addr; }
 
 const bit<8> FOO_IPV6_NEXT_HEADER = 43;
 
-parser P(packet_in pkt, out foo_h hdr, out seg_h[8] segments) {
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=primary]
+         out seg_h[8] segments) {
 	state start {
 		pkt.extract(hdr);
 		transition select(hdr.rt_type) {

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -734,12 +734,10 @@ func auxLayoutNames(m map[string]*AuxLayout) []string {
 }
 
 func TestParseStateMachineSrv6(t *testing.T) {
-	// srv6.p4 now has 2 states: `start` extracts the SRH primary and
-	// transitions to `skip_segments` on routing_type==4 (reject
-	// otherwise); `skip_segments` runs the variable trail via
-	// pkt.advance and accepts. This replaced the legacy single-state
-	// shape where the variable trail came from a Go-side
-	// knownVariableTails entry keyed on srv6_h.
+	// 2 states: `start` extracts the SRH primary and transitions to
+	// `skip_segments` on routing_type==4 (reject otherwise);
+	// `skip_segments` runs the variable trail via pkt.advance and
+	// accepts.
 	specs := loadBundled(t)
 	srv6 := specs["srv6"]
 	if srv6 == nil || srv6.ParseStateMachine == nil {

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -56,6 +56,15 @@ type ProtocolSpec struct {
 	// here when it carries cross-cutting kunai metadata that the
 	// dispatch-const / parser-block channels can't express.
 	HeaderAnnotations map[string]*HeaderAnnotations
+	// StackLayouts captures the @kunai_layout annotation on each
+	// declare-only `out X[N] stack` parser parameter. The resolver
+	// uses these to compute aux-stack base offsets when the parser
+	// block doesn't push entries explicitly — without an explicit
+	// layout declaration, multiple declare-only stacks would alias
+	// onto the same byte offset. Keyed by stack (parameter) name.
+	// Empty when every aux stack in the protocol is pushed by some
+	// parser-block state (= the standard P4 idiom).
+	StackLayouts map[string]*StackLayoutSpec
 	// OptionSegment names the reserved second path segment for 4-/5-part
 	// field references like `<proto>.<seg>.<NAME>.<field>` that route to
 	// the protocol's parser-declared option walk. Defaults to "options"
@@ -72,6 +81,19 @@ type ProtocolSpec struct {
 	selfValidating bool
 	File           *p4lite.File // full AST (for resolver/codegen later)
 	Source         string       // original file path, for diagnostics
+}
+
+// StackLayoutSpec captures the @kunai_layout[after=...] decorator on
+// a parser parameter declaring an aux stack that the parser block
+// does not extract into. The byte offset is computed by resolving the
+// chain: `after=primary` anchors at the primary header end;
+// `after=<other_stack>` walks back to a previously-resolved layout
+// (cycle-free by construction since the loader processes parameters
+// in declaration order and rejects forward references). The resolved
+// BaseByteOff is what the field-path resolver consumes.
+type StackLayoutSpec struct {
+	After       string // "primary" or another stack's parameter name
+	BaseByteOff int    // resolved at load-time
 }
 
 // HeaderAnnotations bundles kunai-specific decorators carried on a

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -161,6 +161,13 @@ type WriteBackSpec struct {
 	ParentField   string
 	SourceByteOff int // resolved during loadFile against the chained header
 	ParentByteOff int // resolved during Load's pass 2 against the parent spec
+	// Resolved distinguishes a real ParentByteOff=0 (= writeback target is the
+	// first byte of the parent's primary header) from "pass-2 hasn't run yet".
+	// Set to true by resolveHeaderWritebackTargets; consumers in codegen panic
+	// loudly when WriteBack is non-nil but Resolved is false, surfacing
+	// loader-bypassing callers immediately rather than silently writing into
+	// byte 0 of a parent that may not be the intended target.
+	Resolved bool
 }
 
 // HeaderLength is the lowered shape of a primary-header variable

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -56,6 +56,14 @@ type ProtocolSpec struct {
 	// here when it carries cross-cutting kunai metadata that the
 	// dispatch-const / parser-block channels can't express.
 	HeaderAnnotations map[string]*HeaderAnnotations
+	// OptionSegment names the reserved second path segment for 4-/5-part
+	// field references like `<proto>.<seg>.<NAME>.<field>` that route to
+	// the protocol's parser-declared option walk. Defaults to "options"
+	// when no @kunai_option_segment[name=...] decorates the parser
+	// block. The non-default value lets a protocol expose its
+	// option-walk under a domain-appropriate name (e.g. "tlvs") without
+	// a resolver-side code change.
+	OptionSegment string
 	// selfValidating caches whether the parser block proves the
 	// protocol's identity itself (start-state `transition select(...)
 	// { ...; default: reject; }` keyed on a primary-header field).

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -65,6 +65,13 @@ type ProtocolSpec struct {
 	// Empty when every aux stack in the protocol is pushed by some
 	// parser-block state (= the standard P4 idiom).
 	StackLayouts map[string]*StackLayoutSpec
+	// StackCounts captures the @kunai_stack_count annotation on a
+	// declare-only aux stack parameter, naming a primary-header byte
+	// whose value (plus an optional offset) gives the stack's runtime
+	// element count for `any/all` quantifiers. Empty when no parameter
+	// carries the annotation; the codegen then falls back to the
+	// static Capacity bound.
+	StackCounts map[string]*StackCountSpec
 	// OptionSegment names the reserved second path segment for 4-/5-part
 	// field references like `<proto>.<seg>.<NAME>.<field>` that route to
 	// the protocol's parser-declared option walk. Defaults to "options"
@@ -94,6 +101,19 @@ type ProtocolSpec struct {
 type StackLayoutSpec struct {
 	After       string // "primary" or another stack's parameter name
 	BaseByteOff int    // resolved at load-time
+}
+
+// StackCountSpec is the .p4-declared form the codegen's quantifier
+// count source consumes for top-level declare-only aux stacks. The
+// loader resolves the @kunai_stack_count[field=NAME, offset=N]
+// annotation against the primary header's bit layout into the byte
+// offset of the named field; the codegen emits a single-byte LDX
+// from `layer_entry + CountByteOff`, adds Offset, and uses the
+// result as the iteration cap. The field must be byte-aligned and
+// exactly 8 bits wide so the LDX hits the whole value in one load.
+type StackCountSpec struct {
+	ByteOff int
+	Offset  int
 }
 
 // HeaderAnnotations bundles kunai-specific decorators carried on a

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -50,6 +50,12 @@ type ProtocolSpec struct {
 	// state extract+accept shape; codegen routes those through the
 	// existing fixed-size path with no behaviour change.
 	ParseStateMachine *ParseStateMachine
+	// HeaderAnnotations records per-header @kunai_* decorators read
+	// from the .p4 source. Nil-or-missing entries mean "no kunai
+	// annotations on that header"; the primary header may also appear
+	// here when it carries cross-cutting kunai metadata that the
+	// dispatch-const / parser-block channels can't express.
+	HeaderAnnotations map[string]*HeaderAnnotations
 	// selfValidating caches whether the parser block proves the
 	// protocol's identity itself (start-state `transition select(...)
 	// { ...; default: reject; }` keyed on a primary-header field).
@@ -58,6 +64,53 @@ type ProtocolSpec struct {
 	selfValidating bool
 	File           *p4lite.File // full AST (for resolver/codegen later)
 	Source         string       // original file path, for diagnostics
+}
+
+// HeaderAnnotations bundles kunai-specific decorators carried on a
+// non-primary header within a protocol's vocab. Today these describe
+// extension-header chain elements (ipv6_ext_h) whose variable-trailer
+// and parent-field write-back behaviour has no native P4 expression.
+// Keyed by header name in ProtocolSpec.HeaderAnnotations.
+type HeaderAnnotations struct {
+	// VariableTail mirrors codegen/parser_trail.go::variableTailSkip
+	// for the in-protocol header; nil when the header declares no
+	// @kunai_variable_tail.
+	VariableTail *VariableTailSpec
+	// WriteBack captures the @kunai_writeback decorator: after the
+	// extension header is consumed inside a self-loop, copy one byte
+	// of its primary back into the parent protocol's named field so
+	// the next dispatch sees the inner protocol identifier.
+	WriteBack *WriteBackSpec
+}
+
+// VariableTailSpec is the .p4-declared form of the same five-tuple
+// codegen/parser_trail.go::variableTailSkip carries: a runtime length
+// computed as `((<byte at LenFieldByteOff> & LenMask) >> LenShift) *
+// Scale + Base`. The kunai-specific @kunai_variable_tail annotation
+// names the field; the loader resolves it against the header's bit
+// layout the same way pkt.advance's lowerCastShiftSkip does.
+type VariableTailSpec struct {
+	LenFieldByteOff int
+	LenMask         int
+	LenShift        int
+	Scale           int
+	Base            int
+}
+
+// WriteBackSpec captures the cross-protocol byte copy a chained
+// extension header's parser-loop emits per iteration. Source names
+// a field on the chained header (resolved against the header's
+// declared layout). Parent identifies the destination via a
+// proto.field path the loader resolves to a concrete byte offset
+// (ParentByteOff) once every spec is loaded — the resolved offset
+// matches the layout codegen already uses, so the write-back stays
+// verifier-safe against PTR_TO_MAP_VALUE.
+type WriteBackSpec struct {
+	SourceField   string
+	ParentProto   string
+	ParentField   string
+	SourceByteOff int // resolved during loadFile against the chained header
+	ParentByteOff int // resolved during Load's pass 2 against the parent spec
 }
 
 // HeaderLength is the lowered shape of a primary-header variable

--- a/pkg/kunai/vocab/p4lite/lexer.go
+++ b/pkg/kunai/vocab/p4lite/lexer.go
@@ -63,6 +63,7 @@ const (
 	TokDot
 	TokMinus
 	TokLShift
+	TokAmp
 )
 
 func (k TokenKind) String() string {
@@ -143,6 +144,8 @@ func (k TokenKind) String() string {
 		return "'-'"
 	case TokLShift:
 		return "'<<'"
+	case TokAmp:
+		return "'&'"
 	}
 	return fmt.Sprintf("TokenKind(%d)", int(k))
 }
@@ -328,6 +331,8 @@ func (l *Lexer) Next() (Token, error) {
 		return Token{Kind: TokDot, Value: ".", Pos: pos}, nil
 	case '-':
 		return Token{Kind: TokMinus, Value: "-", Pos: pos}, nil
+	case '&':
+		return Token{Kind: TokAmp, Value: "&", Pos: pos}, nil
 	}
 	return Token{}, l.syntaxErr(pos, "unexpected character %q", b)
 }

--- a/pkg/kunai/vocab/p4lite/lexer.go
+++ b/pkg/kunai/vocab/p4lite/lexer.go
@@ -64,6 +64,7 @@ const (
 	TokMinus
 	TokLShift
 	TokAmp
+	TokAt
 )
 
 func (k TokenKind) String() string {
@@ -146,6 +147,8 @@ func (k TokenKind) String() string {
 		return "'<<'"
 	case TokAmp:
 		return "'&'"
+	case TokAt:
+		return "'@'"
 	}
 	return fmt.Sprintf("TokenKind(%d)", int(k))
 }
@@ -333,6 +336,8 @@ func (l *Lexer) Next() (Token, error) {
 		return Token{Kind: TokMinus, Value: "-", Pos: pos}, nil
 	case '&':
 		return Token{Kind: TokAmp, Value: "&", Pos: pos}, nil
+	case '@':
+		return Token{Kind: TokAt, Value: "@", Pos: pos}, nil
 	}
 	return Token{}, l.syntaxErr(pos, "unexpected character %q", b)
 }

--- a/pkg/kunai/vocab/p4lite/lexer_test.go
+++ b/pkg/kunai/vocab/p4lite/lexer_test.go
@@ -135,9 +135,23 @@ func TestLexerKeywordsVsIdents(t *testing.T) {
 }
 
 func TestLexerUnexpectedCharacter(t *testing.T) {
-	_, err := NewLexer([]byte("@"), "t.p4").Next()
+	// Pick a character outside the lexer's recognised token set. `@`
+	// became a valid token in the structured-annotation work, so use
+	// `$` here — it's part of P4-16's reserved set but p4lite has no
+	// model for it.
+	_, err := NewLexer([]byte("$"), "t.p4").Next()
 	if err == nil {
-		t.Fatal("expected error for '@'")
+		t.Fatal("expected error for '$'")
+	}
+}
+
+func TestLexerAtToken(t *testing.T) {
+	tok, err := NewLexer([]byte("@"), "t.p4").Next()
+	if err != nil {
+		t.Fatalf("lex '@': %v", err)
+	}
+	if tok.Kind != TokAt {
+		t.Errorf("Kind=%v, want TokAt", tok.Kind)
 	}
 }
 

--- a/pkg/kunai/vocab/p4lite/parser.go
+++ b/pkg/kunai/vocab/p4lite/parser.go
@@ -404,10 +404,19 @@ func (p *parser) parseParser() (*Parser, error) {
 	}
 	par := &Parser{Name: name.Value, Pos: startPos}
 	for p.cur.Kind != TokRParen && p.cur.Kind != TokEOF {
+		var paramAnnotations []Annotation
+		for p.cur.Kind == TokAt {
+			ann, err := p.parseAnnotation()
+			if err != nil {
+				return nil, err
+			}
+			paramAnnotations = append(paramAnnotations, *ann)
+		}
 		param, err := p.parseParam()
 		if err != nil {
 			return nil, err
 		}
+		param.Annotations = paramAnnotations
 		par.Params = append(par.Params, param)
 		if _, ok, err := p.accept(TokComma); err != nil {
 			return nil, err

--- a/pkg/kunai/vocab/p4lite/parser.go
+++ b/pkg/kunai/vocab/p4lite/parser.go
@@ -544,6 +544,9 @@ func (p *parser) parseCounterSetCall(counter string, startPos Position) (Stmt, e
 	if adv.Kind != AdvanceField {
 		return nil, p.errorf(startPos, "%s.set requires the `((bit<N>)(hdr.<F> - K)) << S` template (lookahead form not supported here)", counter)
 	}
+	if adv.Mask != 0 {
+		return nil, p.errorf(startPos, "%s.set requires the subtract form `(hdr.<F> - K)`; mask form `(hdr.<F> & MASK)` is not supported here (CounterCallStmt has no Mask slot, the mask would be silently dropped)", counter)
+	}
 	return &CounterCallStmt{
 		Counter:   counter,
 		Op:        CounterSet,
@@ -838,8 +841,11 @@ func (p *parser) parseAdvanceCastedShift(obj string, startPos Position) (*Advanc
 	return adv, nil
 }
 
-// parseAdvanceFieldOperand parses `(hdr.<F> - K)` after the
-// `((bit<N>)` prefix. Cursor sits on the opening `(`.
+// parseAdvanceFieldOperand parses `(hdr.<F> - K)` (subtract form) or
+// `(hdr.<F> & MASK)` (mask form) after the `((bit<N>)` prefix. Cursor
+// sits on the opening `(`. Subtract form is used by primary-header
+// variable trailers (IPv4 IHL, TCP data_offset); mask form is used by
+// extension-header variable trailers (IPv6 hdr_ext_len, SRH hdr_ext_len).
 func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok Token, expectShape func(TokenKind) (Token, error)) (*AdvanceStmt, error) {
 	if _, err := expectShape(TokLParen); err != nil {
 		return nil, err
@@ -855,18 +861,44 @@ func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok To
 	if err != nil {
 		return nil, err
 	}
-	if _, err := expectShape(TokMinus); err != nil {
-		return nil, err
-	}
-	kTok, err := expectShape(TokInt)
-	if err != nil {
-		return nil, err
+	// Branch on `-` (subtract form) vs `&` (mask form). Any other
+	// token here is a parse error pointing at this position so the
+	// diagnostic names exactly which operator was expected.
+	opTok := p.cur
+	var baseWords, mask int
+	switch opTok.Kind {
+	case TokMinus:
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		kTok, err := expectShape(TokInt)
+		if err != nil {
+			return nil, err
+		}
+		if kTok.Int > uint64(maxInt32) {
+			return nil, p.errorf(kTok.Pos, "K=%d exceeds the supported range for the BaseWords slot", kTok.Int)
+		}
+		baseWords = int(kTok.Int)
+	case TokAmp:
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		mTok, err := expectShape(TokInt)
+		if err != nil {
+			return nil, err
+		}
+		if mTok.Int == 0 {
+			return nil, p.errorf(mTok.Pos, "mask MASK=0 makes the advance always zero — unintended")
+		}
+		if mTok.Int > uint64(maxInt32) {
+			return nil, p.errorf(mTok.Pos, "MASK=0x%x exceeds the supported range for the Mask slot", mTok.Int)
+		}
+		mask = int(mTok.Int)
+	default:
+		return nil, p.errorf(opTok.Pos, "expected `-` (subtract form) or `&` (mask form) after `hdr.<field>` inside pkt.advance, got %s", opTok.Kind)
 	}
 	if _, err := expectShape(TokRParen); err != nil {
 		return nil, err
-	}
-	if kTok.Int > uint64(maxInt32) {
-		return nil, p.errorf(kTok.Pos, "K=%d exceeds the supported range for the BaseWords slot", kTok.Int)
 	}
 	return &AdvanceStmt{
 		Object:    obj,
@@ -874,7 +906,8 @@ func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok To
 		BitWidth:  int(nTok.Int),
 		Target:    hdrTok.Value,
 		FieldName: fldTok.Value,
-		BaseWords: int(kTok.Int),
+		BaseWords: baseWords,
+		Mask:      mask,
 		Pos:       startPos,
 	}, nil
 }

--- a/pkg/kunai/vocab/p4lite/parser.go
+++ b/pkg/kunai/vocab/p4lite/parser.go
@@ -74,10 +74,8 @@ func (p *parser) accept(k TokenKind) (Token, bool, error) {
 func (p *parser) parseFile() (*File, error) {
 	f := &File{}
 	// pending accumulates @-prefixed annotations encountered before the
-	// next declaration. The trailing-annotation guard (`len > 0` at EOF
-	// and before extern, which p4lite treats as opaque) prevents
-	// annotations from silently being dropped when the user mis-orders
-	// them.
+	// next declaration so a dangling @anno (EOF or before an extern
+	// p4lite can't decorate) errors instead of silently dropping.
 	var pending []Annotation
 	for p.cur.Kind != TokEOF {
 		switch p.cur.Kind {
@@ -153,10 +151,10 @@ func (p *parser) parseAnnotation() (*Annotation, error) {
 	default:
 		return nil, p.errorf(p.cur.Pos, "expected '[' to start structured annotation arg list for @%s, got %s", nameTok.Value, p.cur.Kind)
 	}
-	if err := p.advance(); err != nil {
+	if _, err := p.expect(TokLBracket); err != nil {
 		return nil, err
 	}
-	kvs := map[string]AnnotationValue{}
+	var kvs map[string]AnnotationValue
 	for p.cur.Kind != TokRBracket {
 		keyTok, err := p.expect(TokIdent)
 		if err != nil {
@@ -172,16 +170,14 @@ func (p *parser) parseAnnotation() (*Annotation, error) {
 		if _, exists := kvs[keyTok.Value]; exists {
 			return nil, p.errorf(keyTok.Pos, "duplicate annotation key %q in @%s", keyTok.Value, nameTok.Value)
 		}
+		if kvs == nil {
+			kvs = make(map[string]AnnotationValue)
+		}
 		kvs[keyTok.Value] = val
-		switch p.cur.Kind {
-		case TokComma:
-			if err := p.advance(); err != nil {
-				return nil, err
-			}
-		case TokRBracket:
-			// loop will exit
-		default:
-			return nil, p.errorf(p.cur.Pos, "expected ',' or ']' after annotation key=value in @%s, got %s", nameTok.Value, p.cur.Kind)
+		if _, ok, err := p.accept(TokComma); err != nil {
+			return nil, err
+		} else if !ok {
+			break
 		}
 	}
 	if _, err := p.expect(TokRBracket); err != nil {
@@ -986,7 +982,7 @@ func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok To
 	var baseWords, mask int
 	switch opTok.Kind {
 	case TokMinus:
-		if err := p.advance(); err != nil {
+		if _, err := expectShape(TokMinus); err != nil {
 			return nil, err
 		}
 		kTok, err := expectShape(TokInt)
@@ -994,11 +990,11 @@ func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok To
 			return nil, err
 		}
 		if kTok.Int > uint64(maxInt32) {
-			return nil, p.errorf(kTok.Pos, "K=%d exceeds the supported range for the BaseWords slot", kTok.Int)
+			return nil, p.errorf(kTok.Pos, "K=%d exceeds the int32 range", kTok.Int)
 		}
 		baseWords = int(kTok.Int)
 	case TokAmp:
-		if err := p.advance(); err != nil {
+		if _, err := expectShape(TokAmp); err != nil {
 			return nil, err
 		}
 		mTok, err := expectShape(TokInt)
@@ -1009,7 +1005,7 @@ func (p *parser) parseAdvanceFieldOperand(obj string, startPos Position, nTok To
 			return nil, p.errorf(mTok.Pos, "mask MASK=0 makes the advance always zero — unintended")
 		}
 		if mTok.Int > uint64(maxInt32) {
-			return nil, p.errorf(mTok.Pos, "MASK=0x%x exceeds the supported range for the Mask slot", mTok.Int)
+			return nil, p.errorf(mTok.Pos, "MASK=0x%x exceeds the int32 range", mTok.Int)
 		}
 		mask = int(mTok.Int)
 	default:

--- a/pkg/kunai/vocab/p4lite/parser.go
+++ b/pkg/kunai/vocab/p4lite/parser.go
@@ -73,21 +73,40 @@ func (p *parser) accept(k TokenKind) (Token, bool, error) {
 
 func (p *parser) parseFile() (*File, error) {
 	f := &File{}
+	// pending accumulates @-prefixed annotations encountered before the
+	// next declaration. The trailing-annotation guard (`len > 0` at EOF
+	// and before extern, which p4lite treats as opaque) prevents
+	// annotations from silently being dropped when the user mis-orders
+	// them.
+	var pending []Annotation
 	for p.cur.Kind != TokEOF {
 		switch p.cur.Kind {
+		case TokAt:
+			ann, err := p.parseAnnotation()
+			if err != nil {
+				return nil, err
+			}
+			pending = append(pending, *ann)
 		case TokHeader:
 			h, err := p.parseHeader()
 			if err != nil {
 				return nil, err
 			}
+			h.Annotations = pending
+			pending = nil
 			f.Headers = append(f.Headers, h)
 		case TokConst:
 			c, err := p.parseConst()
 			if err != nil {
 				return nil, err
 			}
+			c.Annotations = pending
+			pending = nil
 			f.Consts = append(f.Consts, c)
 		case TokExtern:
+			if len(pending) > 0 {
+				return nil, p.errorf(pending[0].Pos, "annotations are not supported on extern declarations (p4lite treats extern bodies as opaque)")
+			}
 			ex, err := p.parseExtern()
 			if err != nil {
 				return nil, err
@@ -98,12 +117,111 @@ func (p *parser) parseFile() (*File, error) {
 			if err != nil {
 				return nil, err
 			}
+			par.Annotations = pending
+			pending = nil
 			f.Parsers = append(f.Parsers, par)
 		default:
-			return nil, p.errorf(p.cur.Pos, "expected 'header', 'const', 'extern', or 'parser' at top level, got %s (%q)", p.cur.Kind, p.cur.Value)
+			return nil, p.errorf(p.cur.Pos, "expected 'header', 'const', 'extern', 'parser', or '@annotation' at top level, got %s (%q)", p.cur.Kind, p.cur.Value)
 		}
 	}
+	if len(pending) > 0 {
+		return nil, p.errorf(pending[0].Pos, "annotation @%s has no following declaration to attach to", pending[0].Name)
+	}
 	return f, nil
+}
+
+// parseAnnotation parses one structured `@name[k=v, ...]` decorator.
+// Cursor sits on the `@` token on entry. Only the structured form is
+// accepted; positional `@name(...)` is rejected so heterogeneous
+// parameter sets can't be silently reordered. Empty `@name[]` is
+// accepted (lets callers omit args while still declaring the
+// annotation name for future extension).
+func (p *parser) parseAnnotation() (*Annotation, error) {
+	startPos := p.cur.Pos
+	if _, err := p.expect(TokAt); err != nil {
+		return nil, err
+	}
+	nameTok, err := p.expect(TokIdent)
+	if err != nil {
+		return nil, err
+	}
+	switch p.cur.Kind {
+	case TokLBracket:
+		// structured form, fall through
+	case TokLParen:
+		return nil, p.errorf(p.cur.Pos, "positional annotation form @%s(...) is not supported in p4lite; use the structured form @%s[k=v, ...]", nameTok.Value, nameTok.Value)
+	default:
+		return nil, p.errorf(p.cur.Pos, "expected '[' to start structured annotation arg list for @%s, got %s", nameTok.Value, p.cur.Kind)
+	}
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+	kvs := map[string]AnnotationValue{}
+	for p.cur.Kind != TokRBracket {
+		keyTok, err := p.expect(TokIdent)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(TokEquals); err != nil {
+			return nil, err
+		}
+		val, err := p.parseAnnotationValue()
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := kvs[keyTok.Value]; exists {
+			return nil, p.errorf(keyTok.Pos, "duplicate annotation key %q in @%s", keyTok.Value, nameTok.Value)
+		}
+		kvs[keyTok.Value] = val
+		switch p.cur.Kind {
+		case TokComma:
+			if err := p.advance(); err != nil {
+				return nil, err
+			}
+		case TokRBracket:
+			// loop will exit
+		default:
+			return nil, p.errorf(p.cur.Pos, "expected ',' or ']' after annotation key=value in @%s, got %s", nameTok.Value, p.cur.Kind)
+		}
+	}
+	if _, err := p.expect(TokRBracket); err != nil {
+		return nil, err
+	}
+	return &Annotation{Name: nameTok.Value, KVs: kvs, Pos: startPos}, nil
+}
+
+// parseAnnotationValue parses one RHS of a `k=v` pair: an integer
+// literal, a bare identifier, or a dotted `proto.field` reference.
+// P4-16 §7.4 also permits string literals and expression forms;
+// p4lite defers those until a kunai annotation needs them.
+func (p *parser) parseAnnotationValue() (AnnotationValue, error) {
+	pos := p.cur.Pos
+	switch p.cur.Kind {
+	case TokInt:
+		tok := p.cur
+		if err := p.advance(); err != nil {
+			return AnnotationValue{}, err
+		}
+		return AnnotationValue{Kind: AnnotationInt, Int: tok.Int, Pos: pos}, nil
+	case TokIdent:
+		name := p.cur.Value
+		if err := p.advance(); err != nil {
+			return AnnotationValue{}, err
+		}
+		if p.cur.Kind == TokDot {
+			if err := p.advance(); err != nil {
+				return AnnotationValue{}, err
+			}
+			fldTok, err := p.expect(TokIdent)
+			if err != nil {
+				return AnnotationValue{}, err
+			}
+			return AnnotationValue{Kind: AnnotationFieldRef, Proto: name, Field: fldTok.Value, Pos: pos}, nil
+		}
+		return AnnotationValue{Kind: AnnotationIdent, Ident: name, Pos: pos}, nil
+	default:
+		return AnnotationValue{}, p.errorf(pos, "expected int literal, identifier, or 'proto.field' as annotation value, got %s", p.cur.Kind)
+	}
 }
 
 // parseExtern records `extern <Name> { ... }` and skips the body

--- a/pkg/kunai/vocab/p4lite/parser_test.go
+++ b/pkg/kunai/vocab/p4lite/parser_test.go
@@ -477,6 +477,78 @@ func TestParseAdvanceTemplateRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAdvanceMaskFormRoundTrip(t *testing.T) {
+	// Mask form `(hdr.<F> & MASK) << S` — extension-header variable
+	// trailer template used by IPv6 / SRv6 hdr_ext_len.
+	src := `parser P(packet_in pkt, out srv6_h hdr) {
+	state start {
+		pkt.extract(hdr);
+		pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 3);
+		transition accept;
+	}
+}`
+	f, err := Parse([]byte(src), "t.p4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	stmts := f.Parsers[0].States[0].Stmts
+	if len(stmts) != 2 {
+		t.Fatalf("stmts=%d, want 2", len(stmts))
+	}
+	adv, ok := stmts[1].(*AdvanceStmt)
+	if !ok {
+		t.Fatalf("stmt[1] is %T, want *AdvanceStmt", stmts[1])
+	}
+	want := AdvanceStmt{
+		Object:    "pkt",
+		Kind:      AdvanceField,
+		BitWidth:  32,
+		Target:    "hdr",
+		FieldName: "hdr_ext_len",
+		BaseWords: 0,
+		Mask:      0x0F,
+		ScaleLog2: 3,
+	}
+	if adv.Object != want.Object || adv.Kind != want.Kind || adv.BitWidth != want.BitWidth ||
+		adv.Target != want.Target || adv.FieldName != want.FieldName ||
+		adv.BaseWords != want.BaseWords || adv.Mask != want.Mask || adv.ScaleLog2 != want.ScaleLog2 {
+		t.Errorf("AdvanceStmt = %+v, want %+v", *adv, want)
+	}
+}
+
+func TestParseAdvanceMaskRejectsBadOperands(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"mask_zero", `pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0)) << 3);`, "mask MASK=0"},
+		// 0x100 > 0xFF for an 8-bit field — caught at parse time by the
+		// uint64 → int32 range guard if it overflows, otherwise by the
+		// lowering's "exceeds the N-bit field" check (loader_test).
+		// Here we just test the parse-time MASK=0 rejection lives in the
+		// parser.
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := `parser P(packet_in pkt, out srv6_h hdr) {
+	state start {
+		pkt.extract(hdr);
+		` + tc.body + `
+		transition accept;
+	}
+}`
+			_, err := Parse([]byte(src), "t.p4")
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.body)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
 func TestParseAdvanceLiteralRoundTrip(t *testing.T) {
 	src := `parser P(packet_in pkt, out tcp_h hdr) {
 	state s {

--- a/pkg/kunai/vocab/p4lite/parser_test.go
+++ b/pkg/kunai/vocab/p4lite/parser_test.go
@@ -1026,6 +1026,48 @@ header ipv6_ext_h { bit<8> next_header; bit<8> hdr_ext_len; }`
 	}
 }
 
+func TestParseAnnotationOnParserParam(t *testing.T) {
+	src := `header foo_h { bit<8> a; }
+header bar_h { bit<128> b; }
+parser P(packet_in pkt,
+         out foo_h hdr,
+         @kunai_layout[after=primary]
+         out bar_h[8] segments) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}`
+	f, err := Parse([]byte(src), "t.p4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(f.Parsers) != 1 || len(f.Parsers[0].Params) != 3 {
+		t.Fatalf("params=%d, want 3", len(f.Parsers[0].Params))
+	}
+	segParam := f.Parsers[0].Params[2]
+	if segParam.VarName != "segments" {
+		t.Fatalf("params[2].VarName=%q, want segments", segParam.VarName)
+	}
+	if len(segParam.Annotations) != 1 {
+		t.Fatalf("segments annotations=%d, want 1", len(segParam.Annotations))
+	}
+	ann := segParam.Annotations[0]
+	if ann.Name != "kunai_layout" {
+		t.Errorf("annotation name=%q, want kunai_layout", ann.Name)
+	}
+	after, ok := ann.KVs["after"]
+	if !ok {
+		t.Fatal("kunai_layout missing `after` key")
+	}
+	if after.Kind != AnnotationIdent || after.Ident != "primary" {
+		t.Errorf("after = %+v, want ident primary", after)
+	}
+	if len(f.Parsers[0].Params[0].Annotations) != 0 || len(f.Parsers[0].Params[1].Annotations) != 0 {
+		t.Errorf("non-annotated params carry stray annotations: %+v", f.Parsers[0].Params)
+	}
+}
+
 func TestParseAnnotationOnConstAndParser(t *testing.T) {
 	src := `@kunai_dispatch[order=1]
 const bit<8> FOO_TCP = 6;

--- a/pkg/kunai/vocab/p4lite/parser_test.go
+++ b/pkg/kunai/vocab/p4lite/parser_test.go
@@ -963,3 +963,120 @@ func TestParseCounterIsZeroFallthroughOnPlainPath(t *testing.T) {
 		t.Errorf("keys = %+v, want one SelectKeyField(hdr.foo)", keys)
 	}
 }
+
+func TestParseAnnotationOnHeaderEmpty(t *testing.T) {
+	src := `@kunai_marker[]
+header foo_h { bit<8> a; }`
+	f, err := Parse([]byte(src), "t.p4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(f.Headers) != 1 {
+		t.Fatalf("headers=%d, want 1", len(f.Headers))
+	}
+	anns := f.Headers[0].Annotations
+	if len(anns) != 1 {
+		t.Fatalf("annotations=%d, want 1", len(anns))
+	}
+	if anns[0].Name != "kunai_marker" {
+		t.Errorf("Name=%q, want kunai_marker", anns[0].Name)
+	}
+	if len(anns[0].KVs) != 0 {
+		t.Errorf("KVs=%v, want empty", anns[0].KVs)
+	}
+}
+
+func TestParseAnnotationValueShapes(t *testing.T) {
+	// Pins each AnnotationValueKind round-trip end-to-end:
+	// int / ident / proto.field. Together they cover every kv-pair
+	// shape kunai annotations actually use today.
+	src := `@kunai_variable_tail[len_field=hdr_ext_len, scale=8, mask=15]
+@kunai_writeback[source=next_header, parent=ipv6.next_header]
+header ipv6_ext_h { bit<8> next_header; bit<8> hdr_ext_len; }`
+	f, err := Parse([]byte(src), "t.p4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(f.Headers) != 1 || len(f.Headers[0].Annotations) != 2 {
+		t.Fatalf("annotations=%d, want 2 on one header", len(f.Headers[0].Annotations))
+	}
+	vt := f.Headers[0].Annotations[0]
+	if vt.Name != "kunai_variable_tail" {
+		t.Errorf("vt.Name=%q", vt.Name)
+	}
+	if vt.KVs["len_field"].Kind != AnnotationIdent || vt.KVs["len_field"].Ident != "hdr_ext_len" {
+		t.Errorf("len_field = %+v, want ident 'hdr_ext_len'", vt.KVs["len_field"])
+	}
+	if vt.KVs["scale"].Kind != AnnotationInt || vt.KVs["scale"].Int != 8 {
+		t.Errorf("scale = %+v, want int 8", vt.KVs["scale"])
+	}
+	if vt.KVs["mask"].Kind != AnnotationInt || vt.KVs["mask"].Int != 15 {
+		t.Errorf("mask = %+v, want int 15", vt.KVs["mask"])
+	}
+	wb := f.Headers[0].Annotations[1]
+	if wb.Name != "kunai_writeback" {
+		t.Errorf("wb.Name=%q", wb.Name)
+	}
+	if wb.KVs["source"].Kind != AnnotationIdent || wb.KVs["source"].Ident != "next_header" {
+		t.Errorf("source = %+v, want ident 'next_header'", wb.KVs["source"])
+	}
+	parent := wb.KVs["parent"]
+	if parent.Kind != AnnotationFieldRef || parent.Proto != "ipv6" || parent.Field != "next_header" {
+		t.Errorf("parent = %+v, want fieldref 'ipv6.next_header'", parent)
+	}
+}
+
+func TestParseAnnotationOnConstAndParser(t *testing.T) {
+	src := `@kunai_dispatch[order=1]
+const bit<8> FOO_TCP = 6;
+@kunai_loop_cap[iters=8]
+parser P(packet_in pkt, out foo_h hdr) {
+	state start {
+		pkt.extract(hdr);
+		transition accept;
+	}
+}
+header foo_h { bit<8> a; }`
+	f, err := Parse([]byte(src), "t.p4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(f.Consts) != 1 || len(f.Consts[0].Annotations) != 1 {
+		t.Fatalf("const annotations=%d, want 1", len(f.Consts[0].Annotations))
+	}
+	if f.Consts[0].Annotations[0].Name != "kunai_dispatch" {
+		t.Errorf("const annotation name=%q", f.Consts[0].Annotations[0].Name)
+	}
+	if len(f.Parsers) != 1 || len(f.Parsers[0].Annotations) != 1 {
+		t.Fatalf("parser annotations=%d, want 1", len(f.Parsers[0].Annotations))
+	}
+	if f.Parsers[0].Annotations[0].Name != "kunai_loop_cap" {
+		t.Errorf("parser annotation name=%q", f.Parsers[0].Annotations[0].Name)
+	}
+}
+
+func TestParseAnnotationRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"positional_form", `@foo(1, 2) header h { bit<8> a; }`, "positional annotation form"},
+		{"bare_no_args", `@foo header h { bit<8> a; }`, "expected '[' to start structured annotation"},
+		{"duplicate_key", `@foo[a=1, a=2] header h { bit<8> a; }`, "duplicate annotation key"},
+		{"missing_value", `@foo[a=] header h { bit<8> a; }`, "expected int literal, identifier"},
+		{"dangling_eof", `@foo[a=1]`, "has no following declaration"},
+		{"before_extern", `@foo[a=1] extern ParserCounter { }`, "annotations are not supported on extern"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.src), "t.p4")
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/pkg/kunai/vocab/p4lite/types.go
+++ b/pkg/kunai/vocab/p4lite/types.go
@@ -174,17 +174,20 @@ type CounterInst struct {
 }
 
 // Param is one entry in a parser's parameter list, e.g. `packet_in
-// pkt`, `out H hdr`, or `out H[8] stack`.
+// pkt`, `out H hdr`, or `out H[8] stack`. Annotations decorate the
+// parameter itself; today the only consumer is the @kunai_layout
+// loader pass on declare-only aux stacks.
 //
 // BNF: parameter (P4-16 Section 6.8 "Calling convention: call by copy in/out")
 type Param struct {
-	IsPacketIn bool
-	IsOut      bool
-	TypeName   string
-	IsArray    bool
-	ArraySize  int
-	VarName    string
-	Pos        Position
+	IsPacketIn  bool
+	IsOut       bool
+	TypeName    string
+	IsArray     bool
+	ArraySize   int
+	VarName     string
+	Annotations []Annotation
+	Pos         Position
 }
 
 // State is one `state name { stmts; transition ...; }` block.

--- a/pkg/kunai/vocab/p4lite/types.go
+++ b/pkg/kunai/vocab/p4lite/types.go
@@ -62,6 +62,50 @@ type File struct {
 	Parsers []*Parser
 }
 
+// AnnotationValueKind tags the syntactic shape of one annotation
+// argument. P4-16 §7.4 allows expression-form values; p4lite accepts
+// the three shapes kunai-specific annotations need today.
+type AnnotationValueKind int
+
+const (
+	// AnnotationInt is a plain integer literal (decimal or 0x hex).
+	AnnotationInt AnnotationValueKind = iota
+	// AnnotationIdent is a bare identifier — used for field names
+	// (`source=next_header`) and other symbolic values.
+	AnnotationIdent
+	// AnnotationFieldRef is a dotted `proto.field` reference — used
+	// for cross-protocol references (`parent=ipv6.next_header`). The
+	// loader resolves Proto against the loaded ProtocolSpec set.
+	AnnotationFieldRef
+)
+
+// AnnotationValue is one argument to a structured P4 annotation. Each
+// kind activates a distinct subset of fields; unused fields are zero-
+// valued. P4-16 §7.4 also allows string literals; p4lite defers that
+// until a use case arises.
+type AnnotationValue struct {
+	Kind  AnnotationValueKind
+	Int   uint64 // valid when Kind == AnnotationInt
+	Ident string // valid when Kind == AnnotationIdent
+	Proto string // the LHS of "proto.field" when Kind == AnnotationFieldRef
+	Field string // the RHS of "proto.field" when Kind == AnnotationFieldRef
+	Pos   Position
+}
+
+// Annotation is one structured `@name[k=v, k=v, ...]` decorator on a
+// header / const / parser declaration. p4lite accepts only the
+// key-value (structured) form; the positional form `@name(arg, arg)`
+// is rejected at parse time because heterogeneous parameter sets
+// (e.g. variable-trail's mask + scale + shift + base) are
+// silent-break vectors when reordered.
+//
+// BNF: structuredAnnotation (P4-16 §7.4, 1.2.0+)
+type Annotation struct {
+	Name string
+	KVs  map[string]AnnotationValue
+	Pos  Position
+}
+
 // Extern is an architectural extern declaration — kept as an opaque
 // token so vocab files can declare types the host architecture
 // supplies (currently only `extern ParserCounter`). p4lite only
@@ -78,9 +122,10 @@ type Extern struct {
 //
 // BNF: headerTypeDeclaration (P4-16 Section 7.2.2 "Header types")
 type Header struct {
-	Name   string
-	Fields []Field
-	Pos    Position
+	Name        string
+	Fields      []Field
+	Annotations []Annotation
+	Pos         Position
 }
 
 // Field is a single member of a Header (`bit<N> name;`).
@@ -96,23 +141,25 @@ type Field struct {
 //
 // BNF: constantDeclaration (P4-16 Section 11.1 "Constants")
 type Const struct {
-	Name   string
-	IsBool bool
-	Bits   int    // zero when IsBool
-	Bool   bool   // valid when IsBool
-	Int    uint64 // valid when !IsBool
-	Pos    Position
+	Name        string
+	IsBool      bool
+	Bits        int    // zero when IsBool
+	Bool        bool   // valid when IsBool
+	Int         uint64 // valid when !IsBool
+	Annotations []Annotation
+	Pos         Position
 }
 
 // Parser is `parser P(packet_in pkt, out H hdr) { state ... }`.
 //
 // BNF: parserDeclaration (P4-16 Section 13.2 "Parser declarations")
 type Parser struct {
-	Name     string
-	Params   []Param
-	Counters []CounterInst
-	States   []*State
-	Pos      Position
+	Name        string
+	Params      []Param
+	Counters    []CounterInst
+	States      []*State
+	Annotations []Annotation
+	Pos         Position
 }
 
 // CounterInst is a `ParserCounter() <name>;` instance declaration

--- a/pkg/kunai/vocab/p4lite/types.go
+++ b/pkg/kunai/vocab/p4lite/types.go
@@ -177,10 +177,14 @@ func (*ExtractStmt) stmtNode() {}
 type AdvanceKind int
 
 const (
-	// AdvanceField is the `pkt.advance(((bit<N>)(hdr.<F> - K)) << S)`
+	// AdvanceField is the
+	// `pkt.advance(((bit<N>)(hdr.<F> - K)) << S)` (subtract form) or
+	// `pkt.advance(((bit<N>)(hdr.<F> & MASK)) << S)` (mask form)
 	// template — primary-header variable trailer (IPv4 IHL, TCP
-	// data_offset). Active fields: BitWidth, Target, FieldName,
-	// BaseWords, ScaleLog2.
+	// data_offset) and extension-header variable trailer (IPv6
+	// hdr_ext_len, SRH hdr_ext_len). Active fields: BitWidth, Target,
+	// FieldName, ScaleLog2, plus exactly one of BaseWords / Mask
+	// (parser sets BaseWords for `-`, Mask for `&`).
 	AdvanceField AdvanceKind = iota
 	// AdvanceLookahead is the
 	// `pkt.advance(((bit<N>)pkt.lookahead<bit<M>>()[lo:hi]) << S)`
@@ -209,7 +213,8 @@ type AdvanceStmt struct {
 	// AdvanceField only.
 	Target    string // the `hdr` in `hdr.<F>` — the parser's `out` parameter holding the field
 	FieldName string // the `<F>` in `hdr.<F>`
-	BaseWords int    // the K subtracted from the field value
+	BaseWords int    // the K subtracted from the field value (subtract form: (hdr.F - K))
+	Mask      int    // the MASK bitwise-AND'd with the field value (mask form: (hdr.F & MASK)). Zero = "no mask, subtract form active". Mask and BaseWords are mutually exclusive: parseAdvanceFieldOperand branches on `-` vs `&` and only sets one.
 
 	// AdvanceLookahead only.
 	LookaheadBits int // the M in `pkt.lookahead<bit<M>>()`

--- a/pkg/kunai/vocab/parser_machine.go
+++ b/pkg/kunai/vocab/parser_machine.go
@@ -735,7 +735,7 @@ func buildCounter(cs *p4lite.CounterCallStmt, ctx *buildCtx) (CounterOp, error) 
 	}
 	switch cs.Op {
 	case p4lite.CounterSet:
-		skip, h, err := lowerCastShiftSkip(cs.Target, cs.FieldName, cs.BaseWords, cs.ScaleLog2, cs.Counter+".set", ctx, cs.Pos)
+		skip, h, err := lowerCastShiftSkip(cs.Target, cs.FieldName, cs.BaseWords, 0, cs.ScaleLog2, cs.Counter+".set", ctx, cs.Pos)
 		if err != nil {
 			return CounterOp{}, err
 		}
@@ -912,6 +912,8 @@ func lookupAuxFieldByteOffset(target, fieldName string, ctx *buildCtx, pos p4lit
 }
 
 // lowerCastShiftSkip lowers the `((bit<N>)(hdr.<F> - K)) << S`
+// (subtract form, userMask=0) or `((bit<N>)(hdr.<F> & MASK)) << S`
+// (mask form, baseWords=0, userMask=MASK) AdvanceField
 // template — shared by `pkt.advance` (AdvanceField) and
 // `<counter>.set` — into a HeaderLength five-tuple plus the resolved
 // header pointer. variableTailSkip consumes the tuple to drive a
@@ -922,7 +924,7 @@ func lookupAuxFieldByteOffset(target, fieldName string, ctx *buildCtx, pos p4lit
 // always wants primary (the layer-entry slot anchors the load),
 // pkt.advance permits aux for the SACK-style option-with-trailing-
 // array shape.
-func lowerCastShiftSkip(target, fieldName string, baseWords, scaleLog2 int, opName string, ctx *buildCtx, pos p4lite.Position) (*HeaderLength, *p4lite.Header, error) {
+func lowerCastShiftSkip(target, fieldName string, baseWords, userMask, scaleLog2 int, opName string, ctx *buildCtx, pos p4lite.Position) (*HeaderLength, *p4lite.Header, error) {
 	h, ok := ctx.headerRefs[target]
 	if !ok {
 		return nil, nil, fmt.Errorf("%s:%s: %s target %q is not an `out` header parameter", ctx.source, pos, opName, target)
@@ -938,9 +940,26 @@ func lowerCastShiftSkip(target, fieldName string, baseWords, scaleLog2 int, opNa
 	if scaleLog2 < 3 {
 		return nil, nil, fmt.Errorf("%s:%s: %s shift S=%d is sub-byte (codegen advances in whole bytes; require S ≥ 3)", ctx.source, pos, opName, scaleLog2)
 	}
+	if baseWords != 0 && userMask != 0 {
+		return nil, nil, fmt.Errorf("%s:%s: %s combines subtract (-K) and mask (& MASK) forms; only one is supported per advance", ctx.source, pos, opName)
+	}
 	scaleBytes := 1 << (scaleLog2 - 3)
 	lsbShift := 8 - bitInByte - fieldBits
-	mask := ((1 << fieldBits) - 1) << lsbShift
+	fieldExtractionMask := ((1 << fieldBits) - 1) << lsbShift
+	mask := fieldExtractionMask
+	if userMask != 0 {
+		// userMask is expressed against the field value; shift into the
+		// containing byte's coordinate then intersect with the field's
+		// own bit window so out-of-field bits in userMask are silently
+		// dropped after a clear validation below.
+		if userMask >= (1 << fieldBits) {
+			return nil, nil, fmt.Errorf("%s:%s: %s mask MASK=0x%x exceeds the %d-bit field %q (max 0x%x)", ctx.source, pos, opName, userMask, fieldBits, fieldName, (1<<fieldBits)-1)
+		}
+		mask = fieldExtractionMask & (userMask << lsbShift)
+		if mask == 0 {
+			return nil, nil, fmt.Errorf("%s:%s: %s mask combined with field %q yields zero — unintended", ctx.source, pos, opName, fieldName)
+		}
+	}
 	return &HeaderLength{
 		LenByteOff: bitOff / 8,
 		LenMask:    mask,
@@ -951,7 +970,7 @@ func lowerCastShiftSkip(target, fieldName string, baseWords, scaleLog2 int, opNa
 }
 
 func buildAdvanceField(as *p4lite.AdvanceStmt, ctx *buildCtx) (AdvanceOp, error) {
-	skip, _, err := lowerCastShiftSkip(as.Target, as.FieldName, as.BaseWords, as.ScaleLog2, "pkt.advance", ctx, as.Pos)
+	skip, _, err := lowerCastShiftSkip(as.Target, as.FieldName, as.BaseWords, as.Mask, as.ScaleLog2, "pkt.advance", ctx, as.Pos)
 	if err != nil {
 		return AdvanceOp{}, err
 	}

--- a/pkg/kunai/vocab/parser_machine.go
+++ b/pkg/kunai/vocab/parser_machine.go
@@ -945,20 +945,15 @@ func lowerCastShiftSkip(target, fieldName string, baseWords, userMask, scaleLog2
 	}
 	scaleBytes := 1 << (scaleLog2 - 3)
 	lsbShift := 8 - bitInByte - fieldBits
-	fieldExtractionMask := ((1 << fieldBits) - 1) << lsbShift
-	mask := fieldExtractionMask
+	mask := ((1 << fieldBits) - 1) << lsbShift
 	if userMask != 0 {
-		// userMask is expressed against the field value; shift into the
-		// containing byte's coordinate then intersect with the field's
-		// own bit window so out-of-field bits in userMask are silently
-		// dropped after a clear validation below.
+		// userMask is expressed against the field value; reject anything
+		// that doesn't fit so the byte-shifted mask stays inside the
+		// field's own bit window. Parser already rejects userMask=0.
 		if userMask >= (1 << fieldBits) {
 			return nil, nil, fmt.Errorf("%s:%s: %s mask MASK=0x%x exceeds the %d-bit field %q (max 0x%x)", ctx.source, pos, opName, userMask, fieldBits, fieldName, (1<<fieldBits)-1)
 		}
-		mask = fieldExtractionMask & (userMask << lsbShift)
-		if mask == 0 {
-			return nil, nil, fmt.Errorf("%s:%s: %s mask combined with field %q yields zero — unintended", ctx.source, pos, opName, fieldName)
-		}
+		mask = userMask << lsbShift
 	}
 	return &HeaderLength{
 		LenByteOff: bitOff / 8,


### PR DESCRIPTION
## Summary

Migrates kunai's protocol-specific hardcodes from Go (`codegen/parser_trail.go::knownVariableTails`, `resolve/where.go::optionsSegment`) into the `.p4` vocab files themselves, so new protocols can be added by dropping a `.p4` without touching Go code.

- **SRv6**: variable trail now expressed natively as `pkt.advance(((bit<32>)(hdr.hdr_ext_len & 0x0F)) << 6)` in `srv6.p4`'s new `skip_segments` state. The Go-side map entry is gone.
- **IPv6 ext header**: carries `@kunai_variable_tail` + `@kunai_writeback[parent=ipv6.next_header]` annotations. The hardcoded `ParentByteOff: 6` is gone — the loader resolves it from `ipv6.p4`'s field layout.
- **Option-walk routing**: the literal `"options"` reserved name becomes `ProtocolSpec.OptionSegment` with default `"options"` and an `@kunai_option_segment[name=...]` override.
- **Mode B aux stacks**: declare-only `out X[N]` parameters require `@kunai_layout[after=primary|<other_stack>]` so multiple un-pushed stacks can't silently alias. Chain resolution + cycle detection in the loader.

## Why

The hardcoded `knownVariableTails` map keyed on string header names violated kunai's "drop a .p4, no Go edits" design. SRv6's `segments` aux stack was declared in the parser block but never extracted, with no explicit signal to the resolver where the stack bytes lived — a real alias-bug waiting for a second un-extracted aux stack to land.

## Approach

12 commits, each with clean `make test` and `make p4c-check`:

1. p4lite accepts mask form `(hdr.F & MASK) << S` in `pkt.advance`
2. p4lite accepts P4-16 structured annotations `@name[k=v]`
3. SRv6 migrates to native `pkt.advance`
4. `@kunai_variable_tail` / `@kunai_writeback` / `@kunai_option_segment` annotation readers + cross-protocol resolver pass
5. `@kunai_layout[after=primary]` required on top-level declare-only stacks
6. `@kunai_layout[after=<other_stack>]` chain support with fixed-point resolver + cycle detection

Two `/simplify` passes between phases dedup the helpers and drop migration-narrative comments.

## Verification

- `make test` — full Go test sweep, green
- `make p4c-check` — official `p4c --parse-only` against every vocab file, green (chain syntax verified out-of-tree)
- `filterset_test.TestFilterSetCounts` — 30 sub-test raw BPF asm insn counts hold byte-for-byte before/after migration (F1=197, F2=207, F3=338, F4=213, F5=215, F6=83, F7=391, F8=425, F9=281, F10=227)
- `lefthook` pre-commit + commit-msg, golangci-lint 0 issues

## Doc updates

- `docs/ja/dsl-followups.md` — adds V4 entry to the 完了履歴 backlog log
- `docs/ja/dsl-internals.md` — refreshes Mechanism 4 (SRv6 aux header stack) to the current `skip_segments` + `@kunai_layout` shape

## Test plan

- [x] `make test`
- [x] `make p4c-check`
- [x] filterset_test insn count pins hold
- [x] `make lint` (lefthook)
- [ ] `make test-bpf` (BPF verifier load, requires sudo — run before merge)
- [ ] CI 4-kernel matrix (6.1 / 6.6 / 6.12 / 6.18)
