### PR TITLE
refactor(kunai): split Capabilities into phase-scoped groups

### DIFF
--- a/pkg/kunai/README.md
+++ b/pkg/kunai/README.md
@@ -92,16 +92,32 @@ The public surface is intentionally tiny. Sub-packages are exported but consider
 // kunai
 func Compile(expr string, caps codegen.Capabilities) (codegen.Output, error)
 
-// codegen
+// codegen — three phase-scoped groups composed into a thin aggregate.
 type Capabilities struct {
+    Lex  LexCaps  // parser: label reservation
+    Lang LangCaps // resolver + codegen: action atoms
+    Host HostLayout // codegen: host packet-layout facts
+}
+
+type LexCaps struct {
+    // ReservedLabels: symbol names @label cannot collide with.
+    // nil → derived from Lang.Action keys by Compile.
+    ReservedLabels map[string]bool
+}
+
+type LangCaps struct {
     // Action: symbolic name → integer for `where action == NAME`.
     // nil disables action atoms (the resolver rejects them).
     Action map[string]int32
     // ActionFetcher emits insns that load the action u32 into R3.
     // Required iff Action is non-nil.
     ActionFetcher ActionFetcher
-    // ReservedLabels: symbol names @label cannot collide with.
-    ReservedLabels map[string]bool
+}
+
+type HostLayout struct {
+    // VlanInMetadata: the kernel pre-extracted the outer VLAN tag into
+    // skb metadata (tc), so vlan/qinq layers are rejected at compile.
+    VlanInMetadata bool
 }
 
 type ActionFetcher interface {

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -2,35 +2,54 @@ package codegen
 
 import "github.com/cilium/ebpf/asm"
 
-// Capabilities tells the compiler what host-specific DSL extensions
-// are available at runtime. The zero value yields a fully
-// target-agnostic filter — no action atoms, no host-specific
-// reservations, just protocol-stack matching and where/capture
-// clauses. That output is portable across any BPF attach point that
-// supplies the runFilter ABI documented in this package's doc comment.
+// Capabilities is the thin aggregate a host hands to kunai.Compile. It
+// composes three phase-scoped capability groups, each consumed by a
+// single pipeline phase, so no phase has to reach into a grab-bag of
+// unrelated fields:
 //
-// Hosts construct a Capabilities value from their own host adapter
-// package — for example, pkg/kunai/host/xdp.FexitCapabilities() for
-// an XDP fexit attach point — and pass it to kunai.Compile. The
-// kunai core ships no host-specific helpers itself; sub-packages
-// under pkg/kunai/host/ encapsulate that knowledge.
+//   - Lex  → the parser (label reservation)
+//   - Lang → the resolver and codegen (action atoms)
+//   - Host → codegen (host packet-layout facts)
 //
-// Treat a Capabilities value as immutable after construction: the
-// compile pipeline only reads from the maps and the fetcher; multiple
-// goroutines may share the same value safely as long as no caller
-// mutates the maps.
+// The zero value yields a fully target-agnostic filter — no action
+// atoms, no reservations, VLAN assumed in-band — portable across any
+// BPF attach point that supplies the runFilter ABI documented in this
+// package's doc comment.
 //
-// Future host-specific operations (e.g. XDP's packet-resize helpers
-// or skb metadata access) extend this struct with additional hook
-// fields; the contract is always "kunai stays target-agnostic, the
-// host adapter contributes the per-target wiring".
+// Hosts construct a Capabilities from their own adapter package — e.g.
+// pkg/kunai/host/xdp.FexitCapabilities() — and pass it to kunai.Compile.
+// The kunai core ships no host-specific helpers itself.
+//
+// Treat a Capabilities (and its groups) as immutable after
+// construction: the compile pipeline only reads the maps and the
+// fetcher, so multiple goroutines may share one value safely as long
+// as no caller mutates the maps.
 type Capabilities struct {
+	Lex  LexCaps
+	Lang LangCaps
+	Host HostLayout
+}
+
+// LexCaps carries the capabilities the parser needs.
+type LexCaps struct {
+	// ReservedLabels names that DSL @labels must not collide with.
+	// Typically the keys of LangCaps.Action (so a label named "XDP_DROP"
+	// cannot shadow the action symbol); kunai.Compile derives that set
+	// automatically when this is nil. nil means no reservations.
+	ReservedLabels map[string]bool
+}
+
+// LangCaps carries the host-specific language extensions: the action
+// atom vocabulary and the fetcher that loads the action value. The
+// resolver reads Action (to validate `where action == NAME`); codegen
+// reads both (to emit the comparison).
+type LangCaps struct {
 	// Action: symbolic name → integer constant for `where action == NAME`
 	// clauses. Keys (e.g. "XDP_DROP") are the symbols accepted in DSL
 	// expressions; values are the integers the action register is
 	// compared against. nil disables action atoms entirely — both the
-	// parser (label reservation) and resolver (atom validity) treat
-	// `action == ...` as an error.
+	// resolver (atom validity) and codegen treat `action == ...` as an
+	// error.
 	//
 	// Pair Action with a non-nil ActionFetcher.
 	Action map[string]int32
@@ -41,13 +60,18 @@ type Capabilities struct {
 	// XDP fexit reads stack[-48] then args[1]); host adapter packages
 	// provide ready-made implementations.
 	ActionFetcher ActionFetcher
+}
 
-	// ReservedLabels names that DSL @labels must not collide with.
-	// Typically the keys of Action (so a label named "XDP_DROP" cannot
-	// shadow the action symbol). nil means no reservations — useful
-	// for hosts that disable action atoms entirely.
-	ReservedLabels map[string]bool
+// HasActionAtoms reports whether the lang caps configure an action map
+// + fetcher pair. Used by the resolver to short-circuit `action == X`
+// validation when the host has not opted in.
+func (l LangCaps) HasActionAtoms() bool {
+	return l.Action != nil && l.ActionFetcher != nil
+}
 
+// HostLayout carries facts about how the host presents packet bytes to
+// the filter — independent of the language extensions in LangCaps.
+type HostLayout struct {
 	// VlanInMetadata declares that at this host the kernel has already
 	// extracted the outer VLAN tag into skb metadata (skb->vlan_tci)
 	// before the program runs, so it is NOT present in the packet bytes
@@ -61,13 +85,6 @@ type Capabilities struct {
 	// layer at compile time rather than silently parsing the wrong
 	// bytes. Reading the tag from skb metadata is future work.
 	VlanInMetadata bool
-}
-
-// HasActionAtoms reports whether the caps configure an action map +
-// fetcher pair. Used by the resolver to short-circuit `action == X`
-// validation when the host has not opted in.
-func (c Capabilities) HasActionAtoms() bool {
-	return c.Action != nil && c.ActionFetcher != nil
 }
 
 // ActionFetcher loads the current action value into a register so the

--- a/pkg/kunai/codegen/caps_test.go
+++ b/pkg/kunai/codegen/caps_test.go
@@ -33,8 +33,7 @@ func xdpFexitCapsForTest() Capabilities {
 		reserved[k] = true
 	}
 	return Capabilities{
-		Action:         testActions,
-		ActionFetcher:  testFexitFetcher{},
-		ReservedLabels: reserved,
+		Lex:  LexCaps{ReservedLabels: reserved},
+		Lang: LangCaps{Action: testActions, ActionFetcher: testFexitFetcher{}},
 	}
 }

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -298,7 +298,7 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	if err := checkUnsupported(p); err != nil {
 		return Output{}, err
 	}
-	if err := checkHostLayerSupport(p, caps); err != nil {
+	if err := checkHostLayerSupport(p, caps.Host); err != nil {
 		return Output{}, err
 	}
 	capInfo, where, err := computeCapture(p, p.Where)
@@ -352,7 +352,7 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	// layer-level mismatch. `where` may include conditions merged in
 	// from per-capture clauses (see computeCapture).
 	if where != nil {
-		whereInsns, err := genCondition(where, caps, p, qo, dslReject)
+		whereInsns, err := genCondition(where, caps.Lang, p, qo, dslReject)
 		if err != nil {
 			return Output{}, err
 		}
@@ -630,13 +630,13 @@ func checkUnsupported(p *ir.Program) error {
 
 // checkHostLayerSupport rejects chains the target host cannot match by
 // parsing packet bytes. Currently this guards VLAN: when the host has
-// caps.VlanInMetadata set (e.g. tc, where skb_vlan_untag moves the
+// HostLayout.VlanInMetadata set (e.g. tc, where skb_vlan_untag moves the
 // outer tag into skb metadata before the program runs), a vlan or qinq
 // layer in the chain would parse the wrong bytes. We fail at compile
 // time with a clear message instead of silently mis-matching. Reading
-// the tag from skb metadata is future work; see caps.VlanInMetadata.
-func checkHostLayerSupport(p *ir.Program, caps Capabilities) error {
-	if !caps.VlanInMetadata {
+// the tag from skb metadata is future work; see HostLayout.VlanInMetadata.
+func checkHostLayerSupport(p *ir.Program, host HostLayout) error {
+	if !host.VlanInMetadata {
 		return nil
 	}
 	isVlan := func(l *ir.LayerInstance) bool {

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -19,7 +19,7 @@ import (
 // cache.
 type whereCtx struct {
 	p       *ir.Program
-	caps    Capabilities
+	lang    LangCaps
 	labels  int
 	anchors map[*ir.LayerInstance]layerAnchor
 	queried queriedOptions
@@ -90,8 +90,8 @@ func layerSpecName(l *ir.LayerInstance) string {
 // to true and jump to failLabel when it evaluates to false. Errors
 // surface with the condition's source position prefixed so users see
 // which `where` atom blew up.
-func genCondition(w *ir.Condition, caps Capabilities, p *ir.Program, qo queriedOptions, failLabel string) (asm.Instructions, error) {
-	ctx := &whereCtx{p: p, caps: caps, anchors: make(map[*ir.LayerInstance]layerAnchor), queried: qo}
+func genCondition(w *ir.Condition, lang LangCaps, p *ir.Program, qo queriedOptions, failLabel string) (asm.Instructions, error) {
+	ctx := &whereCtx{p: p, lang: lang, anchors: make(map[*ir.LayerInstance]layerAnchor), queried: qo}
 	insns, err := ctx.gen(w, failLabel)
 	return insns, withPos(err, w.Pos)
 }
@@ -105,7 +105,7 @@ func (c *whereCtx) gen(w *ir.Condition, failLabel string) (asm.Instructions, err
 	}
 	switch w.Kind {
 	case ast.WAtomAction:
-		return genActionAtom(w, c.caps, failLabel)
+		return genActionAtom(w, c.lang, failLabel)
 	case ast.WAtomArith:
 		return c.genArithCompare(w, failLabel)
 	case ast.WAtomLiteralCmp:
@@ -1316,15 +1316,15 @@ func altPrefixSizeRange(alts []*ir.LayerInstance) (min, max int, err error) {
 // u32 in R3. When caps disable action atoms (Action map nil or
 // fetcher nil) this returns ErrNotImplemented — the resolver
 // normally catches that earlier with a clearer message.
-func genActionAtom(w *ir.Condition, caps Capabilities, failLabel string) (asm.Instructions, error) {
-	if !caps.HasActionAtoms() {
-		return nil, fmt.Errorf("%w: `action == %s` is not available on this host (caps.Action is nil)", ErrNotImplemented, w.ActionValue)
+func genActionAtom(w *ir.Condition, lang LangCaps, failLabel string) (asm.Instructions, error) {
+	if !lang.HasActionAtoms() {
+		return nil, fmt.Errorf("%w: `action == %s` is not available on this host (action atoms require both LangCaps.Action and LangCaps.ActionFetcher to be set)", ErrNotImplemented, w.ActionValue)
 	}
-	val, ok := caps.Action[w.ActionValue]
+	val, ok := lang.Action[w.ActionValue]
 	if !ok {
-		return nil, fmt.Errorf("codegen: unknown action %q (host caps.Action has %d entries)", w.ActionValue, len(caps.Action))
+		return nil, fmt.Errorf("codegen: unknown action %q (host LangCaps.Action has %d entries)", w.ActionValue, len(lang.Action))
 	}
-	insns := caps.ActionFetcher.EmitFetch(asm.R3)
+	insns := lang.ActionFetcher.EmitFetch(asm.R3)
 	// 32-bit JNE so signed action values (e.g. TC_ACT_UNSPEC = -1)
 	// compare against R3's low 32 bits without 64-bit sign-extension
 	// of the immediate. R3 is loaded zero-extended via Word LDX, so

--- a/pkg/kunai/compile.go
+++ b/pkg/kunai/compile.go
@@ -57,7 +57,7 @@ func CompileWithVocab(expr string, v map[string]*vocab.ProtocolSpec, caps codege
 	if err != nil {
 		return codegen.Output{}, err
 	}
-	prog, err := resolve.Resolve(f, v, caps.Action)
+	prog, err := resolve.Resolve(f, v, caps.Lang.Action)
 	if err != nil {
 		return codegen.Output{}, err
 	}
@@ -65,19 +65,19 @@ func CompileWithVocab(expr string, v map[string]*vocab.ProtocolSpec, caps codege
 }
 
 // reservedLabels picks the parser's @label rejection set: caller
-// override if non-nil, else derive from caps.Action keys (the common
-// case — a host that exposes XDP_DROP probably wants the label
-// "XDP_DROP" reserved too). Returns nil when neither source applies,
-// which the parser interprets as "no reservations".
+// override if Lex.ReservedLabels is non-nil, else derive from
+// Lang.Action keys (the common case — a host that exposes XDP_DROP
+// probably wants the label "XDP_DROP" reserved too). Returns nil when
+// neither source applies, which the parser reads as "no reservations".
 func reservedLabels(caps codegen.Capabilities) map[string]bool {
-	if caps.ReservedLabels != nil {
-		return caps.ReservedLabels
+	if caps.Lex.ReservedLabels != nil {
+		return caps.Lex.ReservedLabels
 	}
-	if caps.Action == nil {
+	if caps.Lang.Action == nil {
 		return nil
 	}
-	out := make(map[string]bool, len(caps.Action))
-	for k := range caps.Action {
+	out := make(map[string]bool, len(caps.Lang.Action))
+	for k := range caps.Lang.Action {
 		out[k] = true
 	}
 	return out

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -960,7 +960,7 @@ func TestVlanInMetadataRejectsVlanLayers(t *testing.T) {
 		"eth/vlan?/ipv4/tcp",
 		"eth/(vlan|qinq)/ipv4/tcp",
 	}
-	tcCaps := codegen.Capabilities{VlanInMetadata: true}
+	tcCaps := codegen.Capabilities{Host: codegen.HostLayout{VlanInMetadata: true}}
 	for _, expr := range rejected {
 		t.Run("reject/"+expr, func(t *testing.T) {
 			_, err := Compile(expr, tcCaps)

--- a/pkg/kunai/host/tc/tc.go
+++ b/pkg/kunai/host/tc/tc.go
@@ -50,28 +50,30 @@ func (fexitFetcher) EmitFetch(dst asm.Register) asm.Instructions {
 }
 
 // FexitCapabilities returns the standard codegen.Capabilities for
-// hosts attached as fexit on a tc clsact program. The parser-side
-// reservation of "TC_ACT_*" labels is derived automatically from
-// Actions by kunai.Compile. VlanInMetadata is set because at the tc
-// attach point the kernel has already extracted the outer VLAN tag
-// into skb metadata, so vlan/qinq layers cannot be matched from packet
-// bytes.
+// hosts attached as fexit on a tc clsact program. The Lang group
+// carries the TC_ACT_* action atoms (parser label reservation is
+// derived from Lang.Action by kunai.Compile); Host.VlanInMetadata is
+// set because at the tc attach point the kernel has already extracted
+// the outer VLAN tag into skb metadata, so vlan/qinq layers cannot be
+// matched from packet bytes.
 func FexitCapabilities() codegen.Capabilities {
 	return codegen.Capabilities{
-		Action:         Actions,
-		ActionFetcher:  FexitFetcher(),
-		VlanInMetadata: true,
+		Lang: codegen.LangCaps{
+			Action:        Actions,
+			ActionFetcher: FexitFetcher(),
+		},
+		Host: codegen.HostLayout{VlanInMetadata: true},
 	}
 }
 
 // EntryCapabilities returns the codegen.Capabilities for hosts attached
 // as fentry on a tc clsact program. fentry has no action value yet, so
-// action atoms are disabled (Action nil); the only tc-specific bit is
-// VlanInMetadata, which holds at the tc attach point regardless of
+// the Lang group stays empty; the only tc-specific bit is
+// Host.VlanInMetadata, which holds at the tc attach point regardless of
 // entry vs fexit because the kernel strips the outer VLAN tag into skb
 // metadata before the program runs.
 func EntryCapabilities() codegen.Capabilities {
 	return codegen.Capabilities{
-		VlanInMetadata: true,
+		Host: codegen.HostLayout{VlanInMetadata: true},
 	}
 }

--- a/pkg/kunai/host/tc/tc_test.go
+++ b/pkg/kunai/host/tc/tc_test.go
@@ -74,16 +74,16 @@ func TestFexitFetcherEmitFetchHonorsDstReg(t *testing.T) {
 // TestFexitCapabilities pins the Capabilities struct shape for tc.
 func TestFexitCapabilities(t *testing.T) {
 	caps := FexitCapabilities()
-	if caps.Action == nil {
-		t.Fatal("Capabilities.Action is nil")
+	if caps.Lang.Action == nil {
+		t.Fatal("Capabilities.Lang.Action is nil")
 	}
-	if len(caps.Action) != len(Actions) {
-		t.Errorf("caps.Action has %d entries, want %d", len(caps.Action), len(Actions))
+	if len(caps.Lang.Action) != len(Actions) {
+		t.Errorf("caps.Lang.Action has %d entries, want %d", len(caps.Lang.Action), len(Actions))
 	}
-	if caps.ActionFetcher == nil {
-		t.Fatal("Capabilities.ActionFetcher is nil")
+	if caps.Lang.ActionFetcher == nil {
+		t.Fatal("Capabilities.Lang.ActionFetcher is nil")
 	}
-	insns := caps.ActionFetcher.EmitFetch(asm.R3)
+	insns := caps.Lang.ActionFetcher.EmitFetch(asm.R3)
 	if len(insns) != 2 {
 		t.Errorf("caps.ActionFetcher.EmitFetch returned %d insns, want 2", len(insns))
 	}

--- a/pkg/kunai/host/xdp/xdp.go
+++ b/pkg/kunai/host/xdp/xdp.go
@@ -53,13 +53,15 @@ func (fexitFetcher) EmitFetch(dst asm.Register) asm.Instructions {
 }
 
 // FexitCapabilities returns the standard codegen.Capabilities for
-// hosts attached as fexit on an XDP program. The parser-side
-// reservation of "XDP_*" labels is derived automatically from
-// Actions by kunai.Compile, so the returned struct only sets the
-// two required fields.
+// hosts attached as fexit on an XDP program. Only the Lang group is
+// populated; the parser-side reservation of "XDP_*" labels is derived
+// automatically from Lang.Action by kunai.Compile, and XDP keeps VLAN
+// in-band so Host stays zero.
 func FexitCapabilities() codegen.Capabilities {
 	return codegen.Capabilities{
-		Action:        Actions,
-		ActionFetcher: FexitFetcher(),
+		Lang: codegen.LangCaps{
+			Action:        Actions,
+			ActionFetcher: FexitFetcher(),
+		},
 	}
 }

--- a/pkg/kunai/host/xdp/xdp_test.go
+++ b/pkg/kunai/host/xdp/xdp_test.go
@@ -81,16 +81,16 @@ func TestFexitFetcherEmitFetchHonorsDstReg(t *testing.T) {
 // returns the same 2-insn shape EmitFetch above pins.
 func TestFexitCapabilities(t *testing.T) {
 	caps := FexitCapabilities()
-	if caps.Action == nil {
-		t.Fatal("Capabilities.Action is nil")
+	if caps.Lang.Action == nil {
+		t.Fatal("Capabilities.Lang.Action is nil")
 	}
-	if len(caps.Action) != len(Actions) {
-		t.Errorf("caps.Action has %d entries, want %d (matching pkg-level Actions)", len(caps.Action), len(Actions))
+	if len(caps.Lang.Action) != len(Actions) {
+		t.Errorf("caps.Lang.Action has %d entries, want %d (matching pkg-level Actions)", len(caps.Lang.Action), len(Actions))
 	}
-	if caps.ActionFetcher == nil {
-		t.Fatal("Capabilities.ActionFetcher is nil")
+	if caps.Lang.ActionFetcher == nil {
+		t.Fatal("Capabilities.Lang.ActionFetcher is nil")
 	}
-	insns := caps.ActionFetcher.EmitFetch(asm.R3)
+	insns := caps.Lang.ActionFetcher.EmitFetch(asm.R3)
 	if len(insns) != 2 {
 		t.Errorf("caps.ActionFetcher.EmitFetch returned %d insns, want 2", len(insns))
 	}


### PR DESCRIPTION
## Summary

OCR design review (Ousterhout / Hickey / Hejlsberg) flagged `codegen.Capabilities` as one struct braiding three concerns, each consumed by a different pipeline phase:

- `ReservedLabels` → parser
- `Action` / `ActionFetcher` → resolver + codegen
- `VlanInMetadata` → codegen

Each phase reached into a grab-bag for one field (Hickey's "complecting" finding, reinforced by Ousterhout).

This splits it into three phase-scoped public types composed into a thin aggregate:

```go
type Capabilities struct {
    Lex  LexCaps    // parser: ReservedLabels
    Lang LangCaps   // resolver + codegen: Action, ActionFetcher (+ HasActionAtoms)
    Host HostLayout // codegen: VlanInMetadata
}
```

- `kunai.Compile` keeps its arity (`Compile(expr, Capabilities)`).
- Each phase receives only its group: parser ← `Lex` (via `reservedLabels`), resolve ← `Lang.Action`, `genCondition` ← `Lang`, `checkHostLayerSupport` ← `Host`.
- `HasActionAtoms` moves to `LangCaps`.
- Host adapters (`xdphost`/`tchost`) build the nested form.
- **Zero-value `Capabilities{}` is unchanged**, so the ~84 codegen/compile test sites that pass it are untouched; `codegen.Gen` keeps taking the aggregate to preserve that.

Pure type reshape, no behavior change.

## Test plan

- [x] `go test ./pkg/... ./internal/...` (no-root) green
- [x] `go vet ./...` clean; pre-commit `golangci-lint` 0 issues
- [x] sudo BPF load sanity on kernel 6.15: `TestBpfFilterSetXDP` + `TestBpfEntryWithDSLFilterTC` pass (nested host caps reach verifier load)
- [ ] CI 5-kernel BPF matrix