### PR TITLE
fix(resolve): reject any/all over two distinct aux stacks

### DIFF
--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -550,12 +550,30 @@ func cloneArithWithRebind(a *ir.ArithExpr, target *ir.QuantTarget, idx uint64) (
 	return &cp, nil
 }
 
+// layerName describes a layer for error messages: "ipv6", or
+// "ipv6@inner" when labelled. Nil-safe.
+func layerName(l *ir.LayerInstance) string {
+	if l == nil || l.Spec == nil {
+		return "?"
+	}
+	if l.Label != "" {
+		return l.Spec.Name + "@" + l.Label
+	}
+	return l.Spec.Name
+}
+
 func rebindFieldRef(ref *ir.FieldRef, target *ir.QuantTarget, idx uint64) (*ir.FieldRef, error) {
 	if ref == nil || ref.Aux == nil || ref.Aux.Stack == nil || !ref.Aux.Stack.IsIterator {
 		return ref, nil
 	}
-	if ref.Aux.OutParam != target.OutParam {
-		return nil, fmt.Errorf("codegen: iterator FieldRef references stack %q but quantifier target is %q", ref.Aux.OutParam, target.OutParam)
+	// Stack identity is (owning layer, out param): distinct layers can
+	// expose a stack under the same name (ipv6 and gtp both declare
+	// `exts`), so the layer must match too. The resolver already
+	// rejects multi-stack quantifiers (findQuantTarget); this guards
+	// the same invariant at the codegen boundary.
+	if ref.Layer != target.Layer || ref.Aux.OutParam != target.OutParam {
+		return nil, fmt.Errorf("codegen: iterator FieldRef references stack %s.%s but quantifier target is %s.%s",
+			layerName(ref.Layer), ref.Aux.OutParam, layerName(target.Layer), target.OutParam)
 	}
 	cp := *ref
 	auxCopy := *ref.Aux

--- a/pkg/kunai/ir/ir.go
+++ b/pkg/kunai/ir/ir.go
@@ -248,6 +248,12 @@ func (r *FieldRef) IsExistsCheck() bool {
 // bpf_loop callback whose per-iter state addresses
 // `OffsetInLayer + iter*ElemSize` within the owning layer.
 type QuantTarget struct {
+	// Layer is the owning layer instance. Stack identity is (Layer,
+	// OutParam): distinct layers can expose a stack under the same
+	// out-param name (ipv6 and gtp both declare `exts`), so OutParam
+	// alone is not a unique key. codegen's rebindFieldRef compares
+	// against Layer to keep iterator refs bound to the right stack.
+	Layer         *LayerInstance
 	OutParam      string // parser out parameter name (e.g. "segments")
 	HeaderName    string // aux header type name (e.g. "srv6_seg_h")
 	OffsetInLayer int    // bytes from layer-entry slot to stack start

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -284,6 +284,19 @@ func TestResolveAuxStackRejectsSinglePath(t *testing.T) {
 	resolveErr(t, "eth/ipv4/udp/gtp[exts.next_ext==0]/ipv4/tcp", nil, "needs an index")
 }
 
+func TestResolveQuantSameStackMultipleRefs(t *testing.T) {
+	// any()/all() require exactly one iteration *target* stack, not
+	// exactly one textual reference. The same stack may appear more
+	// than once; each ref reads the current element per iteration.
+	p := resolveOK(t, "eth/ipv6/srv6/tcp where any(srv6.segments.addr == fc00::1 or srv6.segments.addr == fc00::2)", nil)
+	if p.Where == nil || p.Where.QuantTarget == nil {
+		t.Fatalf("expected a QuantTarget on the any() condition, got %+v", p.Where)
+	}
+	if p.Where.QuantTarget.OutParam != "segments" {
+		t.Errorf("quant target out param = %q, want segments", p.Where.QuantTarget.OutParam)
+	}
+}
+
 func TestResolvePredicateInIntegerAcceptsResolve(t *testing.T) {
 	// F7 landed: integer alternatives now resolve cleanly. The
 	// predicate is no longer flagged Unsupported.

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -297,6 +297,16 @@ func TestResolveQuantSameStackMultipleRefs(t *testing.T) {
 	}
 }
 
+func TestResolveQuantTwoDistinctStacksRejected(t *testing.T) {
+	// ipv6 and gtp both expose a stack named "exts", so identity by
+	// out param alone would miss this. Iterating two different stacks
+	// in one any() is two iteration dimensions and must be rejected at
+	// resolve time (with position info), not slip through to codegen.
+	resolveErr(t,
+		"eth/ipv6/udp/gtp/ipv4/tcp where any(ipv6.exts.next_header == 0 or gtp.exts.next_ext == 0)",
+		nil, "single aux header stack")
+}
+
 func TestResolvePredicateInIntegerAcceptsResolve(t *testing.T) {
 	// F7 landed: integer alternatives now resolve cleanly. The
 	// predicate is no longer flagged Unsupported.

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -165,16 +165,20 @@ func (r *resolver) resolveWhere(w *ast.WhereExpr) (*ir.Condition, error) {
 	return c, nil
 }
 
-// findQuantTarget locates the aux header stack the inner expression
-// iterates over. The inner contains exactly one FieldRef whose
-// Aux.Stack is set and IsStatic is false (no explicit index = the
-// quantifier's iteration variable). Other field refs inside the
-// inner are constants per-iteration. Multiple stack refs or a
-// stack ref already carrying a static index inside any/all are
-// rejected — the codegen contract requires a single iteration
-// dimension.
+// findQuantTarget locates the single aux header stack the inner
+// expression iterates over: a FieldRef whose Aux.Stack is set with
+// IsIterator true (no explicit index = the quantifier's iteration
+// variable). The same stack may be referenced more than once — every
+// such ref reads the current element per iteration (e.g.
+// `addr == X or addr == Y`). Indexed refs and primary fields stay
+// constant within the iteration. Zero iterator refs, or refs to two
+// distinct stacks (which would demand two iteration dimensions), are
+// rejected here so the error carries position info; codegen's
+// rebindFieldRef re-checks the single-stack invariant as
+// defense-in-depth.
 func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.QuantTarget, error) {
 	var found *ir.AuxRef
+	multiple := false
 	ir.WalkConditionFieldRefs(c, func(ref *ir.FieldRef) {
 		if ref == nil || ref.Aux == nil || ref.Aux.Stack == nil {
 			return
@@ -186,10 +190,17 @@ func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.Quant
 		if !ref.Aux.Stack.IsIterator {
 			return
 		}
-		found = ref.Aux
+		if found == nil {
+			found = ref.Aux
+		} else if ref.Aux.OutParam != found.OutParam {
+			multiple = true
+		}
 	})
 	if found == nil {
 		return nil, errorf(pos, "any/all requires exactly one aux header stack reference inside (e.g. `any(srv6.segments.addr == X)`)")
+	}
+	if multiple {
+		return nil, errorf(pos, "any/all iterates a single aux header stack, but the inner expression references more than one (the same stack may be referenced multiple times, but not two different stacks)")
 	}
 	return &ir.QuantTarget{
 		OutParam:      found.OutParam,

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -209,6 +209,7 @@ func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.Quant
 	}
 	a := found.Aux
 	return &ir.QuantTarget{
+		Layer:         found.Layer,
 		OutParam:      a.OutParam,
 		HeaderName:    a.HeaderName,
 		OffsetInLayer: a.OffsetInLayer,

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -173,11 +173,16 @@ func (r *resolver) resolveWhere(w *ast.WhereExpr) (*ir.Condition, error) {
 // `addr == X or addr == Y`). Indexed refs and primary fields stay
 // constant within the iteration. Zero iterator refs, or refs to two
 // distinct stacks (which would demand two iteration dimensions), are
-// rejected here so the error carries position info; codegen's
-// rebindFieldRef re-checks the single-stack invariant as
-// defense-in-depth.
+// rejected here so the error carries position info.
+//
+// Stack identity is (owning layer, out param), not the out param
+// alone: distinct protocols can expose a stack under the same name
+// (ipv6 and gtp both declare `out ... exts`), so `any(ipv6.exts... or
+// gtp.exts...)` is two iteration dimensions despite sharing the
+// "exts" out param. The owning layer must therefore be part of the
+// comparison.
 func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.QuantTarget, error) {
-	var found *ir.AuxRef
+	var found *ir.FieldRef
 	multiple := false
 	ir.WalkConditionFieldRefs(c, func(ref *ir.FieldRef) {
 		if ref == nil || ref.Aux == nil || ref.Aux.Stack == nil {
@@ -191,8 +196,8 @@ func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.Quant
 			return
 		}
 		if found == nil {
-			found = ref.Aux
-		} else if ref.Aux.OutParam != found.OutParam {
+			found = ref
+		} else if ref.Layer != found.Layer || ref.Aux.OutParam != found.Aux.OutParam {
 			multiple = true
 		}
 	})
@@ -202,12 +207,13 @@ func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.Quant
 	if multiple {
 		return nil, errorf(pos, "any/all iterates a single aux header stack, but the inner expression references more than one (the same stack may be referenced multiple times, but not two different stacks)")
 	}
+	a := found.Aux
 	return &ir.QuantTarget{
-		OutParam:      found.OutParam,
-		HeaderName:    found.HeaderName,
-		OffsetInLayer: found.OffsetInLayer,
-		ElemSize:      found.HeaderSize,
-		Capacity:      found.Stack.Capacity,
+		OutParam:      a.OutParam,
+		HeaderName:    a.HeaderName,
+		OffsetInLayer: a.OffsetInLayer,
+		ElemSize:      a.HeaderSize,
+		Capacity:      a.Stack.Capacity,
 	}, nil
 }
 


### PR DESCRIPTION
## 概要

`any()` / `all()` 量化子は、内側の式が走査対象となる補助 header stack（index を省略した参照）を **ちょうど 1 つ** 持つことを前提にしている。しかし `findQuantTarget`（`pkg/kunai/resolve/where.go`）は、index 省略の stack 参照を walk して見つけたものを無条件に上書きするだけで件数チェックが無く、**0 件のときだけ** エラーを返していた。

その結果:

- **異なる stack を 2 つ以上** 参照した場合、resolve は黙って最後の参照を iteration target に採用し、エラーは codegen の `rebindFieldRef` まで滑り込んでから OutParam 不一致で落ちる（**位置情報なし**）。さらに resolve は「最後」を、codegen の `stackCountSource` は「最初」を採るというちぐはぐも残っていた。
- doc コメントは "Multiple stack refs ... are rejected" と書いていたが、**実際には reject していなかった**（コメントが実装と食い違い）。

## 変更

- field-ref の walk 中に **2 つめの異なる stack（OutParam で判定）** を検出し、resolve 段階で **位置情報つきエラー** として拒否する。
- **同一 stack の複数参照は従来どおり許可** — 各参照は iteration ごとの現在要素を読む（例: `any(srv6.segments.addr == X or srv6.segments.addr == Y)`）。
- stale だった doc コメントを実装に合わせて書き直し（codegen の `rebindFieldRef` が同じ不変条件を defense-in-depth で再チェックする旨も明記）。

## テスト

- `TestResolveQuantSameStackMultipleRefs` を追加。同一 stack を 2 回参照する `any()` が resolve でき、`QuantTarget.OutParam == "segments"` になることを pin。
- `go test ./...` 全パス、`go vet` / `golangci-lint` 0 issues。

## 補足

各 protocol は out stack を最大 1 つしか宣言しないため「異なる 2 stack を 1 つの `any()` に入れる」入力を実際に作るのはほぼ不可能であり、新しい reject 経路は主に防御的なもの。ただしエラーを resolve 境界へ引き上げ、位置情報を付け、resolve/codegen の identity 判定（OutParam）を一致させる点に意味がある。
