### PR TITLE
fix(codegen): reject vlan/qinq layers at the tc host

### DIFF
--- a/internal/program/filterset_corpus_test.go
+++ b/internal/program/filterset_corpus_test.go
@@ -1,10 +1,21 @@
 package program
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf"
 )
+
+// exprHasVlanLayer reports whether a corpus expression carries a
+// vlan/qinq layer. The tc host rejects these at compile time because
+// the kernel extracts the outer VLAN tag into skb metadata before the
+// program runs (codegen.Capabilities.VlanInMetadata); they compile and
+// load only on XDP, where VLAN is in-band. No corpus field is named
+// "vlan"/"qinq", so a substring match is sufficient and self-contained.
+func exprHasVlanLayer(expr string) bool {
+	return strings.Contains(expr, "vlan") || strings.Contains(expr, "qinq")
+}
 
 // VerifierCorpus is a curated set of well-typed kunai expressions that
 // extends the F1-F10 set with broader language coverage. Every entry
@@ -134,7 +145,15 @@ func TestFilterCorpusCompiles(t *testing.T) {
 	for _, c := range VerifierCorpus {
 		for _, h := range hosts {
 			t.Run(c.ID+"/"+h.name, func(t *testing.T) {
-				if _, err := compileFilter(c.Expr, true /*useDSL*/, false /*isFexit*/, h.progType); err != nil {
+				tcVlan := h.progType != ebpf.XDP && exprHasVlanLayer(c.Expr)
+				_, err := compileFilter(c.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
+				if tcVlan {
+					if err == nil {
+						t.Fatalf("compile %s (%s): expected tc rejection (VLAN in skb metadata), got success", c.ID, h.name)
+					}
+					return
+				}
+				if err != nil {
 					t.Fatalf("compile %s (%s): %v", c.ID, h.name, err)
 				}
 			})
@@ -159,8 +178,12 @@ func TestBpfFilterCorpusTC(t *testing.T) {
 
 func runFilterCorpusMatrix(t *testing.T, hostProg *ebpf.Program, funcName string) {
 	t.Helper()
+	isTC := funcName == tcFuncName
 	for _, c := range VerifierCorpus {
 		t.Run(c.ID, func(t *testing.T) {
+			if isTC && exprHasVlanLayer(c.Expr) {
+				t.Skipf("%s carries a vlan/qinq layer; the tc host extracts the outer VLAN tag into skb metadata, so it is rejected at compile time (not loadable)", c.ID)
+			}
 			loadProbeOrFail(t, hostProg, funcName, c.Expr, false /*exit*/, true /*useDSL*/)
 		})
 	}

--- a/internal/program/filterset_corpus_test.go
+++ b/internal/program/filterset_corpus_test.go
@@ -1,20 +1,29 @@
 package program
 
 import (
-	"strings"
+	"errors"
+	"regexp"
 	"testing"
 
 	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
+
+// vlanLayerRe matches a vlan/qinq layer token in a chain: a layer name
+// always follows a chain separator (`/`, or `(`/`|` inside an
+// alternation), so anchoring on those excludes labels like `@vlan` and
+// longer names like `vxlan` (preceded by `vx`, not a separator). The
+// trailing \b keeps it from matching a hypothetical `vlanfoo`.
+var vlanLayerRe = regexp.MustCompile(`[/(|](vlan|qinq)\b`)
 
 // exprHasVlanLayer reports whether a corpus expression carries a
 // vlan/qinq layer. The tc host rejects these at compile time because
 // the kernel extracts the outer VLAN tag into skb metadata before the
 // program runs (codegen.Capabilities.VlanInMetadata); they compile and
-// load only on XDP, where VLAN is in-band. No corpus field is named
-// "vlan"/"qinq", so a substring match is sufficient and self-contained.
+// load only on XDP, where VLAN is in-band.
 func exprHasVlanLayer(expr string) bool {
-	return strings.Contains(expr, "vlan") || strings.Contains(expr, "qinq")
+	return vlanLayerRe.MatchString(expr)
 }
 
 // VerifierCorpus is a curated set of well-typed kunai expressions that
@@ -148,8 +157,8 @@ func TestFilterCorpusCompiles(t *testing.T) {
 				tcVlan := h.progType != ebpf.XDP && exprHasVlanLayer(c.Expr)
 				_, err := compileFilter(c.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
 				if tcVlan {
-					if err == nil {
-						t.Fatalf("compile %s (%s): expected tc rejection (VLAN in skb metadata), got success", c.ID, h.name)
+					if !errors.Is(err, codegen.ErrNotImplemented) {
+						t.Fatalf("compile %s (%s): expected tc rejection with ErrNotImplemented (VLAN in skb metadata), got %v", c.ID, h.name, err)
 					}
 					return
 				}

--- a/internal/program/filterset_load_test.go
+++ b/internal/program/filterset_load_test.go
@@ -28,8 +28,12 @@ func TestBpfFilterSetTC(t *testing.T) {
 
 func runFilterSetMatrix(t *testing.T, hostProg *ebpf.Program, funcName string) {
 	t.Helper()
+	isTC := funcName == tcFuncName
 	for _, fs := range FilterSet {
 		t.Run(fs.ID, func(t *testing.T) {
+			if isTC && fs.TCUnsupported {
+				t.Skipf("%s carries a vlan/qinq layer; the tc host extracts the outer VLAN tag into skb metadata, so it is rejected at compile time (not loadable)", fs.ID)
+			}
 			loadProbeOrFail(t, hostProg, funcName, fs.Expr, false /*exit*/, true /*useDSL*/)
 		})
 	}

--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -86,14 +86,14 @@ func TestFilterSetCompiles(t *testing.T) {
 		for _, h := range hosts {
 			t.Run(fs.ID+"/"+h.name, func(t *testing.T) {
 				if fs.TCUnsupported && h.progType != ebpf.XDP {
-					_, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, h.progType)
+					_, err := compileFilter(fs.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
 					if err == nil {
 						t.Fatalf("compile %s (%s): expected tc rejection (VLAN in skb metadata), got success\n  expr: %s", fs.ID, fs.Notes, fs.Expr)
 					}
 					t.Logf("rejected on %s as expected: %v", h.name, err)
 					return
 				}
-				out, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, h.progType)
+				out, err := compileFilter(fs.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
 				if err != nil {
 					t.Fatalf("compile %s (%s): %v\n  expr: %s", fs.ID, fs.Notes, err, fs.Expr)
 				}
@@ -112,7 +112,7 @@ func TestFilterSetCompiles(t *testing.T) {
 func TestFilterSetCounts(t *testing.T) {
 	for _, fs := range FilterSet {
 		t.Run(fs.ID, func(t *testing.T) {
-			out, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, ebpf.XDP)
+			out, err := compileFilter(fs.Expr, true /*useDSL*/, false /*isFexit*/, ebpf.XDP)
 			if err != nil {
 				t.Fatalf("compile %s: %v", fs.ID, err)
 			}

--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -26,6 +26,12 @@ type FilterSpec struct {
 	CBPFCExpr string // pcap-filter equivalent; "" when cBPF cannot express
 	WantInsns int    // entry-mode XDP host raw-insn count (tc emits the same body)
 	Notes     string // short rationale; surfaces in test output
+	// TCUnsupported marks filters the tc host rejects at compile time.
+	// The kernel extracts the outer VLAN tag into skb metadata before
+	// the tc program runs, so vlan/qinq layers are not in packet bytes
+	// (see codegen.Capabilities.VlanInMetadata). These compile and load
+	// on XDP, where VLAN is in-band.
+	TCUnsupported bool
 }
 
 // FilterSet is the canonical F1-F10 used across the paper's expressiveness
@@ -44,11 +50,11 @@ var FilterSet = []FilterSpec{
 		WantInsns: 338, Notes: "IPv6 source CIDR via bracket predicate"},
 	{ID: "F4", Expr: "eth/vlan[tci==100]/ipv4/tcp where tcp.dport == 80",
 		CBPFCExpr: "vlan 100 and tcp dst port 80",
-		WantInsns: 213, Notes: "VLAN tag (TCI=100) + TCP dst"},
+		WantInsns: 213, Notes: "VLAN tag (TCI=100) + TCP dst", TCUnsupported: true},
 	{ID: "F5", Expr: "eth/qinq/vlan/ipv4/tcp where tcp.dport == 80",
 		// pcap "vlan 100 and vlan 200" is kernel/NIC dependent; intentionally
 		// omitted so the bench does not pretend the comparison is meaningful.
-		WantInsns: 215, Notes: "QinQ S-VLAN + inner C-VLAN via chain"},
+		WantInsns: 215, Notes: "QinQ S-VLAN + inner C-VLAN via chain", TCUnsupported: true},
 	{ID: "F6", Expr: "eth/ipv4/icmp where icmp.type == 8",
 		CBPFCExpr: "icmp[icmptype]==8",
 		WantInsns: 83, Notes: "ICMP echo request"},
@@ -79,7 +85,15 @@ func TestFilterSetCompiles(t *testing.T) {
 	for _, fs := range FilterSet {
 		for _, h := range hosts {
 			t.Run(fs.ID+"/"+h.name, func(t *testing.T) {
-				out, err := compileFilter(fs.Expr, /*useDSL=*/ true, /*isFexit=*/ false, h.progType)
+				if fs.TCUnsupported && h.progType != ebpf.XDP {
+					_, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, h.progType)
+					if err == nil {
+						t.Fatalf("compile %s (%s): expected tc rejection (VLAN in skb metadata), got success\n  expr: %s", fs.ID, fs.Notes, fs.Expr)
+					}
+					t.Logf("rejected on %s as expected: %v", h.name, err)
+					return
+				}
+				out, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, h.progType)
 				if err != nil {
 					t.Fatalf("compile %s (%s): %v\n  expr: %s", fs.ID, fs.Notes, err, fs.Expr)
 				}
@@ -98,7 +112,7 @@ func TestFilterSetCompiles(t *testing.T) {
 func TestFilterSetCounts(t *testing.T) {
 	for _, fs := range FilterSet {
 		t.Run(fs.ID, func(t *testing.T) {
-			out, err := compileFilter(fs.Expr, /*useDSL=*/ true, /*isFexit=*/ false, ebpf.XDP)
+			out, err := compileFilter(fs.Expr /*useDSL=*/, true /*isFexit=*/, false, ebpf.XDP)
 			if err != nil {
 				t.Fatalf("compile %s: %v", fs.ID, err)
 			}

--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -1,9 +1,12 @@
 package program
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
 
 // FilterSpec is one row of the paper's evaluation matrix
@@ -87,8 +90,8 @@ func TestFilterSetCompiles(t *testing.T) {
 			t.Run(fs.ID+"/"+h.name, func(t *testing.T) {
 				if fs.TCUnsupported && h.progType != ebpf.XDP {
 					_, err := compileFilter(fs.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
-					if err == nil {
-						t.Fatalf("compile %s (%s): expected tc rejection (VLAN in skb metadata), got success\n  expr: %s", fs.ID, fs.Notes, fs.Expr)
+					if !errors.Is(err, codegen.ErrNotImplemented) {
+						t.Fatalf("compile %s (%s): expected tc rejection with ErrNotImplemented (VLAN in skb metadata), got %v\n  expr: %s", fs.ID, fs.Notes, err, fs.Expr)
 					}
 					t.Logf("rejected on %s as expected: %v", h.name, err)
 					return

--- a/internal/program/load_dsl_test.go
+++ b/internal/program/load_dsl_test.go
@@ -212,7 +212,10 @@ var dslTCEntryExprs = []string{
 	"eth/ipv4/tcp where tcp.dport == 443",
 	"eth/ipv4/tcp capture headers+64",
 	"eth/(ipv4|ipv6)/tcp",
-	"eth/vlan+/ipv4/tcp",
+	// mpls+ (not vlan+) pins the `+` quantifier / bpf_loop path on the
+	// tc context: the kernel strips the outer VLAN tag into skb
+	// metadata before tc, so vlan/qinq layers are rejected there.
+	"eth/mpls+/ipv4/tcp",
 	"eth/ipv4/ipv4/tcp",
 	// Parser-machine paths: GTP-U with optional + ext-header chain,
 	// SRv6 segments, IPv6 ext walk. These exercise the bpf_loop

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -13,11 +13,11 @@ import (
 	"github.com/cloudflare/cbpfc"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/pkg/kunai"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 	tchost "github.com/takehaya/xdp-ninja/pkg/kunai/host/tc"
 	xdphost "github.com/takehaya/xdp-ninja/pkg/kunai/host/xdp"
-	"github.com/takehaya/xdp-ninja/internal/filter"
 	"golang.org/x/net/bpf"
 )
 
@@ -177,18 +177,25 @@ func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType)
 	if useDSL {
 		// fexit attaches see the host retval at args[1] (XDP action
 		// or TC verdict, ABI shared); fentry has no action value yet
-		// so disable action atoms by passing zero Capabilities. The
-		// xdp-ninja host wrapper saves the tracing args ptr at
-		// stack[-48] in either case, which is exactly the ABI both
-		// FexitFetcher implementations expect.
+		// so disables action atoms. The xdp-ninja host wrapper saves
+		// the tracing args ptr at stack[-48] in either case, which is
+		// exactly the ABI both FexitFetcher implementations expect.
+		// The tc host also carries VlanInMetadata in both entry and
+		// fexit caps, because the kernel strips the outer VLAN tag into
+		// skb metadata before either attach point runs.
 		var caps codegen.Capabilities
-		if isFexit {
-			switch progType {
-			case ebpf.XDP:
-				caps = xdphost.FexitCapabilities()
-			case ebpf.SchedCLS, ebpf.SchedACT:
+		switch progType {
+		case ebpf.SchedCLS, ebpf.SchedACT:
+			if isFexit {
 				caps = tchost.FexitCapabilities()
+			} else {
+				caps = tchost.EntryCapabilities()
 			}
+		case ebpf.XDP:
+			if isFexit {
+				caps = xdphost.FexitCapabilities()
+			}
+			// XDP entry keeps zero caps: VLAN is in-band at XDP.
 		}
 		out, err := kunai.Compile(expr, caps)
 		if err != nil {

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -176,8 +176,8 @@ func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType)
 	}
 	if useDSL {
 		// fexit attaches see the host retval at args[1] (XDP action
-		// or TC verdict, ABI shared); fentry has no action value yet
-		// so disables action atoms. The xdp-ninja host wrapper saves
+		// or TC verdict, ABI shared); fentry has no action value yet,
+		// so action atoms are disabled. The xdp-ninja host wrapper saves
 		// the tracing args ptr at stack[-48] in either case, which is
 		// exactly the ABI both FexitFetcher implementations expect.
 		// The tc host also carries VlanInMetadata in both entry and

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -47,6 +47,20 @@ type Capabilities struct {
 	// shadow the action symbol). nil means no reservations — useful
 	// for hosts that disable action atoms entirely.
 	ReservedLabels map[string]bool
+
+	// VlanInMetadata declares that at this host the kernel has already
+	// extracted the outer VLAN tag into skb metadata (skb->vlan_tci)
+	// before the program runs, so it is NOT present in the packet bytes
+	// the filter parses. This is the case at the tc (SCHED_CLS) attach
+	// point, where skb_vlan_untag fires before the program. The zero
+	// value (false) assumes VLAN is in-band — correct for XDP and for
+	// the target-agnostic BPF_PROG_TEST_RUN harness, which feed raw
+	// frames with the tag present.
+	//
+	// When true, kunai rejects any chain containing a vlan or qinq
+	// layer at compile time rather than silently parsing the wrong
+	// bytes. Reading the tag from skb metadata is future work.
+	VlanInMetadata bool
 }
 
 // HasActionAtoms reports whether the caps configure an action map +

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -298,6 +298,9 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	if err := checkUnsupported(p); err != nil {
 		return Output{}, err
 	}
+	if err := checkHostLayerSupport(p, caps); err != nil {
+		return Output{}, err
+	}
 	capInfo, where, err := computeCapture(p, p.Where)
 	if err != nil {
 		return Output{}, err
@@ -621,6 +624,39 @@ func checkUnsupported(p *ir.Program) error {
 		// Unsupported marker set by the resolver (PredIn, PredHas) is
 		// surfaced there. Alternation groups have their own MVP
 		// constraints enforced by genAlternation.
+	}
+	return nil
+}
+
+// checkHostLayerSupport rejects chains the target host cannot match by
+// parsing packet bytes. Currently this guards VLAN: when the host has
+// caps.VlanInMetadata set (e.g. tc, where skb_vlan_untag moves the
+// outer tag into skb metadata before the program runs), a vlan or qinq
+// layer in the chain would parse the wrong bytes. We fail at compile
+// time with a clear message instead of silently mis-matching. Reading
+// the tag from skb metadata is future work; see caps.VlanInMetadata.
+func checkHostLayerSupport(p *ir.Program, caps Capabilities) error {
+	if !caps.VlanInMetadata {
+		return nil
+	}
+	isVlan := func(l *ir.LayerInstance) bool {
+		return l != nil && l.Spec != nil && (l.Spec.Name == "vlan" || l.Spec.Name == "qinq")
+	}
+	reject := func(l *ir.LayerInstance) error {
+		return withPos(fmt.Errorf("%w: layer %q cannot be matched at this host: the kernel extracts the outer VLAN tag into skb metadata before the program runs, so it is not present in the packet bytes (matching VLAN from skb metadata is future work)", ErrNotImplemented, l.Spec.Name), l.Pos)
+	}
+	for _, l := range p.Layers {
+		if isVlan(l) {
+			return reject(l)
+		}
+		// vlan/qinq may also appear inside an alternation group, e.g.
+		// eth/(vlan|qinq)/ipv4/tcp; those alternatives are not
+		// top-level p.Layers entries.
+		for _, alt := range l.Alternation {
+			if isVlan(alt) {
+				return reject(alt)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -369,8 +369,8 @@ func TestCompileBitSliceNonAligned(t *testing.T) {
 	for _, expr := range []string{
 		"eth/ipv6/tcp where ipv6.src[3:9] == 1",     // sub-byte within first byte
 		"eth/ipv6/tcp where ipv6.src[4:12] == 0xff", // crosses byte boundary
-		"eth/ipv6/tcp where ipv6.src[0:24] == 0xa0",  // byte-aligned but odd byte count
-		"eth/ipv6[src[3:9]==1]/tcp",                  // bracket form
+		"eth/ipv6/tcp where ipv6.src[0:24] == 0xa0", // byte-aligned but odd byte count
+		"eth/ipv6[src[3:9]==1]/tcp",                 // bracket form
 	} {
 		t.Run(expr, func(t *testing.T) {
 			insns, err := compileForTest(expr)
@@ -945,6 +945,38 @@ func isHostOwned(ins asm.Instruction) bool {
 		return true
 	}
 	return false
+}
+
+// TestVlanInMetadataRejectsVlanLayers asserts that a host advertising
+// VlanInMetadata (e.g. tc, where the kernel strips the outer VLAN tag
+// into skb metadata before the program runs) rejects any chain with a
+// vlan or qinq layer at compile time, rather than silently parsing the
+// wrong bytes. The same expressions must still compile under the zero
+// (in-band) Capabilities used by XDP and the test harness.
+func TestVlanInMetadataRejectsVlanLayers(t *testing.T) {
+	rejected := []string{
+		"eth/vlan[tci==100]/ipv4/tcp where tcp.dport == 80",
+		"eth/qinq/vlan/ipv4/tcp where tcp.dport == 80",
+		"eth/vlan?/ipv4/tcp",
+		"eth/(vlan|qinq)/ipv4/tcp",
+	}
+	tcCaps := codegen.Capabilities{VlanInMetadata: true}
+	for _, expr := range rejected {
+		t.Run("reject/"+expr, func(t *testing.T) {
+			_, err := Compile(expr, tcCaps)
+			if err == nil {
+				t.Fatalf("Compile(%q) with VlanInMetadata: expected rejection, got nil", expr)
+			}
+			if !errors.Is(err, codegen.ErrNotImplemented) {
+				t.Fatalf("Compile(%q): expected ErrNotImplemented, got %v", expr, err)
+			}
+		})
+		t.Run("allow/"+expr, func(t *testing.T) {
+			if _, err := Compile(expr, codegen.Capabilities{}); err != nil {
+				t.Fatalf("Compile(%q) with zero caps: expected success, got %v", expr, err)
+			}
+		})
+	}
 }
 
 // Cache correctness for dslvocab.Bundled is covered in its own

--- a/pkg/kunai/host/tc/tc.go
+++ b/pkg/kunai/host/tc/tc.go
@@ -52,11 +52,26 @@ func (fexitFetcher) EmitFetch(dst asm.Register) asm.Instructions {
 // FexitCapabilities returns the standard codegen.Capabilities for
 // hosts attached as fexit on a tc clsact program. The parser-side
 // reservation of "TC_ACT_*" labels is derived automatically from
-// Actions by kunai.Compile, so the returned struct only sets the two
-// required fields.
+// Actions by kunai.Compile. VlanInMetadata is set because at the tc
+// attach point the kernel has already extracted the outer VLAN tag
+// into skb metadata, so vlan/qinq layers cannot be matched from packet
+// bytes.
 func FexitCapabilities() codegen.Capabilities {
 	return codegen.Capabilities{
-		Action:        Actions,
-		ActionFetcher: FexitFetcher(),
+		Action:         Actions,
+		ActionFetcher:  FexitFetcher(),
+		VlanInMetadata: true,
+	}
+}
+
+// EntryCapabilities returns the codegen.Capabilities for hosts attached
+// as fentry on a tc clsact program. fentry has no action value yet, so
+// action atoms are disabled (Action nil); the only tc-specific bit is
+// VlanInMetadata, which holds at the tc attach point regardless of
+// entry vs fexit because the kernel strips the outer VLAN tag into skb
+// metadata before the program runs.
+func EntryCapabilities() codegen.Capabilities {
+	return codegen.Capabilities{
+		VlanInMetadata: true,
 	}
 }


### PR DESCRIPTION
## Summary

At the tc (SCHED_CLS) attach point the kernel runs `skb_vlan_untag` before the program, moving the outer VLAN tag into skb metadata, so the tag is **absent from the packet bytes** kunai parses. Filters with a `vlan`/`qinq` layer (F4, F5, and corpus D00/D01/D04/D07/E00/E03) silently mis-matched at tc despite compiling and loading cleanly.

This adds `codegen.Capabilities.VlanInMetadata`:

- The tc host opts in for both entry and fexit; XDP keeps the zero value because VLAN is in-band there.
- When set, codegen rejects any `vlan`/`qinq` layer (including inside an alternation group) at compile time with `ErrNotImplemented` instead of emitting a wrong-offset parse.
- The flag is **opt-in for the exceptional host**, so the zero-value `Capabilities{}` used in ~85 call sites (and dsltest, which feeds in-band frames) is unaffected.

Matching VLAN from skb metadata (reading `skb->vlan_tci`) is left as future work — QinQ is the messy case (outer tag in metadata, inner in-band).

## Verifier-matrix impact

tc no longer loads the 8 VLAN-bearing filters per kernel. New counts: XDP 78/78, tc 70/78 per kernel; 5 kernels → 740 trials (was 780), all pass on first attempt. The paper (`docs/paper/...`) is updated separately to reflect this.

## Test plan

- [x] `go test ./pkg/... ./internal/...` (no-root) green
- [x] `go vet ./...` clean, `golangci-lint` 0 issues (pre-commit)
- [x] sudo BPF load tests on kernel 6.15: tc skips F4/F5 + 6 corpus VLAN entries, all other filters load; XDP loads F4/F5 and all corpus
- [x] new `TestVlanInMetadataRejectsVlanLayers` asserts rejection under tc caps and success under zero/XDP caps
- [ ] CI 5-kernel matrix (6.1/6.6/6.12/6.18/7.0) confirms the new counts