### PR TITLE
fix(codegen): make dispatch reads PTR_TO_PACKET-safe for native XDP

### DIFF
--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -62,13 +62,13 @@ var FilterSet = []FilterSpec{
 		CBPFCExpr: "icmp[icmptype]==8",
 		WantInsns: 83, Notes: "ICMP echo request"},
 	{ID: "F7", Expr: "eth/ipv4@outer/udp/gtp/ipv4@inner/tcp where inner.dst == 10.0.0.1",
-		WantInsns: 391, Notes: "GTP-U inner IPv4 dst (5G core)"},
+		WantInsns: 403, Notes: "GTP-U inner IPv4 dst (5G core)"},
 	{ID: "F8", Expr: "eth/ipv6/srv6 where any(srv6.segments.addr == fc00::1)",
 		WantInsns: 425, Notes: "SRv6 segment-list any-quantifier (5G/SDN)"},
 	{ID: "F9", Expr: "eth/ipv4@outer/udp/geneve/eth/ipv4@inner/tcp where inner.dst == 10.0.0.1",
-		WantInsns: 281, Notes: "Geneve inner IPv4 dst (Cilium overlay / cloud VPC)"},
+		WantInsns: 299, Notes: "Geneve inner IPv4 dst (Cilium overlay / cloud VPC)"},
 	{ID: "F10", Expr: "eth/ipv4/tcp where tcp.options.MSS.value == 1460",
-		WantInsns: 227, Notes: "TCP option MSS via parser-counter walk"},
+		WantInsns: 230, Notes: "TCP option MSS via parser-counter walk"},
 }
 
 // TestFilterSetCompiles confirms every paper filter compiles end-to-end

--- a/internal/program/xdpnative_filterset_test.go
+++ b/internal/program/xdpnative_filterset_test.go
@@ -1,0 +1,27 @@
+package program
+
+// Native-XDP verifier-load coverage for the canonical F1-F10 set.
+//
+// The native path runs the kunai filter directly on ctx->data
+// (PTR_TO_PACKET) instead of the fentry/tc scratch-window copy
+// (PTR_TO_MAP_VALUE). Aux-walk filters (GTP / Geneve / TCP options)
+// used to fail here: dispatch read-backs and the option-walk kind
+// load assumed a map-value bound that the verifier will not carry
+// across a freshly built packet pointer. genFieldDispatch /
+// emitDynamicAuxSlotPrelude now switch to the bounded idiom when R4
+// is a range scalar, so every FilterSet entry must load natively.
+
+import (
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+func TestBpfXDPNativeFilterSet(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+	for _, fs := range FilterSet {
+		t.Run(fs.ID, func(t *testing.T) {
+			loadXDPNativeOrFail(t, fs.Expr, true)
+		})
+	}
+}

--- a/pkg/kunai/codegen/chain.go
+++ b/pkg/kunai/codegen/chain.go
@@ -79,12 +79,17 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 	}
 
 	chainDone := fmt.Sprintf("dsl_chain_done_%d", index)
+	// Self-repeating layer: the dispatch parent is this same layer, so
+	// R4-range and parent-entry-range both reduce to "did anything
+	// before this layer leave R4 a range scalar". Computed once outside
+	// the unroll loop since it is invariant across iterations.
+	selfRange := precedingLayersLeaveR4Range(all, index)
 	for i := 1; i < layer.RangeMax; i++ {
 		failLabel := dslReject
 		if i >= layer.RangeMin {
 			failLabel = chainDone
 		}
-		dispatch, err := genDispatch(selfLayer, layer, hs, failLabel)
+		dispatch, err := genDispatch(selfLayer, layer, hs, selfRange, selfRange, failLabel)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -473,8 +473,14 @@ func emitFieldDispatchCheck(
 // fixed parent, or the parent's layer-entry slot value for a
 // parser-machine parent — loaded by the caller). byteOff is the
 // field's offset relative to that base and may be negative (reading
-// back into the parent header). scalar/dst are caller-provided
-// scratch registers, both distinct from offsetReg, R0 and R1.
+// back into the parent header).
+//
+// Register constraints: scalar receives the folded offset and stays
+// live across the load, so it must differ from offsetReg, dst, R0 and
+// R1. dst is written only by the bounded load, after the fold has
+// already consumed offsetReg, so dst MAY alias offsetReg (the
+// variable-parent caller does exactly this to free a register) but
+// must differ from scalar, R0 and R1.
 func emitFieldDispatchCheckBounded(
 	spec *vocab.ProtocolSpec,
 	c *vocab.DispatchConst,

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -119,28 +119,28 @@ func withPos(err error, pos ast.Position) error {
 // well-typed but the BPF emitter does not yet cover the required
 // shape. Two flavours coexist under this single error:
 //
-//   1. Codegen staging declared by docs/ja/dsl-types.md §9.1 — the
-//      resolver accepts the program, but the spec deliberately
-//      defers the BPF expansion until follow-up work lands. Current
-//      staging cases:
-//        - Int<N> ordered comparison with N > 64 (F3 in
-//          dsl-followups.md): lexicographic cmp not yet wired up,
-//        - Int<128> arithmetic binary ops (+, -, *) (F4/F5):
-//          register-pair carry propagation not yet wired up.
-//      User-visible programs hitting this branch are spec-correct;
-//      they need a kernel build with the staged emitter, not an
-//      expression rewrite.
+//  1. Codegen staging declared by docs/ja/dsl-types.md §9.1 — the
+//     resolver accepts the program, but the spec deliberately
+//     defers the BPF expansion until follow-up work lands. Current
+//     staging cases:
+//     - Int<N> ordered comparison with N > 64 (F3 in
+//     dsl-followups.md): lexicographic cmp not yet wired up,
+//     - Int<128> arithmetic binary ops (+, -, *) (F4/F5):
+//     register-pair carry propagation not yet wired up.
+//     User-visible programs hitting this branch are spec-correct;
+//     they need a kernel build with the staged emitter, not an
+//     expression rewrite.
 //
-//   2. MVP gaps that the resolver structurally lets through but
-//      codegen has yet to plumb. Examples:
-//        - dynamic aux header stack indices outside the static-fold
-//          path (fieldRefByteOffset),
-//        - TCP / IPv4 option lookups reaching the static-fold path
-//          instead of the option-walk emitter,
-//        - non-byte-aligned or oversized primary fields (> 8 bytes),
-//        - quantifier shapes the resolver accepts but emit has not
-//          covered yet.
-//      These are codegen TODOs rather than spec'd staging.
+//  2. MVP gaps that the resolver structurally lets through but
+//     codegen has yet to plumb. Examples:
+//     - dynamic aux header stack indices outside the static-fold
+//     path (fieldRefByteOffset),
+//     - TCP / IPv4 option lookups reaching the static-fold path
+//     instead of the option-walk emitter,
+//     - non-byte-aligned or oversized primary fields (> 8 bytes),
+//     - quantifier shapes the resolver accepts but emit has not
+//     covered yet.
+//     These are codegen TODOs rather than spec'd staging.
 //
 // Callers can match it with errors.Is to distinguish "valid DSL,
 // codegen still to come" from genuine type or vocabulary errors.
@@ -457,6 +457,63 @@ func emitFieldDispatchCheck(
 	return insns, nil
 }
 
+// emitFieldDispatchCheckBounded is the PTR_TO_PACKET-safe counterpart
+// of emitFieldDispatchCheck, used when R4 (the running layer offset)
+// may be a range scalar — i.e. some preceding layer was variable-
+// length, so the verifier cannot prove a fixed range for `R0 +
+// offsetReg` and rejects the negative-immediate readback that the
+// fast path emits. Mirrors emitKeyCompare's range branch: fold the
+// field's byte offset into a non-negative scalar, then run the
+// cbpfc-style end+JGT+LoadMem(-size) bounded load. Harmless (just
+// larger) on PTR_TO_MAP_VALUE, so the same bytecode loads on every
+// host; only filters whose dispatch sits behind a variable-length
+// layer take this path, leaving fixed-offset chains byte-identical.
+//
+// offsetReg holds the scalar base offset from R0 (offsetBase for a
+// fixed parent, or the parent's layer-entry slot value for a
+// parser-machine parent — loaded by the caller). byteOff is the
+// field's offset relative to that base and may be negative (reading
+// back into the parent header). scalar/dst are caller-provided
+// scratch registers, both distinct from offsetReg, R0 and R1.
+func emitFieldDispatchCheckBounded(
+	spec *vocab.ProtocolSpec,
+	c *vocab.DispatchConst,
+	offsetReg, scalar, dst asm.Register,
+	byteOff int,
+	failLabel string,
+) (asm.Instructions, error) {
+	fieldOff, fieldBytes, err := findFieldByteOffset(spec, c.FieldName)
+	if err != nil {
+		return nil, err
+	}
+	size, err := asmSizeFor(fieldBytes)
+	if err != nil {
+		return nil, err
+	}
+	expected := int32(byteSwap(c.Value, fieldBytes))
+	insns := foldOffsetIntoScalar(scalar, offsetReg, int32(fieldOff+byteOff), failLabel)
+	insns = append(insns, boundedScalarLoad(dst, asm.R0, scalar, asm.R1, size, failLabel)...)
+	insns = append(insns, asm.JNE.Imm(dst, expected, failLabel))
+	return insns, nil
+}
+
+// emitVarParentDispatchBounded is the PTR_TO_PACKET-safe dispatch for a
+// variable-layout parent whose entry offset may be a range scalar: load
+// the parent's layer-entry offset from its slot into R3, then bounded-
+// read the dispatch field at +fieldOff off that base. R3 doubles as
+// offset source and load destination (the fold consumes it before the
+// load overwrites it). Shared by genFieldDispatch and the alt-diverged
+// path so the slot-load + register aliasing live in one place.
+func emitVarParentDispatchBounded(spec *vocab.ProtocolSpec, c *vocab.DispatchConst, failLabel string) (asm.Instructions, error) {
+	check, err := emitFieldDispatchCheckBounded(spec, c, asm.R3, asm.R5, asm.R3, 0, failLabel)
+	if err != nil {
+		return nil, err
+	}
+	return append(asm.Instructions{
+		asm.LoadMem(asm.R3, asm.R10, bpfLoopCtxLayerEntrySlot, asm.DWord),
+	}, check...), nil
+}
+
 // offsetBase is the register that holds the byte offset from R0
 // (scratch buffer start) to the current layer's start. Each layer's
 // load instructions first compute `R3 = R0 + offsetBase`, then LDX
@@ -710,7 +767,7 @@ func genStaticLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 	insns := emitBounds(hs, dslReject)
 
 	if index > 0 && layer.Dispatch != nil {
-		di, err := genLayerDispatch(layer, all[index-1], dslReject)
+		di, err := genLayerDispatch(layer, all[index-1], precedingLayersLeaveR4Range(all, index), precedingLayersLeaveR4Range(all, index-1), dslReject)
 		if err != nil {
 			return nil, err
 		}
@@ -807,7 +864,6 @@ func variableTailSkipFromHeaderLength(vs *vocab.HeaderLength) variableTailSkip {
 	}
 }
 
-
 // genOptionalLayer emits the `?` quantifier: peek the dispatch check
 // from the parent; if it fails we skip the layer entirely without
 // advancing R4. If it succeeds we do the bounds check, predicates,
@@ -857,7 +913,7 @@ func emitPeekedIterZero(layer *ir.LayerInstance, index int, all []*ir.LayerInsta
 	if err != nil {
 		return nil, err
 	}
-	peek, err := genLayerDispatch(layer, all[index-1], peekFailLabel)
+	peek, err := genLayerDispatch(layer, all[index-1], precedingLayersLeaveR4Range(all, index), precedingLayersLeaveR4Range(all, index-1), peekFailLabel)
 	if err != nil {
 		return nil, err
 	}
@@ -873,10 +929,10 @@ func emitPeekedIterZero(layer *ir.LayerInstance, index int, all []*ir.LayerInsta
 	return out, nil
 }
 
-func genDispatch(current, parent *ir.LayerInstance, parentHS int, failLabel string) (asm.Instructions, error) {
+func genDispatch(current, parent *ir.LayerInstance, parentHS int, r4IsRange, parentEntryIsRange bool, failLabel string) (asm.Instructions, error) {
 	switch current.Dispatch.Type {
 	case vocab.DispatchField:
-		return genFieldDispatch(current, parent, parentHS, failLabel)
+		return genFieldDispatch(current, parent, parentHS, r4IsRange, parentEntryIsRange, failLabel)
 	case vocab.DispatchNoCheck:
 		return genNoCheckDispatch(current)
 	case vocab.DispatchSelfValidating:
@@ -900,7 +956,14 @@ func genDispatch(current, parent *ir.LayerInstance, parentHS int, failLabel stri
 // holds for the next layer). For non-diverged we keep the historical
 // behavior — collapse the alt group to its first member via
 // dispatchParent and call genDispatch as before.
-func genLayerDispatch(current, prev *ir.LayerInstance, failLabel string) (asm.Instructions, error) {
+// r4IsRange reports whether R4 (the current running offset) may be a
+// range scalar at this dispatch — drives the fixed-parent negative
+// readback's bounded form. parentEntryIsRange reports whether the
+// parent layer's entry offset may be a range scalar — drives the
+// variable-parent (layer-entry slot) forward read's bounded form.
+// Both default false for fully fixed-offset chains, which keeps their
+// bytecode byte-identical.
+func genLayerDispatch(current, prev *ir.LayerInstance, r4IsRange, parentEntryIsRange bool, failLabel string) (asm.Instructions, error) {
 	if current.Dispatch == nil {
 		return nil, nil
 	}
@@ -908,14 +971,14 @@ func genLayerDispatch(current, prev *ir.LayerInstance, failLabel string) (asm.In
 		if prev.Alternation == nil {
 			return nil, fmt.Errorf("codegen: IsAltDiverged dispatch on %q but parent is not an alt group (resolver bug)", current.Spec.Name)
 		}
-		return genFieldDispatchAltDiverged(current, prev.Alternation, failLabel)
+		return genFieldDispatchAltDiverged(current, prev.Alternation, r4IsRange, parentEntryIsRange, failLabel)
 	}
 	parent := dispatchParent(prev)
 	parentHS, err := headerSize(parent.Spec)
 	if err != nil {
 		return nil, err
 	}
-	return genDispatch(current, parent, parentHS, failLabel)
+	return genDispatch(current, parent, parentHS, r4IsRange, parentEntryIsRange, failLabel)
 }
 
 // genFieldDispatchAltDiverged emits per-alt dispatch for a layer
@@ -937,7 +1000,7 @@ func genLayerDispatch(current, prev *ir.LayerInstance, failLabel string) (asm.In
 //
 // The last alt has no skip / ja — matchedAltReg is guaranteed to be
 // N-1 if we got here (genAlternation set it before the fall-through).
-func genFieldDispatchAltDiverged(current *ir.LayerInstance, altParents []*ir.LayerInstance, failLabel string) (asm.Instructions, error) {
+func genFieldDispatchAltDiverged(current *ir.LayerInstance, altParents []*ir.LayerInstance, r4IsRange, parentEntryIsRange bool, failLabel string) (asm.Instructions, error) {
 	consts := current.Dispatch.AltConsts
 	if len(altParents) != len(consts) {
 		return nil, fmt.Errorf("codegen: alt parent count %d != AltConsts count %d (resolver bug)", len(altParents), len(consts))
@@ -957,33 +1020,46 @@ func genFieldDispatchAltDiverged(current *ir.LayerInstance, altParents []*ir.Lay
 			err   error
 		)
 		if altParent.Spec.HasVariableLayout() {
-			check, err = emitFieldDispatchCheck(
-				altParent.Spec,
-				consts[i],
-				0,
-				asm.R3,
-				asm.Instructions{
-					asm.LoadMem(asm.R3, asm.R10, bpfLoopCtxLayerEntrySlot, asm.DWord),
-					asm.Add.Reg(asm.R3, asm.R0),
-				},
-				failLabel,
-			)
+			// Forward read off the layer-entry slot; bounded when the
+			// parent entry may be a range scalar (see genFieldDispatch).
+			if parentEntryIsRange {
+				check, err = emitVarParentDispatchBounded(altParent.Spec, consts[i], failLabel)
+			} else {
+				check, err = emitFieldDispatchCheck(
+					altParent.Spec,
+					consts[i],
+					0,
+					asm.R3,
+					asm.Instructions{
+						asm.LoadMem(asm.R3, asm.R10, bpfLoopCtxLayerEntrySlot, asm.DWord),
+						asm.Add.Reg(asm.R3, asm.R0),
+					},
+					failLabel,
+				)
+			}
 		} else {
 			altParentHS, herr := headerSize(altParent.Spec)
 			if herr != nil {
 				return nil, herr
 			}
-			check, err = emitFieldDispatchCheck(
-				altParent.Spec,
-				consts[i],
-				altParentHS,
-				asm.R3,
-				asm.Instructions{
-					asm.Mov.Reg(asm.R3, asm.R0),
-					asm.Add.Reg(asm.R3, offsetBase),
-				},
-				failLabel,
-			)
+			if r4IsRange {
+				check, err = emitFieldDispatchCheckBounded(
+					altParent.Spec, consts[i],
+					offsetBase /*offsetReg=R4*/, asm.R5 /*scalar*/, asm.R3 /*dst*/, -altParentHS, failLabel,
+				)
+			} else {
+				check, err = emitFieldDispatchCheck(
+					altParent.Spec,
+					consts[i],
+					altParentHS,
+					asm.R3,
+					asm.Instructions{
+						asm.Mov.Reg(asm.R3, asm.R0),
+						asm.Add.Reg(asm.R3, offsetBase),
+					},
+					failLabel,
+				)
+			}
 		}
 		if err != nil {
 			return nil, err
@@ -1038,8 +1114,19 @@ func nextAltDispatchLabel(role string) string {
 // The scratch buffer holds packet bytes in network order but eBPF
 // LDX reads them little-endian; rather than emit a BSwap at runtime
 // we byte-swap the constant at codegen time so a single JNE suffices.
-func genFieldDispatch(current, parent *ir.LayerInstance, parentHS int, failLabel string) (asm.Instructions, error) {
+func genFieldDispatch(current, parent *ir.LayerInstance, parentHS int, r4IsRange, parentEntryIsRange bool, failLabel string) (asm.Instructions, error) {
 	if parent.Spec.HasVariableLayout() {
+		// Parser-machine parent: base is the parent's layer-entry slot
+		// value, dispatch field at +fieldOff (forward read from the
+		// parent's primary header start). When that slot value is a
+		// range scalar (the parent itself started at a non-constant
+		// offset, e.g. inner IPv4 behind a GTP tunnel) the forward read
+		// through `R0 + slotval` has no proven range and is rejected on
+		// PTR_TO_PACKET; the bounded idiom fixes it. A constant slot
+		// (parent at a fixed offset) keeps the byte-identical fast path.
+		if parentEntryIsRange {
+			return emitVarParentDispatchBounded(parent.Spec, current.Dispatch.Const, failLabel)
+		}
 		return emitFieldDispatchCheck(
 			parent.Spec,
 			current.Dispatch.Const,
@@ -1050,6 +1137,18 @@ func genFieldDispatch(current, parent *ir.LayerInstance, parentHS int, failLabel
 				asm.Add.Reg(asm.R3, asm.R0),
 			},
 			failLabel,
+		)
+	}
+	// Fixed parent: base is offsetBase (R4), dispatch field at
+	// (fieldOff - parentHS) — negative when reading back into the
+	// parent header (e.g. udp.dport at gtp_start-6). When R4 is a
+	// range scalar (a preceding layer was variable-length) the
+	// negative readback through a freshly built packet pointer is
+	// rejected on PTR_TO_PACKET; the bounded idiom fixes it.
+	if r4IsRange {
+		return emitFieldDispatchCheckBounded(
+			parent.Spec, current.Dispatch.Const,
+			offsetBase /*offsetReg=R4*/, asm.R5 /*scalar*/, asm.R3 /*dst*/, -parentHS, failLabel,
 		)
 	}
 	return emitFieldDispatchCheck(
@@ -1064,7 +1163,6 @@ func genFieldDispatch(current, parent *ir.LayerInstance, parentHS int, failLabel
 		failLabel,
 	)
 }
-
 
 // findFieldBitOffset returns the bit offset (from the start of the
 // header) and bit width of the named field, or an error when the

--- a/pkg/kunai/codegen/parser_loop.go
+++ b/pkg/kunai/codegen/parser_loop.go
@@ -213,19 +213,22 @@ func emitFillStackSlots(initImm int32, n int, resolve func(int) (int16, error)) 
 // The store reaches main's stack via R2 (= ctx pointer) plus a
 // constant offset — callback R10 points at a separate frame. R1 is
 // the kind-byte scratch (R0 was clobbered by the bound check above).
-// The byte is loaded from R4+R3 with no additional bound check
-// because the immediately preceding `R0 = R4+R3+1; JGT R0, R5,
-// break` already proved the byte is in scratch.
-func (c *pmCtx) emitDynamicAuxSlotPrelude() (asm.Instructions, error) {
+//
+// The kind byte is loaded through boundedScalarLoad rather than a
+// bare `R1 = R4+R3; *(u8*)(R1)`. On PTR_TO_MAP_VALUE the preceding
+// `R0 = R4+R3+1; JGT R0, R5, break` would suffice, but on
+// PTR_TO_PACKET (native XDP) the verifier does not carry that bound
+// across to a freshly built pointer in another register, so it
+// rejects the load as out of packet range. boundedScalarLoad re-runs
+// the end-pointer check on the load register itself, which both hosts
+// accept; the extra check is redundant on the map-value path.
+func (c *pmCtx) emitDynamicAuxSlotPrelude(breakLabel string) (asm.Instructions, error) {
 	demand := c.queried[c.layer]
 	if len(demand) == 0 {
 		return nil, nil
 	}
-	insns := asm.Instructions{
-		asm.Mov.Reg(asm.R1, asm.R4),
-		asm.Add.Reg(asm.R1, asm.R3),
-		asm.LoadMem(asm.R1, asm.R1, 0, asm.Byte),
-	}
+	// R1 = kind byte at scratchStart(R4) + cursor(R3); R3/R4/R5 survive.
+	insns := boundedScalarLoad(asm.R1, asm.R4, asm.R3, asm.R5, asm.Byte, breakLabel)
 	for idx, layout := range demand {
 		slot, err := c.queried.slotForLayer(c.layer, idx+1)
 		if err != nil {
@@ -279,7 +282,7 @@ func (c *pmCtx) emitMultiStateCallback(entry *vocab.ParseState, entryIdx int, cb
 	// function of the kind byte alone so the verifier doesn't track
 	// "which case ran × which slot was written" across iters. See
 	// docs/ja/dsl-internals.md §6.5 Mechanism 7.
-	prelude, err := c.emitDynamicAuxSlotPrelude()
+	prelude, err := c.emitDynamicAuxSlotPrelude(breakLabel)
 	if err != nil {
 		return nil, err
 	}
@@ -843,7 +846,6 @@ func transitionRefsState(t vocab.TransitionOp, stateIdx int) bool {
 	}
 	return false
 }
-
 
 // selectCounter feeds unique case-skip labels per (layer, state, case).
 // Each emit pass starts at zero so labels stay deterministic.

--- a/pkg/kunai/codegen/parser_state.go
+++ b/pkg/kunai/codegen/parser_state.go
@@ -239,7 +239,7 @@ func (c *pmCtx) emitEntryDispatch() (asm.Instructions, error) {
 	if c.layerIdx == 0 || c.layer.Dispatch == nil {
 		return nil, nil
 	}
-	return genLayerDispatch(c.layer, c.all[c.layerIdx-1], dslReject)
+	return genLayerDispatch(c.layer, c.all[c.layerIdx-1], c.r4IsRange, precedingLayersLeaveR4Range(c.all, c.layerIdx-1), dslReject)
 }
 
 // emitStateBody emits one state's extracts + transition. When the


### PR DESCRIPTION
## What

Native XDP direct execution (`--mode xdp` / `runFilterDirect`) failed to load the aux-walk filters — GTP-U inner IPv4 (F7), Geneve inner IPv4 (F9), and TCP options (F10) — because the inline layer dispatch read the parent's dispatch field through a freshly built packet pointer at an offset the verifier could not prove in range.

Two cases broke on `PTR_TO_PACKET`:
- **fixed parent, negative readback** — e.g. `udp.dport` at `gtp_start - 6`, where `R4` (the running offset) is a range scalar because an upstream header was variable-length (IPv4 IHL).
- **variable parent, forward read** — e.g. `ipv4.protocol` off a parser-machine parent's layer-entry slot, where that slot value is a range scalar (inner IPv4 behind a tunnel).

The fentry/tc scratch-window path (`PTR_TO_MAP_VALUE`) was unaffected: the map's static bound transfers across the rebuilt pointer, so this only surfaced on native XDP.

## How

Switch those reads to the bounded `foldOffsetIntoScalar` + `boundedScalarLoad` idiom — the same recipe `emitKeyCompare` already uses on the parser-machine path — gated by two predicates:
- `r4IsRange` → fixed-parent negative readback
- `parentEntryIsRange` → variable-parent forward read

Fixed-offset chains keep the byte-identical fast path, so **F1–F6 and F8 are unchanged**. The bounded checks add instructions only to the three affected filters.

## Impact on pinned instruction counts

| filter | before | after |
|---|---:|---:|
| F7 (GTP-U) | 391 | 403 |
| F9 (Geneve) | 281 | 299 |
| F10 (TCP opt) | 227 | 230 |

`filterset_test.go` pins updated accordingly.

## Tests

- New `TestBpfXDPNativeFilterSet` loads all of F1–F10 natively (the regression guard).
- Full BPF load matrix green: native XDP, scratch XDP, tc, and the 68-expression corpus across the kernel matrix.
- `go vet` / `golangci-lint` / `gofmt` clean.