### PR TITLE
post-review fixes: host tests, layering, deduplication, fuzz CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,16 @@ jobs:
       - name: Unit Tests
         run: go test ./...
 
+      # Short fuzz gate (30s × 2 targets) to extend the seed corpus
+      # past `go test`'s seed-only run. Caches a fail to ./fuzz/ —
+      # any reproducer surfaces in the next pre-merge cycle. The
+      # cap is per-target so the total CI minute cost stays bounded.
+      - name: Fuzz (compile)
+        run: go test -run=^$ -fuzz=^FuzzCompile$ -fuzztime=30s ./pkg/kunai/
+
+      - name: Fuzz (lexer)
+        run: go test -run=^$ -fuzz=^FuzzLexNext$ -fuzztime=30s ./pkg/kunai/lexer/
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-24.04

--- a/pkg/kunai/codegen/callback_lint_test.go
+++ b/pkg/kunai/codegen/callback_lint_test.go
@@ -8,29 +8,54 @@ import (
 	"github.com/cilium/ebpf/asm"
 )
 
-// TestAssertCallbackComplexityUnderThreshold pins that a callback
-// with branch count just below the cap passes.
-func TestAssertCallbackComplexityUnderThreshold(t *testing.T) {
-	insns := makeCallbackWithBranches(callbackBranchThreshold)
-	if err := assertCallbackComplexity(insns, "test_under"); err != nil {
-		t.Errorf("threshold case rejected: %v", err)
+// TestCallbackBranchThresholdValue pins the threshold constant itself
+// to 64. A silent change to this number (= raising or lowering it)
+// would shift the verifier-blowup risk envelope without surfacing in
+// the parametric tests below, since those reference the const rather
+// than a literal. The 64 number is rationalized in callback_lint.go's
+// docblock (worst-case TCP options walk ≈ 44 branches + 50% headroom);
+// a drift here MUST be accompanied by an update to that doc and to
+// the matching paper §6 limitations sentence.
+func TestCallbackBranchThresholdValue(t *testing.T) {
+	if callbackBranchThreshold != 64 {
+		t.Errorf("callbackBranchThreshold = %d, want 64 — see callback_lint.go docblock + dsl-followups.md B-2a class for rationale; if this is an intentional change, update both doc sources before bumping the literal here", callbackBranchThreshold)
 	}
 }
 
-// TestAssertCallbackComplexityOverThreshold pins that one extra
-// branch trips the assertion with ErrNotImplemented and a message
-// that names the callback symbol + branch count.
-func TestAssertCallbackComplexityOverThreshold(t *testing.T) {
-	insns := makeCallbackWithBranches(callbackBranchThreshold + 1)
-	err := assertCallbackComplexity(insns, "test_over")
-	if err == nil {
-		t.Fatal("expected ErrNotImplemented, got nil")
+// TestAssertCallbackComplexityBoundary table-pins the threshold's
+// pass/fail behaviour at the boundary. Three rows cover the standard
+// "off-by-one" failure modes: just-below (passes), exactly-at
+// (passes), and just-above (fails).
+func TestAssertCallbackComplexityBoundary(t *testing.T) {
+	cases := []struct {
+		name     string
+		branches int
+		wantErr  bool
+	}{
+		{"just_below_threshold", callbackBranchThreshold - 1, false},
+		{"at_threshold", callbackBranchThreshold, false},
+		{"just_above_threshold", callbackBranchThreshold + 1, true},
 	}
-	if !errors.Is(err, ErrNotImplemented) {
-		t.Errorf("err does not wrap ErrNotImplemented: %v", err)
-	}
-	if !strings.Contains(err.Error(), "test_over") {
-		t.Errorf("err missing callback symbol: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			insns := makeCallbackWithBranches(tc.branches)
+			err := assertCallbackComplexity(insns, "test_"+tc.name)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error at %d branches, got nil", tc.branches)
+				}
+				if !errors.Is(err, ErrNotImplemented) {
+					t.Errorf("err does not wrap ErrNotImplemented: %v", err)
+				}
+				if !strings.Contains(err.Error(), "test_"+tc.name) {
+					t.Errorf("err missing callback symbol: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected pass at %d branches, got %v", tc.branches, err)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -47,14 +47,6 @@ type Capabilities struct {
 	// shadow the action symbol). nil means no reservations — useful
 	// for hosts that disable action atoms entirely.
 	ReservedLabels map[string]bool
-
-	// StrictArithLint promotes the F1 overflow-suspect lint
-	// (resolve.Options.StrictArithLint) from silent-wrap to a
-	// resolver-level error. Off by default so existing hosts keep
-	// the typed-OK / silent-wrap contract; opt-in for hosts that
-	// prefer to surface arithmetic foot-guns at compile time.
-	// dsl-types.md §9.4 row F1.
-	StrictArithLint bool
 }
 
 // HasActionAtoms reports whether the caps configure an action map +

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -449,7 +449,7 @@ func stackCountSource(w *ir.Condition) (*quantCountSource, error) {
 		return &quantCountSource{
 			Layer:   iterRef.Layer,
 			ByteOff: cnt.ByteOff,
-			Offset:  cnt.Offset,
+			Offset:  cnt.Addend,
 		}, nil
 	}
 	// No @kunai_stack_count → caller unrolls over the static Capacity.

--- a/pkg/kunai/compile.go
+++ b/pkg/kunai/compile.go
@@ -57,9 +57,7 @@ func CompileWithVocab(expr string, v map[string]*vocab.ProtocolSpec, caps codege
 	if err != nil {
 		return codegen.Output{}, err
 	}
-	prog, err := resolve.ResolveWithOptions(f, v, caps.Action, resolve.Options{
-		StrictArithLint: caps.StrictArithLint,
-	})
+	prog, err := resolve.Resolve(f, v, caps.Action)
 	if err != nil {
 		return codegen.Output{}, err
 	}

--- a/pkg/kunai/host/tc/tc_test.go
+++ b/pkg/kunai/host/tc/tc_test.go
@@ -1,0 +1,90 @@
+package tc
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+)
+
+// TestActionsMapMatchesUAPI pins the Actions map to the verdicts
+// declared in uapi/linux/pkt_cls.h. A drift would silently
+// mis-resolve `where action == TC_ACT_*` predicates at runtime.
+func TestActionsMapMatchesUAPI(t *testing.T) {
+	want := map[string]int32{
+		"TC_ACT_UNSPEC":     -1,
+		"TC_ACT_OK":         0,
+		"TC_ACT_RECLASSIFY": 1,
+		"TC_ACT_SHOT":       2,
+		"TC_ACT_PIPE":       3,
+		"TC_ACT_STOLEN":     4,
+		"TC_ACT_QUEUED":     5,
+		"TC_ACT_REPEAT":     6,
+		"TC_ACT_REDIRECT":   7,
+		"TC_ACT_TRAP":       8,
+	}
+	if len(Actions) != len(want) {
+		t.Fatalf("Actions has %d entries, want %d", len(Actions), len(want))
+	}
+	for name, wantCode := range want {
+		got, ok := Actions[name]
+		if !ok {
+			t.Errorf("Actions missing %q", name)
+			continue
+		}
+		if got != wantCode {
+			t.Errorf("Actions[%q] = %d, want %d", name, got, wantCode)
+		}
+	}
+}
+
+// TestFexitFetcherEmitFetchShape pins the 2-insn shape the fexit
+// ActionFetcher emits for tc. Mirrors the xdp adapter's contract.
+func TestFexitFetcherEmitFetchShape(t *testing.T) {
+	insns := FexitFetcher().EmitFetch(asm.R3)
+	if len(insns) != 2 {
+		t.Fatalf("EmitFetch returned %d insns, want 2", len(insns))
+	}
+
+	got := insns[0]
+	want := asm.LoadMem(asm.R3, asm.R10, -48, asm.DWord)
+	if got.OpCode != want.OpCode || got.Dst != want.Dst || got.Src != want.Src || got.Offset != want.Offset {
+		t.Errorf("insn[0] = %+v, want %+v (load tracing args ptr from stack[-48])", got, want)
+	}
+
+	got = insns[1]
+	want = asm.LoadMem(asm.R3, asm.R3, 8, asm.Word)
+	if got.OpCode != want.OpCode || got.Dst != want.Dst || got.Src != want.Src || got.Offset != want.Offset {
+		t.Errorf("insn[1] = %+v, want %+v (load args[1] = TC verdict)", got, want)
+	}
+}
+
+// TestFexitFetcherEmitFetchHonorsDstReg pins dst register threading.
+func TestFexitFetcherEmitFetchHonorsDstReg(t *testing.T) {
+	for _, dst := range []asm.Register{asm.R0, asm.R3, asm.R5} {
+		insns := FexitFetcher().EmitFetch(dst)
+		if insns[0].Dst != dst {
+			t.Errorf("dst=%v: insn[0].Dst = %v, want %v", dst, insns[0].Dst, dst)
+		}
+		if insns[1].Dst != dst || insns[1].Src != dst {
+			t.Errorf("dst=%v: insn[1] dst/src = %v/%v, want %v/%v", dst, insns[1].Dst, insns[1].Src, dst, dst)
+		}
+	}
+}
+
+// TestFexitCapabilities pins the Capabilities struct shape for tc.
+func TestFexitCapabilities(t *testing.T) {
+	caps := FexitCapabilities()
+	if caps.Action == nil {
+		t.Fatal("Capabilities.Action is nil")
+	}
+	if len(caps.Action) != len(Actions) {
+		t.Errorf("caps.Action has %d entries, want %d", len(caps.Action), len(Actions))
+	}
+	if caps.ActionFetcher == nil {
+		t.Fatal("Capabilities.ActionFetcher is nil")
+	}
+	insns := caps.ActionFetcher.EmitFetch(asm.R3)
+	if len(insns) != 2 {
+		t.Errorf("caps.ActionFetcher.EmitFetch returned %d insns, want 2", len(insns))
+	}
+}

--- a/pkg/kunai/host/xdp/xdp_test.go
+++ b/pkg/kunai/host/xdp/xdp_test.go
@@ -1,0 +1,97 @@
+package xdp
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+)
+
+// TestActionsMapMatchesUAPI pins the Actions map to the integer
+// verdicts declared in uapi/linux/bpf.h. A drift here would silently
+// mis-resolve `where action == XDP_*` predicates against the wrong
+// verdict at runtime; the verifier would still accept the program.
+func TestActionsMapMatchesUAPI(t *testing.T) {
+	want := map[string]int32{
+		"XDP_ABORTED":  0,
+		"XDP_DROP":     1,
+		"XDP_PASS":     2,
+		"XDP_TX":       3,
+		"XDP_REDIRECT": 4,
+	}
+	if len(Actions) != len(want) {
+		t.Fatalf("Actions has %d entries, want %d", len(Actions), len(want))
+	}
+	for name, wantCode := range want {
+		got, ok := Actions[name]
+		if !ok {
+			t.Errorf("Actions missing %q", name)
+			continue
+		}
+		if got != wantCode {
+			t.Errorf("Actions[%q] = %d, want %d", name, got, wantCode)
+		}
+	}
+}
+
+// TestFexitFetcherEmitFetchShape pins the exact 2-instruction shape
+// the fexit ActionFetcher emits. The host wrapper's stack contract
+// (tracing args pointer at stack[-48], args[1] = XDP retval at +8)
+// is load-bearing for `where action == XDP_*` predicates; a silent
+// off-by-one in either offset would compile cleanly but read the
+// wrong byte at runtime.
+func TestFexitFetcherEmitFetchShape(t *testing.T) {
+	insns := FexitFetcher().EmitFetch(asm.R3)
+	if len(insns) != 2 {
+		t.Fatalf("EmitFetch returned %d insns, want 2", len(insns))
+	}
+
+	// insn[0]: LoadMem R3, R10, -48, DWord
+	got := insns[0]
+	want := asm.LoadMem(asm.R3, asm.R10, -48, asm.DWord)
+	if got.OpCode != want.OpCode || got.Dst != want.Dst || got.Src != want.Src || got.Offset != want.Offset {
+		t.Errorf("insn[0] = %+v, want %+v (load tracing args ptr from stack[-48])", got, want)
+	}
+
+	// insn[1]: LoadMem R3, R3, 8, Word (= args[1] = XDP return value)
+	got = insns[1]
+	want = asm.LoadMem(asm.R3, asm.R3, 8, asm.Word)
+	if got.OpCode != want.OpCode || got.Dst != want.Dst || got.Src != want.Src || got.Offset != want.Offset {
+		t.Errorf("insn[1] = %+v, want %+v (load args[1] = XDP retval)", got, want)
+	}
+}
+
+// TestFexitFetcherEmitFetchHonorsDstReg pins that the dst register
+// flows through both loads. Codegen passes various dst registers
+// depending on the call site; the fetcher must thread it without
+// implicit assumption.
+func TestFexitFetcherEmitFetchHonorsDstReg(t *testing.T) {
+	for _, dst := range []asm.Register{asm.R0, asm.R3, asm.R5} {
+		insns := FexitFetcher().EmitFetch(dst)
+		if insns[0].Dst != dst {
+			t.Errorf("dst=%v: insn[0].Dst = %v, want %v", dst, insns[0].Dst, dst)
+		}
+		if insns[1].Dst != dst || insns[1].Src != dst {
+			t.Errorf("dst=%v: insn[1] dst/src = %v/%v, want %v/%v", dst, insns[1].Dst, insns[1].Src, dst, dst)
+		}
+	}
+}
+
+// TestFexitCapabilities pins the Capabilities struct shape: Action
+// map is the package-level Actions, ActionFetcher is non-nil and
+// returns the same 2-insn shape EmitFetch above pins.
+func TestFexitCapabilities(t *testing.T) {
+	caps := FexitCapabilities()
+	if caps.Action == nil {
+		t.Fatal("Capabilities.Action is nil")
+	}
+	if len(caps.Action) != len(Actions) {
+		t.Errorf("caps.Action has %d entries, want %d (matching pkg-level Actions)", len(caps.Action), len(Actions))
+	}
+	if caps.ActionFetcher == nil {
+		t.Fatal("Capabilities.ActionFetcher is nil")
+	}
+	insns := caps.ActionFetcher.EmitFetch(asm.R3)
+	if len(insns) != 2 {
+		t.Errorf("caps.ActionFetcher.EmitFetch returned %d insns, want 2", len(insns))
+	}
+}

--- a/pkg/kunai/parser/parser_test.go
+++ b/pkg/kunai/parser/parser_test.go
@@ -538,6 +538,67 @@ func TestParseWhereNetworkLiteralOnLHS(t *testing.T) {
 	}
 }
 
+// TestParseWhereLHSLiteralBailReplay pins the bail/replay invariant
+// of tryLeadingNetworkLiteralCmp: when the LHS isn't a network
+// literal, the lexer must be restored exactly so the fallback arith
+// path sees the same multi-byte token the entry call had.
+// Hex and decimal integer LHS exercise multi-byte token boundaries —
+// a silent off-by-one in lexer.Restore/Next replay would consume the
+// wrong bytes and parseArithExpr would fail or read a different value.
+func TestParseWhereLHSLiteralBailReplay(t *testing.T) {
+	cases := []struct {
+		name     string
+		expr     string
+		wantOp   ast.CmpOp
+		wantLHS  uint64 // expected LHS literal value after bail+replay
+		wantRHSF string // expected RHS field path
+	}{
+		{
+			"hex_lhs_eq_field",
+			"eth/ipv4/tcp where 0x1bb == tcp.dport",
+			ast.CmpEq, 0x1bb, "tcp.dport",
+		},
+		{
+			"hex_lhs_large_eq_field",
+			"eth/ipv4/tcp where 0xDEADBEEF == tcp.seq",
+			ast.CmpEq, 0xDEADBEEF, "tcp.seq",
+		},
+		{
+			"decimal_lhs_eq_field",
+			"eth/ipv4/tcp where 443 == tcp.dport",
+			ast.CmpEq, 443, "tcp.dport",
+		},
+		{
+			"decimal_lhs_ordered_field",
+			// Ordered op with non-network LHS — bail path returns false,
+			// fallback succeeds with the legal arith ordered comparison.
+			"eth/ipv4/tcp where 1000 < tcp.seq",
+			ast.CmpLt, 1000, "tcp.seq",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			f := mustParse(t, c.expr)
+			if f.Where == nil || f.Where.Kind != ast.WAtomArith {
+				t.Fatalf("where kind = %v, want WAtomArith (= bail succeeded, fallback parsed integer LHS as arith)", f.Where.Kind)
+			}
+			if f.Where.Op != c.wantOp {
+				t.Errorf("op = %v, want %v", f.Where.Op, c.wantOp)
+			}
+			if f.Where.ArithL == nil || f.Where.ArithL.Kind != ast.ArithConst {
+				t.Fatalf("LHS = %+v, want ArithConst (bail must restore lexer so the integer literal re-parses correctly)", f.Where.ArithL)
+			}
+			if f.Where.ArithL.Const != c.wantLHS {
+				t.Errorf("LHS value = %d (0x%x), want %d (0x%x) — multi-byte token boundary regression in bail/replay",
+					f.Where.ArithL.Const, f.Where.ArithL.Const, c.wantLHS, c.wantLHS)
+			}
+			if f.Where.ArithR == nil || f.Where.ArithR.Field == nil || f.Where.ArithR.Field.String() != c.wantRHSF {
+				t.Errorf("RHS = %+v, want field %q", f.Where.ArithR, c.wantRHSF)
+			}
+		})
+	}
+}
+
 func TestParseWhereNetworkLiteralLHSOrderedRejected(t *testing.T) {
 	// Per dsl-types.md §6.2 network literals only support ==/!=. The
 	// ordered comparison falls through to the arith path which then

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -298,7 +298,7 @@ func readParserParamCounts(file *p4lite.File, primaryFields []Field, source stri
 				}
 				out[prm.VarName] = &StackCountSpec{
 					ByteOff: bitOff / 8,
-					Offset:  offset,
+					Addend:  offset,
 				}
 			}
 		}

--- a/pkg/kunai/vocab/header_annotations.go
+++ b/pkg/kunai/vocab/header_annotations.go
@@ -36,39 +36,23 @@ const stackLayoutAfterPrimary = "primary"
 // header's byte end) or another stack's parameter name (chain — not
 // yet supported; reserved for a follow-up that walks dependencies).
 func readParserParamLayouts(file *p4lite.File, source string) (map[string]*StackLayoutSpec, error) {
-	if file == nil {
-		return nil, nil
-	}
-	allowed := map[string]bool{"after": true}
-	out := make(map[string]*StackLayoutSpec)
-	for _, par := range file.Parsers {
-		for _, prm := range par.Params {
-			for _, ann := range prm.Annotations {
-				if ann.Name != annKunaiLayout {
-					continue
-				}
-				if err := requireKnownKeys(ann, allowed, source); err != nil {
-					return nil, err
-				}
-				afterVal, ok := ann.KVs["after"]
-				if !ok {
-					return nil, fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `after`", source, ann.Pos, annKunaiLayout, prm.VarName)
-				}
-				if afterVal.Kind != p4lite.AnnotationIdent {
-					return nil, fmt.Errorf("%s:%s: @%s.after must be an identifier (got %v)", source, ann.Pos, annKunaiLayout, afterVal.Kind)
-				}
-				if !prm.IsOut || !prm.IsArray {
-					return nil, fmt.Errorf("%s:%s: @%s only applies to `out X[N] name` parameters (got %q)", source, ann.Pos, annKunaiLayout, prm.VarName)
-				}
-				if _, exists := out[prm.VarName]; exists {
-					return nil, fmt.Errorf("%s:%s: parameter %q has multiple @%s annotations", source, ann.Pos, prm.VarName, annKunaiLayout)
-				}
-				out[prm.VarName] = &StackLayoutSpec{After: afterVal.Ident}
-			}
+	var out map[string]*StackLayoutSpec
+	err := forEachParserParamAnnotation(file, annKunaiLayout, stackLayoutAllowedKeys, source, func(prm *p4lite.Param, ann p4lite.Annotation) error {
+		afterVal, ok := ann.KVs["after"]
+		if !ok {
+			return fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `after`", source, ann.Pos, annKunaiLayout, prm.VarName)
 		}
-	}
-	if len(out) == 0 {
-		return nil, nil
+		if afterVal.Kind != p4lite.AnnotationIdent {
+			return fmt.Errorf("%s:%s: @%s.after must be an identifier (got %v)", source, ann.Pos, annKunaiLayout, afterVal.Kind)
+		}
+		if out == nil {
+			out = make(map[string]*StackLayoutSpec)
+		}
+		out[prm.VarName] = &StackLayoutSpec{After: afterVal.Ident}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -241,10 +225,57 @@ func ownerBoundStackNames(spec *ProtocolSpec) map[string]bool {
 	return out
 }
 
-// stackCountAllowedKeys is the @kunai_stack_count key set, hoisted to
-// package scope so the no-annotation common case (= every protocol
-// except srv6 today) doesn't allocate a transient map per loadFile.
-var stackCountAllowedKeys = map[string]bool{"field": true, "offset": true}
+// Allowed-key sets per parser-param annotation, hoisted to package
+// scope so the no-annotation common case (= every protocol except
+// srv6 today) doesn't allocate a transient map per loadFile.
+var (
+	stackLayoutAllowedKeys = map[string]bool{"after": true}
+	stackCountAllowedKeys  = map[string]bool{"field": true, "offset": true}
+)
+
+// forEachParserParamAnnotation walks each parser parameter's
+// @<annName> annotation across all parser blocks in file. The helper
+// owns the structural preconditions every param-level kunai annotation
+// needs — allowed-key validation, IsOut + IsArray shape check,
+// duplicate-per-param dedup — so per-reader callbacks only handle
+// annotation-specific key decoding. Returning an error halts
+// iteration and propagates up.
+func forEachParserParamAnnotation(
+	file *p4lite.File,
+	annName string,
+	allowedKeys map[string]bool,
+	source string,
+	fn func(prm *p4lite.Param, ann p4lite.Annotation) error,
+) error {
+	if file == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	for _, par := range file.Parsers {
+		for i := range par.Params {
+			prm := &par.Params[i]
+			for _, ann := range prm.Annotations {
+				if ann.Name != annName {
+					continue
+				}
+				if err := requireKnownKeys(ann, allowedKeys, source); err != nil {
+					return err
+				}
+				if !prm.IsOut || !prm.IsArray {
+					return fmt.Errorf("%s:%s: @%s only applies to `out X[N] name` parameters (got %q)", source, ann.Pos, annName, prm.VarName)
+				}
+				if seen[prm.VarName] {
+					return fmt.Errorf("%s:%s: parameter %q has multiple @%s annotations", source, ann.Pos, prm.VarName, annName)
+				}
+				seen[prm.VarName] = true
+				if err := fn(prm, ann); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
 
 // readParserParamCounts lowers each @kunai_stack_count decorator on a
 // parser parameter into a StackCountSpec keyed by parameter name.
@@ -253,55 +284,40 @@ var stackCountAllowedKeys = map[string]bool{"field": true, "offset": true}
 // for `any/all` quantifiers. Resolution requires the primary header's
 // field layout, so the caller supplies the parsed `[]Field` slice.
 func readParserParamCounts(file *p4lite.File, primaryFields []Field, source string) (map[string]*StackCountSpec, error) {
-	if file == nil {
-		return nil, nil
-	}
 	var out map[string]*StackCountSpec
-	for _, par := range file.Parsers {
-		for _, prm := range par.Params {
-			for _, ann := range prm.Annotations {
-				if ann.Name != annKunaiStackCount {
-					continue
-				}
-				if err := requireKnownKeys(ann, stackCountAllowedKeys, source); err != nil {
-					return nil, err
-				}
-				if !prm.IsOut || !prm.IsArray {
-					return nil, fmt.Errorf("%s:%s: @%s only applies to `out X[N] name` parameters (got %q)", source, ann.Pos, annKunaiStackCount, prm.VarName)
-				}
-				fieldVal, ok := ann.KVs["field"]
-				if !ok {
-					return nil, fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `field`", source, ann.Pos, annKunaiStackCount, prm.VarName)
-				}
-				if fieldVal.Kind != p4lite.AnnotationIdent {
-					return nil, fmt.Errorf("%s:%s: @%s.field must be an identifier (got %v)", source, ann.Pos, annKunaiStackCount, fieldVal.Kind)
-				}
-				bitOff, bits, found := BitOffsetIn(primaryFields, fieldVal.Ident)
-				if !found {
-					return nil, fmt.Errorf("%s:%s: @%s.field references unknown field %q in primary header", source, ann.Pos, annKunaiStackCount, fieldVal.Ident)
-				}
-				if bits != 8 || bitOff%8 != 0 {
-					return nil, fmt.Errorf("%s:%s: @%s.field %q must be a byte-aligned 8-bit field (got bit offset %d, %d bits wide)", source, ann.Pos, annKunaiStackCount, fieldVal.Ident, bitOff, bits)
-				}
-				offset := 0
-				if oVal, ok := ann.KVs["offset"]; ok {
-					if oVal.Kind != p4lite.AnnotationInt {
-						return nil, fmt.Errorf("%s:%s: @%s.offset must be an int literal", source, ann.Pos, annKunaiStackCount)
-					}
-					offset = int(oVal.Int)
-				}
-				if _, exists := out[prm.VarName]; exists {
-					return nil, fmt.Errorf("%s:%s: parameter %q has multiple @%s annotations", source, ann.Pos, prm.VarName, annKunaiStackCount)
-				}
-				if out == nil {
-					out = make(map[string]*StackCountSpec)
-				}
-				out[prm.VarName] = &StackCountSpec{
-					ByteOff: bitOff / 8,
-					Addend:  offset,
-				}
-			}
+	err := forEachParserParamAnnotation(file, annKunaiStackCount, stackCountAllowedKeys, source, func(prm *p4lite.Param, ann p4lite.Annotation) error {
+		fieldVal, ok := ann.KVs["field"]
+		if !ok {
+			return fmt.Errorf("%s:%s: @%s on parameter %q is missing required key `field`", source, ann.Pos, annKunaiStackCount, prm.VarName)
 		}
+		if fieldVal.Kind != p4lite.AnnotationIdent {
+			return fmt.Errorf("%s:%s: @%s.field must be an identifier (got %v)", source, ann.Pos, annKunaiStackCount, fieldVal.Kind)
+		}
+		bitOff, bits, found := BitOffsetIn(primaryFields, fieldVal.Ident)
+		if !found {
+			return fmt.Errorf("%s:%s: @%s.field references unknown field %q in primary header", source, ann.Pos, annKunaiStackCount, fieldVal.Ident)
+		}
+		if bits != 8 || bitOff%8 != 0 {
+			return fmt.Errorf("%s:%s: @%s.field %q must be a byte-aligned 8-bit field (got bit offset %d, %d bits wide)", source, ann.Pos, annKunaiStackCount, fieldVal.Ident, bitOff, bits)
+		}
+		addend := 0
+		if oVal, ok := ann.KVs["offset"]; ok {
+			if oVal.Kind != p4lite.AnnotationInt {
+				return fmt.Errorf("%s:%s: @%s.offset must be an int literal", source, ann.Pos, annKunaiStackCount)
+			}
+			addend = int(oVal.Int)
+		}
+		if out == nil {
+			out = make(map[string]*StackCountSpec)
+		}
+		out[prm.VarName] = &StackCountSpec{
+			ByteOff: bitOff / 8,
+			Addend:  addend,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -790,8 +790,8 @@ func TestSRv6SegmentsStackCount(t *testing.T) {
 	if cnt.ByteOff != 4 {
 		t.Errorf("ByteOff = %d, want 4 (= byte position of srv6_h.last_entry)", cnt.ByteOff)
 	}
-	if cnt.Offset != 1 {
-		t.Errorf("Offset = %d, want 1 (= last_entry + 1 SRv6 spec formula)", cnt.Offset)
+	if cnt.Addend != 1 {
+		t.Errorf("Addend = %d, want 1 (= last_entry + 1 SRv6 spec formula)", cnt.Addend)
 	}
 }
 

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -112,8 +112,8 @@ type StackLayoutSpec struct {
 // result as the iteration cap. The field must be byte-aligned and
 // exactly 8 bits wide so the LDX hits the whole value in one load.
 type StackCountSpec struct {
-	ByteOff int
-	Offset  int
+	ByteOff int // primary-header byte where the raw count value lives
+	Addend  int // integer added to the loaded byte to yield the final count (= SRv6 `last_entry + 1` would be Addend=1); intentionally NOT named "Offset" to avoid confusion with the sibling ByteOff
 }
 
 // HeaderAnnotations bundles kunai-specific decorators carried on a

--- a/pkg/kunai/vocab/parser_machine_test.go
+++ b/pkg/kunai/vocab/parser_machine_test.go
@@ -1,0 +1,143 @@
+package vocab
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// The aux-gating helpers (computeAuxGating → gatingFromSelect →
+// mergeBitFieldsToMask) only get exercised on the success path by the
+// bundled GTP vocab. Their error branches — multi-case gating,
+// non-zero explicit case, byte-straddling key, multi-byte key span —
+// had only indirect coverage. These tests craft synthetic .p4 that
+// reaches each branch through the real Load() pipeline and pins the
+// diagnostic.
+
+// loadGatingP4 wraps a single synthetic .p4 source through the vocab
+// loader. The source must declare a `foo_h` primary so the loader's
+// primary-header convention is satisfied.
+func loadGatingP4(t *testing.T, src string) error {
+	t.Helper()
+	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
+	_, err := Load(fsys, "vocab")
+	return err
+}
+
+// TestGatingFromSelectRejectsMultipleExplicitCases pins that an
+// entry-state select where the aux-extract is the default branch but
+// more than one explicit case exists is rejected — the MVP gating
+// model only inverts a single explicit case.
+func TestGatingFromSelectRejectsMultipleExplicitCases(t *testing.T) {
+	src := `header foo_h { bit<5> pad; bit<3> flags; }
+header foo_opt_h { bit<8> data; }
+parser P(packet_in pkt, out foo_h hdr, out foo_opt_h opt) {
+	state start {
+		pkt.extract(hdr);
+		transition select(hdr.flags) {
+			0: accept;
+			1: accept;
+			default: parse_opt;
+		}
+	}
+	state parse_opt {
+		pkt.extract(opt);
+		transition accept;
+	}
+}`
+	err := loadGatingP4(t, src)
+	if err == nil {
+		t.Fatal("expected error for multi-case aux gating, got nil")
+	}
+	if !strings.Contains(err.Error(), "exactly one explicit case") {
+		t.Errorf("err = %q; want 'exactly one explicit case'", err.Error())
+	}
+}
+
+// TestGatingFromSelectRejectsNonZeroExplicitCase pins that the
+// default→extract gating shape requires the lone explicit case to be
+// all-zero (the gating predicate is "the OR of the key bits is
+// non-zero"; a non-zero case value would make the negation wrong).
+func TestGatingFromSelectRejectsNonZeroExplicitCase(t *testing.T) {
+	src := `header foo_h { bit<5> pad; bit<3> flags; }
+header foo_opt_h { bit<8> data; }
+parser P(packet_in pkt, out foo_h hdr, out foo_opt_h opt) {
+	state start {
+		pkt.extract(hdr);
+		transition select(hdr.flags) {
+			1: accept;
+			default: parse_opt;
+		}
+	}
+	state parse_opt {
+		pkt.extract(opt);
+		transition accept;
+	}
+}`
+	err := loadGatingP4(t, src)
+	if err == nil {
+		t.Fatal("expected error for non-zero explicit gating case, got nil")
+	}
+	if !strings.Contains(err.Error(), "all-zero") {
+		t.Errorf("err = %q; want 'all-zero'", err.Error())
+	}
+}
+
+// TestMergeBitFieldsRejectsByteStraddle pins that a gating key whose
+// bit window crosses a byte boundary is rejected — codegen emits a
+// single byte read + mask, which a straddling field would corrupt.
+func TestMergeBitFieldsRejectsByteStraddle(t *testing.T) {
+	// `straddler` occupies bits [6,10): it crosses the byte-0/byte-1
+	// boundary.
+	src := `header foo_h { bit<6> pad; bit<4> straddler; bit<6> rest; }
+header foo_opt_h { bit<8> data; }
+parser P(packet_in pkt, out foo_h hdr, out foo_opt_h opt) {
+	state start {
+		pkt.extract(hdr);
+		transition select(hdr.straddler) {
+			0: accept;
+			default: parse_opt;
+		}
+	}
+	state parse_opt {
+		pkt.extract(opt);
+		transition accept;
+	}
+}`
+	err := loadGatingP4(t, src)
+	if err == nil {
+		t.Fatal("expected error for byte-straddling gating key, got nil")
+	}
+	if !strings.Contains(err.Error(), "straddles a byte boundary") {
+		t.Errorf("err = %q; want 'straddles a byte boundary'", err.Error())
+	}
+}
+
+// TestMergeBitFieldsRejectsMultiByteSpan pins that a multi-key gating
+// tuple whose keys land in different bytes is rejected — the MVP
+// single-byte read can't cover two bytes.
+func TestMergeBitFieldsRejectsMultiByteSpan(t *testing.T) {
+	// `a` is in byte 0 (bits [0,3)), `b` is in byte 1 (bits [8,11)).
+	src := `header foo_h { bit<3> a; bit<5> pad0; bit<3> b; bit<5> pad1; }
+header foo_opt_h { bit<8> data; }
+parser P(packet_in pkt, out foo_h hdr, out foo_opt_h opt) {
+	state start {
+		pkt.extract(hdr);
+		transition select(hdr.a, hdr.b) {
+			(0, 0): accept;
+			default: parse_opt;
+		}
+	}
+	state parse_opt {
+		pkt.extract(opt);
+		transition accept;
+	}
+}`
+	err := loadGatingP4(t, src)
+	if err == nil {
+		t.Fatal("expected error for multi-byte gating key span, got nil")
+	}
+	if !strings.Contains(err.Error(), "span multiple bytes") {
+		t.Errorf("err = %q; want 'span multiple bytes'", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Address findings from the post-merge `/ocr:review` of `pkg/kunai/` (after PR #22 vocab migration landed). 7 commits, ordered from Critical → Important per reviewer priority.

## Critical

1. **host adapter unit tests** (`host/xdp/`, `host/tc/`) — `Capabilities`, action map, `EmitFetch` 2-insn shape, dst register threading. Previously test 0 件 despite being part of the 1.0-stable public API surface.
2. **parser LHS-literal bail-replay test gap** — `tryLeadingNetworkLiteralCmp`'s bail path replays the lexer through structural mode; multi-byte token boundaries (hex / multi-digit decimal) are now pinned to detect silent off-by-one in `lex.Restore` / `Next` sequencing.

## Important

3. **`StackCountSpec.Offset` → `Addend` rename** — `Offset` sat next to sibling `ByteOff` despite not being a byte offset (it's the additive constant in `count = byte + Addend`). Renaming defuses a 誤読 magnet.
4. **`forEachParserParamAnnotation` helper extraction** — `readParserParamLayouts` and `readParserParamCounts` shared the outer iteration + IsOut/IsArray + duplicate-dedup structure. Centralise so adding the next `@kunai_*` param annotation costs only a callback.
5. **drop `Capabilities.StrictArithLint`** — layering violation: this is a resolver option, not a host capability. Zero production callers (the field existed but was never plumbed through any host adapter), so this is a clean removal rather than a deprecation carry-over.
6. **`callbackBranchThreshold` value pin + boundary table** — the previous tests parameterised against the const, so a drift would shift the verifier-blowup envelope silently. Add an explicit `== 64` pin + a 3-row boundary table (just-below / at / just-above).
7. **CI fuzz gate** — `go test` runs fuzz targets in seed-only mode by default. Add a 30s × 2 fuzz step (`FuzzCompile`, `FuzzLexNext`) to extend the corpus per-PR. ~1 min/push cost, ~30M execs/push coverage.

## Skipped from the review (intentional, documented in commit msgs)

- ProtocolSpec API surface bloat (12+ fields): documented as 1.0 split candidate, no current pain
- F12 slice desugar location: doc-only fix vs. invasive move — defer the decision
- Project-wide `ByteOff`/`ByteOffset` unification: cosmetic, low ROI
- `forEachParserParamAnnotation` net line count is +16 not -60: helper amortises with the next annotation reader
- `parser_trail.go::variableTailFor` panic vs. error: minor, panic remains as defensive guard against loader bypass

## Verification

- `make test` — all packages green (incl. new 4 host adapter sub-tests + 4 LHS-literal sub-tests + 4 callback-lint sub-tests)
- `make p4c-check` — green
- lefthook (golangci-lint 0 issues, go-vet, conventional-commit) — green per commit
- Fuzz gate: locally sanity-checked at 5s for both targets (444K / 1M execs/sec)
- filterset_test 30 sub-test insn count pins — unchanged (refactors are byte-for-byte BPF asm equivalent)

## Test plan

- [x] `make test`
- [x] `make p4c-check`
- [x] `make lint`
- [x] local fuzz sanity (5s × 2 targets)
- [ ] CI 5-kernel matrix (6.1 / 6.6 / 6.12 / 6.18 / 7.0)
- [ ] CI fuzz gate (30s × 2)
