### PR TITLE
fix(codegen): chain-quantifier termination + nested bool-eq, with a packet-level corpus suite

### DIFF
--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -21,6 +21,7 @@ package program
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/google/gopacket/layers"
@@ -292,17 +293,49 @@ var corpusLoadOnly = map[string]string{
 
 func TestBpfFilterCorpusCorrectness(t *testing.T) {
 	exprByID := make(map[string]string, len(VerifierCorpus))
-	covered := make(map[string]bool, len(corpusCorrectness))
 	for _, c := range VerifierCorpus {
 		exprByID[c.ID] = c.Expr
+	}
+
+	// drift guard (root-free): every corpus ID must be classified in exactly
+	// one of corpusCorrectness or corpusLoadOnly. Forces a decision as the
+	// corpus grows and catches an ID listed in both (a dead load-only reason).
+	for _, c := range VerifierCorpus {
+		_, correct := corpusCorrectness[c.ID]
+		_, loadOnly := corpusLoadOnly[c.ID]
+		switch {
+		case correct && loadOnly:
+			t.Errorf("corpus %s is in both corpusCorrectness and corpusLoadOnly; it must be in exactly one", c.ID)
+		case !correct && !loadOnly:
+			t.Errorf("corpus %s (%q): classify it in corpusCorrectness or corpusLoadOnly", c.ID, c.Expr)
+		}
+	}
+	// no stale IDs in either map.
+	for id := range corpusCorrectness {
+		if _, ok := exprByID[id]; !ok {
+			t.Errorf("corpusCorrectness has %s which is not in VerifierCorpus", id)
+		}
+	}
+	for id := range corpusLoadOnly {
+		if _, ok := exprByID[id]; !ok {
+			t.Errorf("corpusLoadOnly has %s which is not in VerifierCorpus", id)
+		}
+	}
+
+	// Packet-level checks need root (BPF_PROG_TEST_RUN / CAP_SYS_ADMIN). Gate
+	// once here rather than letting dt.New skip inside each subtest, which
+	// would spawn dozens of skipped subtests in non-root runs.
+	if os.Getuid() != 0 {
+		t.Skip("packet-level corpus checks need root (BPF_PROG_TEST_RUN)")
+	}
+	for _, c := range VerifierCorpus {
 		cc, ok := corpusCorrectness[c.ID]
 		if !ok {
 			continue
 		}
-		covered[c.ID] = true
 		c := c
 		t.Run(c.ID, func(t *testing.T) {
-			r := dt.New(t, c.Expr) // skips when not root
+			r := dt.New(t, c.Expr)
 			for i, mk := range cc.match {
 				r.MustMatch(t, mk(t), fmt.Sprintf("%s match #%d (%s)", c.ID, i, c.Expr))
 			}
@@ -310,32 +343,5 @@ func TestBpfFilterCorpusCorrectness(t *testing.T) {
 				r.MustReject(t, rk(t), fmt.Sprintf("%s reject #%d (%s)", c.ID, i, c.Expr))
 			}
 		})
-	}
-
-	// drift guard: every corpus ID must be correctness-covered or documented
-	// load-only. Forces a decision as the corpus grows.
-	for _, c := range VerifierCorpus {
-		if covered[c.ID] {
-			continue
-		}
-		if _, ok := corpusLoadOnly[c.ID]; !ok {
-			t.Errorf("corpus %s (%q): classify it in corpusCorrectness or corpusLoadOnly", c.ID, c.Expr)
-		}
-	}
-	// other direction: no stale IDs in either map.
-	for id := range corpusCorrectness {
-		if _, ok := exprByID[id]; !ok {
-			t.Errorf("corpusCorrectness has %s which is not in VerifierCorpus", id)
-		}
-		// "exactly one of" — an ID in both maps would be silently treated as
-		// covered above, leaving a dead load-only reason. Reject it.
-		if _, both := corpusLoadOnly[id]; both {
-			t.Errorf("corpus %s is in both corpusCorrectness and corpusLoadOnly; it must be in exactly one", id)
-		}
-	}
-	for id := range corpusLoadOnly {
-		if _, ok := exprByID[id]; !ok {
-			t.Errorf("corpusLoadOnly has %s which is not in VerifierCorpus", id)
-		}
 	}
 }

--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -325,6 +325,11 @@ func TestBpfFilterCorpusCorrectness(t *testing.T) {
 		if _, ok := exprByID[id]; !ok {
 			t.Errorf("corpusCorrectness has %s which is not in VerifierCorpus", id)
 		}
+		// "exactly one of" — an ID in both maps would be silently treated as
+		// covered above, leaving a dead load-only reason. Reject it.
+		if _, both := corpusLoadOnly[id]; both {
+			t.Errorf("corpus %s is in both corpusCorrectness and corpusLoadOnly; it must be in exactly one", id)
+		}
 	}
 	for id := range corpusLoadOnly {
 		if _, ok := exprByID[id]; !ok {

--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -1,0 +1,330 @@
+package program
+
+// Packet-level correctness for the VerifierCorpus.
+//
+// filterset_corpus_test.go asserts every corpus expression compiles and
+// loads on the verifier. That is the *load* path only: a filter can load
+// yet read the wrong bytes (e.g. the historical Geneve opt_len mis-read).
+// This file closes that gap by running each corpus expression through the
+// dsltest BPF_PROG_TEST_RUN harness against hand-built packets and
+// asserting match / reject, so corpus coverage is correctness, not just
+// loadability.
+//
+// The corpus expression strings stay single-sourced in VerifierCorpus;
+// entries here are keyed by ID and supply only the packets. A drift guard
+// at the end forces every corpus ID into exactly one of: a correctness
+// case, a documented load-only reason, or a test failure.
+//
+// Root only (BPF_PROG_TEST_RUN needs CAP_SYS_ADMIN); runs under
+// `make test-bpf` via the TestBpf prefix.
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+
+	dt "github.com/takehaya/xdp-ninja/pkg/kunai/dsltest"
+)
+
+type pktFn = func(testing.TB) []byte
+
+// cp builds a packet from dsltest.Defaults() with mut applied.
+func cp(mut func(o *dt.PacketOpts)) pktFn {
+	return func(t testing.TB) []byte {
+		o := dt.Defaults()
+		if mut != nil {
+			mut(&o)
+		}
+		return dt.Build(t, o)
+	}
+}
+
+func pks(fs ...pktFn) []pktFn { return fs }
+
+// asUDP / asICMP swap the default TCP L4 for the chain-shape match/reject cases.
+var (
+	asUDP  = func(o *dt.PacketOpts) { o.TCP, o.UDP = false, true }
+	asICMP = func(o *dt.PacketOpts) { o.TCP, o.ICMP = false, true }
+)
+
+func mac(s string) net.HardwareAddr {
+	m, err := net.ParseMAC(s)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// v6 turns a default packet into an Ethernet/IPv6/TCP frame with the
+// given addresses (callers override ports/L4 as needed afterwards).
+func v6(src, dst string) func(o *dt.PacketOpts) {
+	return func(o *dt.PacketOpts) {
+		o.SrcIP = net.ParseIP(src)
+		o.DstIP = net.ParseIP(dst)
+	}
+}
+
+type corpusCase struct {
+	match  []pktFn // every packet here MUST match
+	reject []pktFn // every packet here MUST reject
+}
+
+// corpusCorrectness maps corpus ID -> expected packets. The expression is
+// looked up from VerifierCorpus by ID. A nil/empty match or reject list is
+// allowed for one-sided predicates (where true / where false).
+var corpusCorrectness = map[string]corpusCase{
+	// --- basic chains: match the chain's L4, reject a different one ---
+	"C01": {pks(cp(nil)), pks(cp(asUDP))},
+	"C02": {pks(cp(asUDP)), pks(cp(nil))},
+	"C03": {pks(cp(v6("fe80::1", "fe80::2"))), pks(cp(nil))},
+	"C04": {pks(cp(func(o *dt.PacketOpts) { v6("fe80::1", "fe80::2")(o); asUDP(o) })),
+		pks(cp(v6("fe80::1", "fe80::2")))},
+	"C05": {pks(cp(asICMP)), pks(cp(nil))},
+	"C06": {pks(cp(func(o *dt.PacketOpts) { v6("fe80::1", "fe80::2")(o); asICMP(o) })),
+		pks(cp(v6("fe80::1", "fe80::2")))},
+
+	// --- bracket predicates: integer ---
+	"C10": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))},
+	"C11": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))},
+	"C12": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 22 }))},
+	"C13": {pks(cp(nil)), pks(cp(func(o *dt.PacketOpts) { o.TTL = 63 }))}, // default TTL 64 matches
+
+	// --- bracket predicates: IPv4 host / prefix ---
+	"C20": {pks(cp(nil)), pks(cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("10.0.0.9") }))}, // default src 10.0.0.1
+	"C21": {pks(cp(func(o *dt.PacketOpts) { o.DstIP = net.ParseIP("192.168.1.42") })), pks(cp(nil))},
+	"C22": {pks(cp(nil)), pks(cp(func(o *dt.PacketOpts) { o.DstIP = net.ParseIP("192.168.1.1") }))}, // default dst 10.0.0.2 in 10/8
+	"C23": {
+		pks(cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("192.168.1.1"); o.DstPort = 443 })),
+		pks(
+			cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("10.0.0.1"); o.DstPort = 443 }),   // src out of /16
+			cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("192.168.1.1"); o.DstPort = 80 }), // dport mismatch
+		),
+	},
+
+	// --- bracket predicates: IPv6 host / prefix ---
+	"C30": {pks(cp(v6("fe80::1", "fe80::2"))), pks(cp(v6("fe80::2", "fe80::2")))},
+	"C31": {pks(cp(v6("fe80::1", "::1"))), pks(cp(v6("fe80::1", "::2")))},
+	"C32": {pks(cp(v6("fe80::1", "fe80::2"))), pks(cp(v6("2001:db8::1", "fe80::2")))},
+	"C33": {pks(cp(v6("fe80::1", "2001:db8::1"))), pks(cp(v6("fe80::1", "fe80::2")))},
+	"C34": {pks(cp(v6("2001:db8::1", "fe80::2"))), pks(cp(v6("2001:db8::2", "fe80::2")))},
+	"C35": {pks(cp(v6("fe80::2", "fe80::2"))), pks(cp(v6("fe80::1", "fe80::2")))},
+
+	// --- bracket predicates: MAC ---
+	"C40": {pks(cp(func(o *dt.PacketOpts) { o.DstMAC = mac("de:ad:be:ef:00:01") })), pks(cp(nil))},
+	"C41": {pks(cp(nil)), pks(cp(func(o *dt.PacketOpts) { o.SrcMAC = mac("00:11:22:33:44:55") }))},
+
+	// --- where-clause: comparison ---
+	"C50": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))},
+	"C51": {
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 }), cp(func(o *dt.PacketOpts) { o.DstPort = 80 })),
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 22 })),
+	},
+	"C52": {pks(cp(func(o *dt.PacketOpts) { o.Payload = make([]byte, 60) })), pks(cp(nil))}, // 20+20+60 = 100
+	"C53": {
+		pks(cp(nil)), // sport 12345 > 1024, dport 80
+		pks(
+			cp(func(o *dt.PacketOpts) { o.SrcPort = 500 }), // sport not > 1024
+			cp(func(o *dt.PacketOpts) { o.DstPort = 22 }),  // dport in neither
+		),
+	},
+	"C54": {pks(cp(nil)), nil}, // where true: match only
+	"C55": {nil, pks(cp(nil))}, // where false: reject only
+	"C56": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 0 }))},
+	"C57": { // (dport==443)==(sport==443): bool-eq is XNOR — match when both bools agree
+		pks(
+			cp(func(o *dt.PacketOpts) { o.DstPort, o.SrcPort = 443, 443 }),  // T == T
+			cp(func(o *dt.PacketOpts) { o.DstPort, o.SrcPort = 80, 12345 }), // F == F
+		),
+		pks(
+			cp(func(o *dt.PacketOpts) { o.DstPort, o.SrcPort = 443, 12345 }), // T == F
+			cp(func(o *dt.PacketOpts) { o.DstPort, o.SrcPort = 80, 443 }),    // F == T
+		),
+	},
+
+	// --- where-clause: bitwise / shift, (a OP b) binds tighter than == ---
+	"C60": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 81 }))},
+	"C61": {pks(cp(func(o *dt.PacketOpts) { o.TTL = 65 })), pks(cp(func(o *dt.PacketOpts) { o.TTL = 64 }))},         // 64&0x0f==0
+	"C62": {nil, pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))},                                                // (dport|0x80)>=128, never ==80
+	"C63": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 81 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))}, // 81^1==80
+	"C64": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 8 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 }))},  // 8>>4==0
+	"C65": {pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 })), pks(cp(func(o *dt.PacketOpts) { o.DstPort = 81 }))}, // 80<<1==160
+
+	// --- where-clause: IPv6 bit-slice ---
+	"C70": {pks(cp(v6("2001:db8::1", "fe80::2"))), pks(cp(v6("fe80::1", "fe80::2")))},
+	"C71": {pks(cp(v6("2001:db8::1234:5678", "fe80::1234:5678"))), pks(cp(v6("2001:db8::1234:5678", "fe80::1234:5679")))},
+	"C72": {pks(cp(v6("2001:db8::1:2:3:4", "fe80::1:2:3:4"))), pks(cp(v6("2001:db8::1:2:3:4", "fe80::1:2:3:5")))},
+	"C73": {pks(cp(v6("2001:db8::1", "fe80::1"))), pks(cp(v6("2001:db8::1", "2001:db8::2")))}, // != on /64
+	"C74": {pks(cp(v6("2001:db8::1", "fe80::2"))), pks(cp(v6("fe80::1", "fe80::2")))},
+
+	// --- where-clause: literal LHS ---
+	"C80": {pks(cp(func(o *dt.PacketOpts) { o.DstIP = net.ParseIP("10.0.0.1") })), pks(cp(nil))}, // default dst 10.0.0.2
+	"C81": {pks(cp(func(o *dt.PacketOpts) { o.DstIP = net.ParseIP("192.168.1.1") })), pks(cp(nil))},
+	"C82": {pks(cp(func(o *dt.PacketOpts) { o.DstMAC = mac("aa:bb:cc:dd:ee:ff") })), pks(cp(nil))},
+
+	// --- where-clause: field-vs-field 128-bit ---
+	"C90": {pks(cp(v6("2001:db8::1", "2001:db8::1"))), pks(cp(v6("2001:db8::1", "2001:db8::2")))},
+	"C91": {pks(cp(v6("::1", "::2"))), pks(cp(v6("::2", "::1")))},
+
+	// --- quantified layers ---
+	"D00": { // vlan? — match with and without a tag
+		pks(cp(nil), cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100} })),
+		pks(cp(asUDP)),
+	},
+	"D01": {
+		pks(cp(nil), cp(func(o *dt.PacketOpts) { o.QinQ = true; o.VLAN = []uint16{100, 200} })),
+		pks(cp(asUDP)),
+	},
+	"D02": { // mpls+ — 1 or more labels (1 and 2 both match)
+		pks(
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16} }),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17} }),
+		),
+		pks(cp(nil)),
+	},
+	"D03": { // mpls* — 0 or more labels (0, 1, 2 all match)
+		pks(
+			cp(nil),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16} }),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17} }),
+		),
+		pks(cp(asUDP)),
+	},
+	"D04": { // vlan{1,3}
+		pks(cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100} }), cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100, 200, 300} })),
+		pks(cp(nil)),
+	},
+	"D05": { // mpls{1,4}: 1-4 labels match; 0 and 5+ reject (s-bit chain-end termination)
+		pks(
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16} }),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17} }),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18} }),
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18, 19} }),
+		),
+		pks(
+			cp(nil), // 0 labels
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18, 19, 20} }), // 5 > max 4
+		),
+	},
+	"D06": { // mpls{2,2}: exactly 2 labels matches; 3 is out of range
+		pks(cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17} })),
+		pks(cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18} }), cp(nil)),
+	},
+	"D07": {
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 }), cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100}; o.DstPort = 443 })),
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 })),
+	},
+
+	// --- heterogeneous-size alternation ---
+	"E00": {
+		pks(cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100} }), cp(func(o *dt.PacketOpts) { o.QinQ = true; o.VLAN = []uint16{100} })),
+		pks(cp(nil)),
+	},
+	"E01": {
+		pks(cp(nil), cp(v6("fe80::1", "fe80::2"))),
+		pks(cp(asUDP)),
+	},
+	"E02": {
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 }), cp(func(o *dt.PacketOpts) { v6("fe80::1", "fe80::2")(o); o.DstPort = 443 })),
+		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 80 })),
+	},
+	"E03": {
+		pks(cp(nil), cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100} }), cp(func(o *dt.PacketOpts) { o.QinQ = true; o.VLAN = []uint16{100} })),
+		pks(cp(v6("fe80::1", "fe80::2"))),
+	},
+
+	// --- @label multi-encap: inner.dst / inner port ---
+	"F00": {pks(func(t testing.TB) []byte { return dt.BuildVXLANInnerIPv4TCP(t, net.IPv4(10, 0, 0, 1), 80) }),
+		pks(func(t testing.TB) []byte { return dt.BuildVXLANInnerIPv4TCP(t, net.IPv4(10, 0, 0, 2), 80) })},
+	"F01": {pks(func(t testing.TB) []byte {
+		return dt.BuildGeneveInnerIPv4TCP(t, dt.GeneveInnerIPv4TCPOpts{InnerDstIP: net.IPv4(10, 0, 0, 1)})
+	}), pks(func(t testing.TB) []byte {
+		return dt.BuildGeneveInnerIPv4TCP(t, dt.GeneveInnerIPv4TCPOpts{InnerDstIP: net.IPv4(10, 0, 0, 2)})
+	})},
+	"F02": {pks(func(t testing.TB) []byte {
+		return dt.BuildGTPU(t, dt.GTPUOpts{InnerDst: net.IPv4(10, 0, 0, 1)})
+	}), pks(func(t testing.TB) []byte {
+		return dt.BuildGTPU(t, dt.GTPUOpts{InnerDst: net.IPv4(10, 0, 0, 2)})
+	})},
+	"F03": {pks(func(t testing.TB) []byte { return dt.BuildVXLANInnerIPv4TCP(t, net.IPv4(10, 0, 0, 1), 80) }),
+		pks(func(t testing.TB) []byte { return dt.BuildVXLANInnerIPv4TCP(t, net.IPv4(10, 0, 0, 1), 443) })},
+
+	// --- aux-walk: any() over segments / TCP options ---
+	"G00": {pks(func(t testing.TB) []byte {
+		return dt.BuildSRv6(t, dt.SRv6Opts{Segments: []net.IP{net.ParseIP("fc00::3"), net.ParseIP("fc00::2"), net.ParseIP("fc00::1")}})
+	}), pks(func(t testing.TB) []byte {
+		return dt.BuildSRv6(t, dt.SRv6Opts{Segments: []net.IP{net.ParseIP("fc00::3"), net.ParseIP("fc00::2"), net.ParseIP("fc00::9")}})
+	})},
+	"G01": {pks(func(t testing.TB) []byte {
+		return dt.BuildSRv6(t, dt.SRv6Opts{Segments: []net.IP{net.ParseIP("fc00::1"), net.ParseIP("2001:db8::5")}})
+	}), pks(func(t testing.TB) []byte {
+		return dt.BuildSRv6(t, dt.SRv6Opts{Segments: []net.IP{net.ParseIP("fc00::1"), net.ParseIP("fc00::2")}})
+	})},
+	"G02": {
+		pks(cp(func(o *dt.PacketOpts) { o.TCPOptions = mssOption(1460) })),
+		pks(cp(func(o *dt.PacketOpts) { o.TCPOptions = mssOption(1400) })),
+	},
+}
+
+func mssOption(v uint16) []layers.TCPOption {
+	return []layers.TCPOption{{
+		OptionType:   layers.TCPOptionKindMSS,
+		OptionLength: 4,
+		OptionData:   []byte{byte(v >> 8), byte(v)},
+	}}
+}
+
+// corpusLoadOnly documents IDs whose match/reject verdict is out of this
+// suite's scope: the verdict is trivial or the intended semantics are
+// genuinely unclear, so there is no confident oracle to assert.
+var corpusLoadOnly = map[string]string{
+	"H00": "capture clause: changes captured output bytes, not the match/reject verdict (which equals eth/ipv4/tcp); capture-byte correctness needs a separate oracle",
+	"H01": "capture clause (capture all): same as H00",
+	"H03": "capture clause (capture absolute 96): same as H00",
+}
+
+func TestBpfFilterCorpusCorrectness(t *testing.T) {
+	exprByID := make(map[string]string, len(VerifierCorpus))
+	covered := make(map[string]bool, len(corpusCorrectness))
+	for _, c := range VerifierCorpus {
+		exprByID[c.ID] = c.Expr
+		cc, ok := corpusCorrectness[c.ID]
+		if !ok {
+			continue
+		}
+		covered[c.ID] = true
+		c := c
+		t.Run(c.ID, func(t *testing.T) {
+			r := dt.New(t, c.Expr) // skips when not root
+			for i, mk := range cc.match {
+				r.MustMatch(t, mk(t), fmt.Sprintf("%s match #%d (%s)", c.ID, i, c.Expr))
+			}
+			for i, rk := range cc.reject {
+				r.MustReject(t, rk(t), fmt.Sprintf("%s reject #%d (%s)", c.ID, i, c.Expr))
+			}
+		})
+	}
+
+	// drift guard: every corpus ID must be correctness-covered or documented
+	// load-only. Forces a decision as the corpus grows.
+	for _, c := range VerifierCorpus {
+		if covered[c.ID] {
+			continue
+		}
+		if _, ok := corpusLoadOnly[c.ID]; !ok {
+			t.Errorf("corpus %s (%q): classify it in corpusCorrectness or corpusLoadOnly", c.ID, c.Expr)
+		}
+	}
+	// other direction: no stale IDs in either map.
+	for id := range corpusCorrectness {
+		if _, ok := exprByID[id]; !ok {
+			t.Errorf("corpusCorrectness has %s which is not in VerifierCorpus", id)
+		}
+	}
+	for id := range corpusLoadOnly {
+		if _, ok := exprByID[id]; !ok {
+			t.Errorf("corpusLoadOnly has %s which is not in VerifierCorpus", id)
+		}
+	}
+}

--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -207,9 +207,13 @@ var corpusCorrectness = map[string]corpusCase{
 			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18, 19, 20} }), // 5 > max 4
 		),
 	},
-	"D06": { // mpls{2,2}: exactly 2 labels matches; 3 is out of range
+	"D06": { // mpls{2,2}: exactly 2 labels match; 1 (under-run), 3 (over-run), 0 all reject on the s-bit
 		pks(cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17} })),
-		pks(cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18} }), cp(nil)),
+		pks(
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16} }),         // 1 < min 2 (under-run)
+			cp(func(o *dt.PacketOpts) { o.MPLS = []uint32{16, 17, 18} }), // 3 > max 2 (over-run)
+			cp(nil), // 0 labels
+		),
 	},
 	"D07": {
 		pks(cp(func(o *dt.PacketOpts) { o.DstPort = 443 }), cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100}; o.DstPort = 443 })),

--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -43,10 +43,12 @@ func cp(mut func(o *dt.PacketOpts)) pktFn {
 
 func pks(fs ...pktFn) []pktFn { return fs }
 
-// asUDP / asICMP swap the default TCP L4 for the chain-shape match/reject cases.
+// asUDP / asICMP swap the default TCP L4 for the chain-shape match/reject
+// cases. Each sets all three L4 flags so the selection is unambiguous even
+// if a mutation composes them (buildL3L4 picks UDP before ICMP before TCP).
 var (
-	asUDP  = func(o *dt.PacketOpts) { o.TCP, o.UDP = false, true }
-	asICMP = func(o *dt.PacketOpts) { o.TCP, o.ICMP = false, true }
+	asUDP  = func(o *dt.PacketOpts) { o.TCP, o.UDP, o.ICMP = false, true, false }
+	asICMP = func(o *dt.PacketOpts) { o.TCP, o.UDP, o.ICMP = false, false, true }
 )
 
 func mac(s string) net.HardwareAddr {

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -99,18 +99,21 @@ const bpfLoopChainCap = 32
 // metadata on its first instruction — required by the kernel for any
 // bpf2bpf subprogram.
 //
-// s-bit termination here is exact for the cases that reach this path in
-// practice — `+` and `*` (RangeMin ≤ 1, unbounded RangeMax): the callback
-// breaks on the chain-end signal and the pre-loop check handles a
-// single-header stack, so there is no under- or over-run to bound. The
-// genuinely bounded `{n,m>staticChainCap}` shape with n ≥ 2 is the one
-// gap: a chain-end before RangeMin jumps to chainDone past the RangeMin
-// floor check, and a stack longer than RangeMax is not rejected (the
-// iteration cap stops consuming but the last header's s-bit is never
-// required). The common bounded MPLS quantifiers (m ≤ staticChainCap)
-// take the fully-guarded static path in chain.go; tightening this loop's
-// bounded case to match is a follow-up. Non-chain-end protocols (VLAN)
-// bound both ends via their self-dispatch peek and are unaffected.
+// s-bit termination here is exact for `+` and `*` (RangeMin ≤ 1,
+// unbounded RangeMax): the callback breaks on the chain-end signal and the
+// pre-loop check accepts a single-header stack as a valid natural end.
+// Under-run is bounded for the bounded `{n,m>staticChainCap}` shape too:
+// the pre-loop check rejects a single-header stack when RangeMin > 1, and
+// the post-loop RangeMin floor rejects a multi-header under-run. The one
+// remaining gap is over-run — a stack longer than RangeMax is not rejected
+// on the s-bit (the iteration cap stops consuming but the last header's
+// s-bit is never required), so it leans on the next layer's
+// self-validation to reject the mis-parse: masked in practice, never
+// reproduced as a false-accept, but not the primary guard. The common
+// bounded MPLS quantifiers (m ≤ staticChainCap) take the fully-guarded
+// static path in chain.go; tightening this loop's over-run to match is a
+// follow-up. Non-chain-end protocols (VLAN) bound both ends via their
+// self-dispatch peek.
 func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, asm.Instructions, error) {
 	rangeMin, _ := chainBounds(layer)
 	if rangeMin == 0 && index == 0 {
@@ -165,12 +168,19 @@ func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance
 
 	// Both branches above consumed iteration 0 and advanced offsetBase. If
 	// that header already signals chain-end (e.g. an MPLS single-label
-	// stack with s == 1), skip the bpf_loop entirely — otherwise its first
-	// callback iteration consumes the following layer as a phantom
-	// instance. No-op when the protocol declares no ChainEnd (VLAN
-	// terminates via its self-dispatch). For `*` the 0-label peek-miss has
-	// already jumped to chainDone, so this runs only when ≥1 was consumed.
-	preLoopEnd, err := chainEndCheck(layer.Spec, hs, staticChainFrame, chainDone)
+	// stack with s == 1), the stack has exactly one header. For `+` / `*`
+	// (RangeMin <= 1) that is a valid natural end → skip the bpf_loop
+	// entirely (otherwise its first callback iteration consumes the
+	// following layer as a phantom instance). For a bounded quantifier with
+	// RangeMin > 1 a single-header stack is an under-run → reject; skipping
+	// to chainDone here would bypass the post-loop RangeMin floor check and
+	// wrongly accept it. No-op when the protocol declares no ChainEnd (VLAN
+	// terminates via its self-dispatch).
+	preLoopTarget := chainDone
+	if rangeMin > 1 {
+		preLoopTarget = dslReject
+	}
+	preLoopEnd, err := chainEndCheck(layer.Spec, hs, staticChainFrame, preLoopTarget)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -98,6 +98,19 @@ const bpfLoopChainCap = 32
 // the main Return. The returned callback always carries btf.Func
 // metadata on its first instruction — required by the kernel for any
 // bpf2bpf subprogram.
+//
+// s-bit termination here is exact for the cases that reach this path in
+// practice — `+` and `*` (RangeMin ≤ 1, unbounded RangeMax): the callback
+// breaks on the chain-end signal and the pre-loop check handles a
+// single-header stack, so there is no under- or over-run to bound. The
+// genuinely bounded `{n,m>staticChainCap}` shape with n ≥ 2 is the one
+// gap: a chain-end before RangeMin jumps to chainDone past the RangeMin
+// floor check, and a stack longer than RangeMax is not rejected (the
+// iteration cap stops consuming but the last header's s-bit is never
+// required). The common bounded MPLS quantifiers (m ≤ staticChainCap)
+// take the fully-guarded static path in chain.go; tightening this loop's
+// bounded case to match is a follow-up. Non-chain-end protocols (VLAN)
+// bound both ends via their self-dispatch peek and are unaffected.
 func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, asm.Instructions, error) {
 	rangeMin, _ := chainBounds(layer)
 	if rangeMin == 0 && index == 0 {
@@ -302,23 +315,55 @@ func chainEndCheck(spec *vocab.ProtocolSpec, hs int, fr chainFrame, breakLabel s
 	if spec.ChainEnd == nil {
 		return nil, nil
 	}
-	byteOff, mask, expected, err := chainEndShape(spec)
+	insns, expected, err := chainEndLoad(spec, hs, fr, breakLabel)
 	if err != nil {
 		return nil, err
 	}
-	// The chain-end byte lives in the just-consumed header at
-	// fr.offset + (-hs + byteOff); the offset is post-advance so the
-	// const is typically negative.
+	// Terminate when the loaded value equals the chain-end value. MPLS
+	// declares CHAIN_END_S = 1: "stop when s == 1 (= bottom of stack)".
+	insns = append(insns, asm.JEq.Imm(fr.dst, expected, breakLabel))
+	return insns, nil
+}
+
+// chainEndRequire is the over-run guard for the last static iteration:
+// after consuming the quantifier's RangeMax headers without an earlier
+// natural end, the final header MUST signal chain-end, otherwise the
+// stack is longer than the quantifier allows and the chain rejects.
+// Inverse of chainEndCheck — jumps to rejectLabel when the signal is
+// *absent*. No-op for protocols without a chain-end signal (their
+// over-run is caught by the next layer's self-dispatch peek instead).
+func chainEndRequire(spec *vocab.ProtocolSpec, hs int, fr chainFrame, rejectLabel string) (asm.Instructions, error) {
+	if spec.ChainEnd == nil {
+		return nil, nil
+	}
+	insns, expected, err := chainEndLoad(spec, hs, fr, rejectLabel)
+	if err != nil {
+		return nil, err
+	}
+	insns = append(insns, asm.JNE.Imm(fr.dst, expected, rejectLabel))
+	return insns, nil
+}
+
+// chainEndLoad emits the load+mask of the just-consumed header's
+// chain-end byte into fr.dst and returns the expected value the caller
+// compares against. The byte lives in the just-consumed header at
+// fr.offset + (-hs + byteOff); the offset is post-advance so the const
+// is typically negative. boundsLabel takes an out-of-window load — for a
+// terminate check that means "treat as end", for an over-run guard
+// "reject", so the caller supplies the right target. Shared by
+// chainEndCheck and chainEndRequire.
+func chainEndLoad(spec *vocab.ProtocolSpec, hs int, fr chainFrame, boundsLabel string) (asm.Instructions, int32, error) {
+	byteOff, mask, expected, err := chainEndShape(spec)
+	if err != nil {
+		return nil, 0, err
+	}
 	loadByteOff := int32(-hs + byteOff)
-	insns := append(asm.Instructions{}, foldOffsetIntoScalar(fr.scalar, fr.offset, loadByteOff, breakLabel)...)
-	insns = append(insns, boundedScalarLoad(fr.dst, fr.start, fr.scalar, fr.end, asm.Byte, breakLabel)...)
+	insns := append(asm.Instructions{}, foldOffsetIntoScalar(fr.scalar, fr.offset, loadByteOff, boundsLabel)...)
+	insns = append(insns, boundedScalarLoad(fr.dst, fr.start, fr.scalar, fr.end, asm.Byte, boundsLabel)...)
 	if mask != 0xff {
 		insns = append(insns, asm.And.Imm(fr.dst, int32(mask)))
 	}
-	// Terminate when the loaded value equals the chain-end value. MPLS
-	// declares CHAIN_END_S = 1: "stop when s == 1 (= bottom of stack)".
-	insns = append(insns, asm.JEq.Imm(fr.dst, int32(expected), breakLabel))
-	return insns, nil
+	return insns, int32(expected), nil
 }
 
 // chainEndShape resolves the vocab's CHAIN_END field into (byteOff,

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -150,6 +150,19 @@ func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance
 		mainInsns = append(mainInsns, first...)
 	}
 
+	// Both branches above consumed iteration 0 and advanced offsetBase. If
+	// that header already signals chain-end (e.g. an MPLS single-label
+	// stack with s == 1), skip the bpf_loop entirely — otherwise its first
+	// callback iteration consumes the following layer as a phantom
+	// instance. No-op when the protocol declares no ChainEnd (VLAN
+	// terminates via its self-dispatch). For `*` the 0-label peek-miss has
+	// already jumped to chainDone, so this runs only when ≥1 was consumed.
+	preLoopEnd, err := chainEndCheck(layer.Spec, hs, staticChainFrame, chainDone)
+	if err != nil {
+		return nil, nil, err
+	}
+	mainInsns = append(mainInsns, preLoopEnd...)
+
 	// Seed ctx with offsetBase + scratch_start/end, then call bpf_loop
 	// with (max_iter, &cb, &ctx, flags=0). R0..R5 are caller-saved
 	// across the helper so we must restore them from ctx afterwards.
@@ -183,13 +196,14 @@ func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance
 		asm.LoadMem(asm.R1, asm.R10, bpfLoopCtxScratchEndSlot, asm.DWord),
 	)
 
-	if optionalChain {
-		// Landing for the `*` peek-miss path. The no-op must use a
-		// register whose verifier type agrees on both paths: the
-		// peek-miss path skipped the helper entirely, so R0 retains
-		// the scratch_start PTR_TO_MAP_VALUE; the bpf_loop path
-		// just reloaded it from ctx. R3 is caller-saved and would
-		// land as !read_ok on the miss path.
+	if optionalChain || layer.Spec.ChainEnd != nil {
+		// Landing for paths that jump past the bpf_loop call: the `*`
+		// peek-miss path, and the pre-loop chain-end skip above. The
+		// no-op must use a register whose verifier type agrees on both
+		// paths: the skip paths never entered the helper, so R0 retains
+		// the scratch_start PTR_TO_MAP_VALUE; the bpf_loop path just
+		// reloaded it from ctx. R3 is caller-saved and would land as
+		// !read_ok on the miss path.
 		mainInsns = append(mainInsns, asm.Mov.Reg(asm.R0, asm.R0).WithSymbol(chainDone))
 	}
 
@@ -232,7 +246,7 @@ func genBpfLoopCallback(spec *vocab.ProtocolSpec, selfConst *vocab.DispatchConst
 		asm.Add.Imm(asm.R3, int32(hs)),
 		asm.StoreMem(asm.R2, bpfLoopCbCtxOffsetField, asm.R3, asm.DWord),
 	)
-	endCheck, err := chainEndCheck(spec, hs, breakLabel)
+	endCheck, err := chainEndCheck(spec, hs, loopChainFrame, breakLabel)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +279,26 @@ func genBpfLoopCallback(spec *vocab.ProtocolSpec, selfConst *vocab.DispatchConst
 // Wider byte-aligned fields (16/32-bit) and bit fields wider than 1
 // are deliberately rejected so the codegen path stays auditable; add
 // support when a real protocol needs it.
-func chainEndCheck(spec *vocab.ProtocolSpec, hs int, breakLabel string) (asm.Instructions, error) {
+// chainFrame names the registers a chain-end check uses, so the static
+// unroll path and the bpf_loop callback can share one chainEndCheck even
+// though their frames map the offset / window / scratch to different
+// registers. This is what makes quantifier termination uniform across
+// protocols: VLAN ends on its self-dispatch ethertype, MPLS on its s-bit
+// chain-end signal, and both codegen paths run the same check.
+type chainFrame struct {
+	offset, start, end, scalar, dst asm.Register
+}
+
+var (
+	// loopChainFrame: inside the bpf_loop callback the idx is gone, so
+	// R0/R1 are free; R3=post-advance offset, R4=window start, R5=end.
+	loopChainFrame = chainFrame{offset: asm.R3, start: asm.R4, end: asm.R5, scalar: asm.R1, dst: asm.R0}
+	// staticChainFrame: the main frame's host ABI — offsetBase=R4,
+	// window is [R0, R1], R3/R5 are scratch.
+	staticChainFrame = chainFrame{offset: offsetBase, start: asm.R0, end: asm.R1, scalar: asm.R3, dst: asm.R5}
+)
+
+func chainEndCheck(spec *vocab.ProtocolSpec, hs int, fr chainFrame, breakLabel string) (asm.Instructions, error) {
 	if spec.ChainEnd == nil {
 		return nil, nil
 	}
@@ -273,20 +306,18 @@ func chainEndCheck(spec *vocab.ProtocolSpec, hs int, breakLabel string) (asm.Ins
 	if err != nil {
 		return nil, err
 	}
-	// Chain-end byte lives at R4 + R3 + (-hs + byteOff); R3 is
-	// post-advance so the const offset is typically negative. R1 is
-	// free in this callback frame (bpf_loop idx no longer used) — use
-	// it as the scalar scratch.
+	// The chain-end byte lives in the just-consumed header at
+	// fr.offset + (-hs + byteOff); the offset is post-advance so the
+	// const is typically negative.
 	loadByteOff := int32(-hs + byteOff)
-	insns := append(asm.Instructions{}, foldOffsetIntoScalar(asm.R1, asm.R3, loadByteOff, breakLabel)...)
-	insns = append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R1, asm.R5, asm.Byte, breakLabel)...)
+	insns := append(asm.Instructions{}, foldOffsetIntoScalar(fr.scalar, fr.offset, loadByteOff, breakLabel)...)
+	insns = append(insns, boundedScalarLoad(fr.dst, fr.start, fr.scalar, fr.end, asm.Byte, breakLabel)...)
 	if mask != 0xff {
-		insns = append(insns, asm.And.Imm(asm.R0, int32(mask)))
+		insns = append(insns, asm.And.Imm(fr.dst, int32(mask)))
 	}
-	// Break when the loaded value equals the chain-end value. MPLS
-	// declares CHAIN_END_S = 1: "stop iterating when s == 1 (=
-	// bottom of stack)".
-	insns = append(insns, asm.JEq.Imm(asm.R0, int32(expected), breakLabel))
+	// Terminate when the loaded value equals the chain-end value. MPLS
+	// declares CHAIN_END_S = 1: "stop when s == 1 (= bottom of stack)".
+	insns = append(insns, asm.JEq.Imm(fr.dst, int32(expected), breakLabel))
 	return insns, nil
 }
 

--- a/pkg/kunai/codegen/chain.go
+++ b/pkg/kunai/codegen/chain.go
@@ -88,6 +88,18 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 		failLabel := dslReject
 		if i >= layer.RangeMin {
 			failLabel = chainDone
+			// RangeMin is satisfied (i instances consumed): terminate the
+			// chain when the just-consumed header signals chain-end — the
+			// same s-bit check the bpf_loop path runs. Protocols that
+			// distinguish the next instance by a self-dispatch const (VLAN
+			// ethertype) declare no ChainEnd, so this is a no-op for them
+			// and they terminate via genDispatch below instead. Either way
+			// both paths share one termination mechanism.
+			endCheck, err := chainEndCheck(layer.Spec, hs, staticChainFrame, chainDone)
+			if err != nil {
+				return nil, err
+			}
+			insns = append(insns, endCheck...)
 		}
 		dispatch, err := genDispatch(selfLayer, layer, hs, selfRange, selfRange, failLabel)
 		if err != nil {

--- a/pkg/kunai/codegen/chain.go
+++ b/pkg/kunai/codegen/chain.go
@@ -50,6 +50,14 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 	}
 	insns := append(asm.Instructions{}, first...)
 	if layer.RangeMax == 1 {
+		// One mandatory header. For a chain-end protocol it must signal
+		// end, else an (RangeMax+1)-th header follows that the quantifier
+		// disallows — reject. No-op for self-dispatch protocols.
+		overRun, err := chainEndRequire(layer.Spec, hs, staticChainFrame, dslReject)
+		if err != nil {
+			return nil, err
+		}
+		insns = append(insns, overRun...)
 		return insns, nil
 	}
 
@@ -85,23 +93,25 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 	// the unroll loop since it is invariant across iterations.
 	selfRange := precedingLayersLeaveR4Range(all, index)
 	for i := 1; i < layer.RangeMax; i++ {
-		failLabel := dslReject
+		// Where this iteration goes when the chain ends here (i headers in
+		// so far). Below RangeMin a chain-end means the stack is shorter
+		// than the quantifier requires (under-run) → reject; at or above
+		// RangeMin it is a valid natural end → terminate the chain and fall
+		// through to the next layer. Both termination mechanisms share the
+		// target: chainEndCheck (the MPLS s-bit, the same check the bpf_loop
+		// path runs) and genDispatch's fail path (VLAN's self-dispatch peek,
+		// for which chainEndCheck is a no-op).
+		target := dslReject
 		if i >= layer.RangeMin {
-			failLabel = chainDone
-			// RangeMin is satisfied (i instances consumed): terminate the
-			// chain when the just-consumed header signals chain-end — the
-			// same s-bit check the bpf_loop path runs. Protocols that
-			// distinguish the next instance by a self-dispatch const (VLAN
-			// ethertype) declare no ChainEnd, so this is a no-op for them
-			// and they terminate via genDispatch below instead. Either way
-			// both paths share one termination mechanism.
-			endCheck, err := chainEndCheck(layer.Spec, hs, staticChainFrame, chainDone)
-			if err != nil {
-				return nil, err
-			}
-			insns = append(insns, endCheck...)
+			target = chainDone
 		}
-		dispatch, err := genDispatch(selfLayer, layer, hs, selfRange, selfRange, failLabel)
+		endCheck, err := chainEndCheck(layer.Spec, hs, staticChainFrame, target)
+		if err != nil {
+			return nil, err
+		}
+		insns = append(insns, endCheck...)
+
+		dispatch, err := genDispatch(selfLayer, layer, hs, selfRange, selfRange, target)
 		if err != nil {
 			return nil, err
 		}
@@ -111,11 +121,21 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 		insns = append(insns, emitAdvance(hs))
 	}
 
+	// All RangeMax headers consumed without an earlier natural end: the
+	// last one must signal chain-end, else the stack is longer than the
+	// quantifier allows (over-run) → reject. No-op for self-dispatch
+	// protocols, whose over-run the next layer's dispatch peek catches.
+	overRun, err := chainEndRequire(layer.Spec, hs, staticChainFrame, dslReject)
+	if err != nil {
+		return nil, err
+	}
+	insns = append(insns, overRun...)
+
 	if layer.RangeMin < layer.RangeMax {
-		// Landing for any optional iteration that missed its
-		// self-dispatch peek: falls through to the next layer with
-		// offsetBase still pointing past the last successful
-		// iteration.
+		// Landing for any in-range iteration that hit its natural chain-end
+		// (or, for self-dispatch protocols, missed its self-dispatch peek):
+		// falls through to the next layer with offsetBase still pointing
+		// past the last successful iteration.
 		insns = append(insns, landingNoop(chainDone))
 	}
 	return insns, nil

--- a/pkg/kunai/codegen/codegen_test.go
+++ b/pkg/kunai/codegen/codegen_test.go
@@ -367,6 +367,59 @@ func TestGenArithNestedHappyPath(t *testing.T) {
 	}
 }
 
+// deepLeftArithCompare returns `ipv4.total_length == (1+1+...+1)` whose
+// RHS is `binops` left-leaning additions, so its leaves land at arith
+// call-depth `binops`. layer is the ipv4 LayerInstance the field reads.
+func deepLeftArithCompare(layer *ir.LayerInstance, binops int) *ir.Condition {
+	var expr = &ir.ArithExpr{Kind: ast.ArithConst, Const: 1}
+	for range binops {
+		expr = &ir.ArithExpr{
+			Kind:  ast.ArithBinOp,
+			Op:    ast.ArithAdd,
+			Left:  expr,
+			Right: &ir.ArithExpr{Kind: ast.ArithConst, Const: 1},
+		}
+	}
+	return &ir.Condition{
+		Kind:   ast.WAtomArith,
+		Op:     ast.CmpEq,
+		ArithL: &ir.ArithExpr{Kind: ast.ArithField, Field: &ir.FieldRef{Layer: layer, Field: &ipv4Spec.Fields[3]}},
+		ArithR: expr,
+	}
+}
+
+// TestGenBoolEqOperandArithDepthBudget pins the bool-eq / operand-arith
+// slot accounting. genBoolEq parks each operand's LHS truth value at the
+// top of the arith region, so genArithWithBits lowers the usable arith
+// depth by the bool-eq nesting level: a `+`/`-` chain that compiles at the
+// top depth standalone must be rejected once it sits inside a bool-eq
+// operand, where climbing that deep would clobber the parked LHS and
+// silently mis-compare.
+func TestGenBoolEqOperandArithDepthBudget(t *testing.T) {
+	// binops = maxArithDepth-1 puts the leaves at the deepest call-depth
+	// the full (boolEqDepth == 0) guard still accepts.
+	const binops = maxArithDepth - 1
+
+	standalone := ethIPv4TCPProgram()
+	standalone.Where = deepLeftArithCompare(standalone.Layers[1], binops)
+	if _, err := Gen(standalone, Capabilities{}); err != nil {
+		t.Fatalf("standalone deep arith should compile at the top depth: %v", err)
+	}
+
+	// Same chain as a bool-eq operand: the budget drops by one level, so
+	// the deepest leaf now exceeds the ceiling and is rejected.
+	nested := ethIPv4TCPProgram()
+	nested.Where = &ir.Condition{
+		Kind:     ast.WAtomBoolEq,
+		BoolEqOp: ast.CmpEq,
+		BoolL:    deepLeftArithCompare(nested.Layers[1], binops),
+		BoolR:    deepLeftArithCompare(nested.Layers[1], 0), // shallow, valid operand
+	}
+	if _, err := Gen(nested, Capabilities{}); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("deep arith inside bool-eq operand: err = %v; want ErrNotImplemented", err)
+	}
+}
+
 // --- Logical ops ---
 
 func actionAtom(v string) *ir.Condition {

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -671,6 +671,15 @@ func (c *whereCtx) genNot(w *ir.Condition, failLabel string) (asm.Instructions, 
 //     LHS hold, 2,3 for genArith128's `field + field` LHS hi/lo, and
 //     4 for genArithField128Load's high-half transient stash.
 //
+// genBoolEq also parks LHS truth values in this region, growing *down*
+// from slot 15 (one per bool-eq nesting level) while operand arith grows
+// *up* from slot 0. The two are kept disjoint by two guards: bool-eq park
+// slots can't drop below boolEqOperandReserve (protecting the 128-bit
+// path's fixed low slots), and genArithWithBits caps operand arith depth
+// at maxArithDepth-boolEqDepth (protecting the parked slots from a deep
+// `+`/`-` chain). Without the latter, a bool-eq operand arith chain
+// reaching slot 15 would overwrite the saved LHS and silently mis-compare.
+//
 // The deepest slot (slot 15 at -176) writes bytes [-176, -168) and
 // abuts bpfLoopCtxLayerEntrySlot's range [-184, -176) without
 // overlap.
@@ -1057,8 +1066,17 @@ func (c *whereCtx) genArith(e *ir.ArithExpr, depth int) (asm.Instructions, error
 // the constant to its low `targetBits` so 2's-complement negative
 // literals fit the BPF int32 immediate.
 func (c *whereCtx) genArithWithBits(e *ir.ArithExpr, depth int, targetBits int) (asm.Instructions, error) {
-	if depth >= maxArithDepth {
-		return nil, fmt.Errorf("%w: arith expression nested deeper than %d levels", ErrNotImplemented, maxArithDepth)
+	// Cap the usable arith depth by the bool-eq LHS values currently
+	// parked at the top of the arith region. genBoolEq parks one slot per
+	// nesting level growing down from slot maxArithDepth-1, so operand
+	// arith must stay strictly below the lowest parked slot; otherwise a
+	// deep `+`/`-` chain inside a bool-eq operand reaches slot
+	// (maxArithDepth-1) and overwrites the saved LHS, silently
+	// mis-comparing. Outside any bool-eq (boolEqDepth == 0) the ceiling is
+	// the full maxArithDepth, so non-bool-eq expressions are unaffected.
+	ceiling := maxArithDepth - c.boolEqDepth
+	if depth >= ceiling {
+		return nil, fmt.Errorf("%w: arith expression nested deeper than %d levels", ErrNotImplemented, ceiling)
 	}
 	switch e.Kind {
 	case ast.ArithConst:

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -169,7 +169,9 @@ func (c *whereCtx) genBoolEq(w *ir.Condition, failLabel string) (asm.Instruction
 	// bool-eq) parks its own LHS one slot lower, so they never collide.
 	slotDepth := maxArithDepth - 1 - c.boolEqDepth
 	if slotDepth < boolEqOperandReserve {
-		return nil, fmt.Errorf("%w: bool-eq nested deeper than %d levels", ErrNotImplemented, maxArithDepth-1-boolEqOperandReserve)
+		// Usable park slots are boolEqOperandReserve..maxArithDepth-1
+		// inclusive, i.e. maxArithDepth-boolEqOperandReserve nesting levels.
+		return nil, fmt.Errorf("%w: bool-eq nested deeper than %d levels", ErrNotImplemented, maxArithDepth-boolEqOperandReserve)
 	}
 	slot := arithStackSlot(slotDepth)
 

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -23,6 +23,10 @@ type whereCtx struct {
 	labels  int
 	anchors map[*ir.LayerInstance]layerAnchor
 	queried queriedOptions
+	// boolEqDepth is the current `Bool == Bool` nesting level. genBoolEq
+	// uses it to pick a distinct LHS-save slot per level so a nested
+	// bool-eq operand does not clobber an enclosing one.
+	boolEqDepth int
 }
 
 func (c *whereCtx) freshLabel(prefix string) string {
@@ -146,14 +150,6 @@ func (c *whereCtx) genBoolEq(w *ir.Condition, failLabel string) (asm.Instruction
 	if w == nil || w.BoolL == nil || w.BoolR == nil {
 		return nil, fmt.Errorf("codegen: bool-eq lacks operands")
 	}
-	leftInsns, err := c.genConditionAsBool(w.BoolL)
-	if err != nil {
-		return nil, err
-	}
-	rightInsns, err := c.genConditionAsBool(w.BoolR)
-	if err != nil {
-		return nil, err
-	}
 	var jumpOp asm.JumpOp
 	switch w.BoolEqOp {
 	case ast.CmpEq:
@@ -165,10 +161,30 @@ func (c *whereCtx) genBoolEq(w *ir.Condition, failLabel string) (asm.Instruction
 	default:
 		return nil, fmt.Errorf("codegen: bool-eq with op %v not supported", w.BoolEqOp)
 	}
-	// Reuse the arith scratch slot 0; bool-eq doesn't nest with
-	// arith binops in the resolved IR (parser produces them as
-	// disjoint subtrees), so the slot is free at this point.
-	slot := arithStackSlot(0)
+	// Park the LHS truth value across the RHS evaluation. The RHS is a full
+	// condition whose own comparison/arith codegen writes the low arith
+	// scratch slots (slot 0 for a scalar compare, up to slot 4 for a
+	// 128-bit compare), so the LHS lives in the top of the arith region.
+	// One slot per bool-eq nesting level: a bool-eq operand (nested
+	// bool-eq) parks its own LHS one slot lower, so they never collide.
+	slotDepth := maxArithDepth - 1 - c.boolEqDepth
+	if slotDepth < boolEqOperandReserve {
+		return nil, fmt.Errorf("%w: bool-eq nested deeper than %d levels", ErrNotImplemented, maxArithDepth-1-boolEqOperandReserve)
+	}
+	slot := arithStackSlot(slotDepth)
+
+	// Operands are one level deeper so a nested bool-eq uses a lower slot.
+	c.boolEqDepth++
+	defer func() { c.boolEqDepth-- }()
+	leftInsns, err := c.genConditionAsBool(w.BoolL)
+	if err != nil {
+		return nil, err
+	}
+	rightInsns, err := c.genConditionAsBool(w.BoolR)
+	if err != nil {
+		return nil, err
+	}
+
 	var insns asm.Instructions
 	insns = append(insns, leftInsns...)
 	insns = append(insns, asm.StoreMem(asm.R10, slot, asm.R3, asm.DWord))
@@ -181,11 +197,11 @@ func (c *whereCtx) genBoolEq(w *ir.Condition, failLabel string) (asm.Instruction
 // genConditionAsBool evaluates cond once and leaves R3 ∈ {0, 1}
 // reflecting whether cond was true. Internally:
 //
-//   inner emit (jump to `falsyLabel` on miss)
-//   R3 = 1
-//   Ja done
-//   falsyLabel: R3 = 0
-//   done:
+//	inner emit (jump to `falsyLabel` on miss)
+//	R3 = 1
+//	Ja done
+//	falsyLabel: R3 = 0
+//	done:
 //
 // Used by genBoolEq so each operand of a Bool == Bool comparison is
 // emitted exactly once.
@@ -306,6 +322,7 @@ func (c *whereCtx) genQuantUnroll(w *ir.Condition, acceptLabel, failLabel string
 // it. The fail target depends on anySemantics:
 //   - any: per-iter mismatch → iterSkip (= "try next iter")
 //   - all: per-iter mismatch → failLabel (= "all() fails")
+//
 // On success:
 //   - any: emit a Ja to acceptLabel after the body so the unroll
 //     short-circuits
@@ -581,10 +598,10 @@ func (c *whereCtx) genAnd(w *ir.Condition, failLabel string) (asm.Instructions, 
 // genOr: left success skips right (short-circuit accept); otherwise
 // try right with the caller's failLabel.
 //
-//   <left with failLabel = tryRight>
-//   Ja orDone
-//   tryRight: <right with failLabel = failLabel>
-//   orDone: <landing symbol>
+//	<left with failLabel = tryRight>
+//	Ja orDone
+//	tryRight: <right with failLabel = failLabel>
+//	orDone: <landing symbol>
 func (c *whereCtx) genOr(w *ir.Condition, failLabel string) (asm.Instructions, error) {
 	tryRight := c.freshLabel("or_right")
 	orDone := c.freshLabel("or_done")
@@ -620,9 +637,9 @@ func (c *whereCtx) genOr(w *ir.Condition, failLabel string) (asm.Instructions, e
 // genNot: inner success means "not" fails; inner failure means "not"
 // succeeds.
 //
-//   <inner with failLabel = notSucc>
-//   Ja failLabel    # inner succeeded → not fails
-//   notSucc: <landing symbol>
+//	<inner with failLabel = notSucc>
+//	Ja failLabel    # inner succeeded → not fails
+//	notSucc: <landing symbol>
 func (c *whereCtx) genNot(w *ir.Condition, failLabel string) (asm.Instructions, error) {
 	notSucc := c.freshLabel("not_succ")
 	inner, err := c.gen(w.Inner, notSucc)
@@ -660,6 +677,12 @@ func (c *whereCtx) genNot(w *ir.Condition, failLabel string) (asm.Instructions, 
 const (
 	arithStackBase = -56
 	maxArithDepth  = 16
+	// boolEqOperandReserve is how many low arith slots a single bool-eq
+	// operand compare may consume (slots 0..4 for a 128-bit compare).
+	// genBoolEq parks its LHS in the top of the arith region growing
+	// downward one slot per nesting level, so it must stay above these
+	// reserved low slots; deeper bool-eq nesting is rejected.
+	boolEqOperandReserve = 5
 )
 
 // arithCmpTargetBits returns the comparison's effective integer
@@ -819,12 +842,12 @@ func (c *whereCtx) genArithCompare128(w *ir.Condition, failLabel string, targetB
 //   - ArithField: 16-byte field load via genArithField128Load
 //   - ArithConst: literal materialised as (0, const) (rare standalone)
 //   - ArithBinOp with op ∈ {+, -}:
-//     - `field op const`: const folded into low half, carry/borrow
-//       propagated to high via a const-relative compare (no register
-//       beyond R3/R5 needed).
-//     - `field op field`: LHS preserved in arith slots 2/3 while RHS
-//       is computed, then RHS is the in-place accumulator that LHS
-//       gets added/subtracted into.
+//   - `field op const`: const folded into low half, carry/borrow
+//     propagated to high via a const-relative compare (no register
+//     beyond R3/R5 needed).
+//   - `field op field`: LHS preserved in arith slots 2/3 while RHS
+//     is computed, then RHS is the in-place accumulator that LHS
+//     gets added/subtracted into.
 //
 // Mul / div / mod on bit<128> stay ErrNotImplemented (F5 — bit-slice
 // covers the practical IPv6 manipulation cases).
@@ -908,7 +931,9 @@ func (c *whereCtx) genArith128FieldOpConst(e *ir.ArithExpr) (asm.Instructions, e
 // host-callee-saved, R0/R4 carry packet pointers we mustn't trample).
 //
 // Output: R3 = (lhs_high + rhs_high + carry) mod 2^64,
-//         R5 = (lhs_low  + rhs_low)            mod 2^64
+//
+//	R5 = (lhs_low  + rhs_low)            mod 2^64
+//
 // (mirrored for sub: borrow propagates from low to high).
 func (c *whereCtx) genArith128FieldOpField(e *ir.ArithExpr) (asm.Instructions, error) {
 	leftInsns, err := c.genArith128(e.Left)
@@ -934,7 +959,7 @@ func (c *whereCtx) genArith128FieldOpField(e *ir.ArithExpr) (asm.Instructions, e
 		// register" slot. R5 keeps rhs_low until we add lhs_low.
 		insns = append(insns, asm.StoreMem(asm.R10, arithStackSlot(4), asm.R3, asm.DWord))
 		insns = append(insns, asm.LoadMem(asm.R3, asm.R10, lhsLowSlot, asm.DWord)) // R3 = lhs_low
-		insns = append(insns, asm.Add.Reg(asm.R5, asm.R3))                          // R5 = lhs_low + rhs_low
+		insns = append(insns, asm.Add.Reg(asm.R5, asm.R3))                         // R5 = lhs_low + rhs_low
 		// Carry iff sum < lhs_low (R3 still holds lhs_low).
 		noCarry := c.freshLabel("v128_ff_nocarry")
 		insns = append(insns, asm.JGE.Reg(asm.R5, asm.R3, noCarry))
@@ -947,11 +972,11 @@ func (c *whereCtx) genArith128FieldOpField(e *ir.ArithExpr) (asm.Instructions, e
 		// R5 holds new_low. Compute R3 = rhs_high + lhs_high
 		// (carry-adjusted). Park R5, free R3 for the high add.
 		insns = append(insns,
-			asm.StoreMem(asm.R10, lhsLowSlot, asm.R5, asm.DWord), // park new_low briefly
+			asm.StoreMem(asm.R10, lhsLowSlot, asm.R5, asm.DWord),       // park new_low briefly
 			asm.LoadMem(asm.R3, asm.R10, arithStackSlot(4), asm.DWord), // R3 = rhs_high
-			asm.LoadMem(asm.R5, asm.R10, lhsHighSlot, asm.DWord),        // R5 = lhs_high (carry-adjusted)
-			asm.Add.Reg(asm.R3, asm.R5),                                 // R3 = rhs_high + lhs_high
-			asm.LoadMem(asm.R5, asm.R10, lhsLowSlot, asm.DWord),         // R5 = new_low restored
+			asm.LoadMem(asm.R5, asm.R10, lhsHighSlot, asm.DWord),       // R5 = lhs_high (carry-adjusted)
+			asm.Add.Reg(asm.R3, asm.R5),                                // R3 = rhs_high + lhs_high
+			asm.LoadMem(asm.R5, asm.R10, lhsLowSlot, asm.DWord),        // R5 = new_low restored
 		)
 	case ast.ArithSub:
 		// Sub mirror: borrow ⇔ lhs_low < rhs_low. Detect first, then
@@ -971,12 +996,12 @@ func (c *whereCtx) genArith128FieldOpField(e *ir.ArithExpr) (asm.Instructions, e
 		// the Mov R5,R3 + Store R5 → slot dance collapses to one
 		// Store. R5 stays free for the rhs_high load below.
 		insns = append(insns,
-			asm.Sub.Reg(asm.R3, asm.R5),                                 // R3 = lhs_low − rhs_low
-			asm.StoreMem(asm.R10, lhsLowSlot, asm.R3, asm.DWord),        // park new_low
-			asm.LoadMem(asm.R3, asm.R10, lhsHighSlot, asm.DWord),        // R3 = lhs_high (carry-adjusted)
-			asm.LoadMem(asm.R5, asm.R10, arithStackSlot(4), asm.DWord),  // R5 = rhs_high
-			asm.Sub.Reg(asm.R3, asm.R5),                                 // R3 = new_high
-			asm.LoadMem(asm.R5, asm.R10, lhsLowSlot, asm.DWord),         // R5 = new_low
+			asm.Sub.Reg(asm.R3, asm.R5),                                // R3 = lhs_low − rhs_low
+			asm.StoreMem(asm.R10, lhsLowSlot, asm.R3, asm.DWord),       // park new_low
+			asm.LoadMem(asm.R3, asm.R10, lhsHighSlot, asm.DWord),       // R3 = lhs_high (carry-adjusted)
+			asm.LoadMem(asm.R5, asm.R10, arithStackSlot(4), asm.DWord), // R5 = rhs_high
+			asm.Sub.Reg(asm.R3, asm.R5),                                // R3 = new_high
+			asm.LoadMem(asm.R5, asm.R10, lhsLowSlot, asm.DWord),        // R5 = new_low
 		)
 	}
 	return insns, nil

--- a/pkg/kunai/dsltest/builders.go
+++ b/pkg/kunai/dsltest/builders.go
@@ -532,6 +532,10 @@ func BuildVXLANInnerIPv4TCP(t testing.TB, innerDst net.IP, innerDstPort uint16) 
 	if innerDst == nil {
 		innerDst = net.IPv4(10, 0, 0, 1)
 	}
+	innerDst4 := innerDst.To4()
+	if innerDst4 == nil {
+		t.Fatalf("BuildVXLANInnerIPv4TCP: innerDst %v is not an IPv4 address", innerDst)
+	}
 	if innerDstPort == 0 {
 		innerDstPort = 80
 	}
@@ -547,7 +551,7 @@ func BuildVXLANInnerIPv4TCP(t testing.TB, innerDst net.IP, innerDstPort uint16) 
 	vx := &layers.VXLAN{ValidIDFlag: true, VNI: 100}
 	inner := &layers.IPv4{
 		Version: 4, IHL: 5, TTL: 64,
-		SrcIP: net.IPv4(192, 168, 0, 1).To4(), DstIP: innerDst.To4(),
+		SrcIP: net.IPv4(192, 168, 0, 1).To4(), DstIP: innerDst4,
 		Protocol: layers.IPProtocolTCP,
 	}
 	itcp := &layers.TCP{

--- a/pkg/kunai/dsltest/builders.go
+++ b/pkg/kunai/dsltest/builders.go
@@ -31,6 +31,11 @@ type PacketOpts struct {
 	// IP layer: SrcIP / DstIP (v4 or v6). When both are nil, no IP.
 	SrcIP, DstIP net.IP
 	IPProto      uint8 // overridden by upper layer when zero
+	// TTL sets the IPv4 TTL (and is ignored for IPv6, which uses a
+	// fixed HopLimit). Zero means the default 64, so predicates like
+	// `ipv4[ttl==64]` match out of the box and a reject case sets a
+	// different value.
+	TTL uint8
 
 	// L4
 	SrcPort, DstPort uint16
@@ -206,10 +211,14 @@ func buildL3L4(t testing.TB, o *PacketOpts, isV6 bool) ([]gopacket.SerializableL
 		}
 		ip, netLayer = v6, v6
 	default:
+		ttl := o.TTL
+		if ttl == 0 {
+			ttl = 64
+		}
 		v4 := &layers.IPv4{
 			Version:  4,
 			IHL:      5,
-			TTL:      64,
+			TTL:      ttl,
 			SrcIP:    o.SrcIP.To4(),
 			DstIP:    o.DstIP.To4(),
 			Protocol: layers.IPProtocolTCP,
@@ -237,9 +246,11 @@ func buildL3L4(t testing.TB, o *PacketOpts, isV6 bool) ([]gopacket.SerializableL
 		upper = append(upper, udp)
 	case o.ICMP:
 		if isV6 {
-			upper = append(upper, &layers.ICMPv6{
+			icmp6 := &layers.ICMPv6{
 				TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
-			})
+			}
+			_ = icmp6.SetNetworkLayerForChecksum(netLayer)
+			upper = append(upper, icmp6)
 		} else {
 			upper = append(upper, &layers.ICMPv4{
 				TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
@@ -432,11 +443,11 @@ func stripToTCPSegment(t testing.TB, src, dst net.IP, srcPort, dstPort uint16) [
 
 // SRv6Opts describes an Ethernet/IPv6/SRH/<inner> frame.
 type SRv6Opts struct {
-	Src, Dst         net.IP
-	Segments         []net.IP // segment list (last_entry+1 entries); first is innermost
-	InnerNextHeader  uint8    // protocol for SRH.next_header (e.g. 6=TCP)
-	InnerSrcPort     uint16
-	InnerDstPort     uint16
+	Src, Dst        net.IP
+	Segments        []net.IP // segment list (last_entry+1 entries); first is innermost
+	InnerNextHeader uint8    // protocol for SRH.next_header (e.g. 6=TCP)
+	InnerSrcPort    uint16
+	InnerDstPort    uint16
 }
 
 // BuildSRv6 builds Ethernet+IPv6(NH=43)+SRH+inner-TCP. The number
@@ -493,7 +504,7 @@ func BuildEthIPv4UDPVXLAN(t testing.TB, vni uint32) []byte {
 	d := Defaults()
 	eth := &layers.Ethernet{SrcMAC: d.SrcMAC, DstMAC: d.DstMAC, EthernetType: layers.EthernetTypeIPv4}
 	v4 := &layers.IPv4{
-		Version:  4, IHL: 5, TTL: 64,
+		Version: 4, IHL: 5, TTL: 64,
 		SrcIP:    d.SrcIP.To4(),
 		DstIP:    d.DstIP.To4(),
 		Protocol: layers.IPProtocolUDP,
@@ -506,6 +517,49 @@ func BuildEthIPv4UDPVXLAN(t testing.TB, vni uint32) []byte {
 		ComputeChecksums: true, FixLengths: true,
 	}, eth, v4, udp, vx); err != nil {
 		t.Fatalf("gopacket.SerializeLayers (vxlan): %v", err)
+	}
+	return buf.Bytes()
+}
+
+// BuildVXLANInnerIPv4TCP builds eth/ipv4/udp(4789)/VXLAN/ipv4/tcp.
+// The vxlan vocab parser extracts the fixed 8-byte header and accepts,
+// transitioning straight to the next network header (no inner
+// Ethernet), so the inner IPv4/TCP sits immediately after the VXLAN
+// header. innerDst and innerDstPort drive the fields the F00/F03
+// corpus filters read; nil/zero fall back to 10.0.0.1 / port 80.
+func BuildVXLANInnerIPv4TCP(t testing.TB, innerDst net.IP, innerDstPort uint16) []byte {
+	t.Helper()
+	if innerDst == nil {
+		innerDst = net.IPv4(10, 0, 0, 1)
+	}
+	if innerDstPort == 0 {
+		innerDstPort = 80
+	}
+	d := Defaults()
+	eth := &layers.Ethernet{SrcMAC: d.SrcMAC, DstMAC: d.DstMAC, EthernetType: layers.EthernetTypeIPv4}
+	outer := &layers.IPv4{
+		Version: 4, IHL: 5, TTL: 64,
+		SrcIP: d.SrcIP.To4(), DstIP: d.DstIP.To4(),
+		Protocol: layers.IPProtocolUDP,
+	}
+	udp := &layers.UDP{SrcPort: 12345, DstPort: 4789}
+	_ = udp.SetNetworkLayerForChecksum(outer)
+	vx := &layers.VXLAN{ValidIDFlag: true, VNI: 100}
+	inner := &layers.IPv4{
+		Version: 4, IHL: 5, TTL: 64,
+		SrcIP: net.IPv4(192, 168, 0, 1).To4(), DstIP: innerDst.To4(),
+		Protocol: layers.IPProtocolTCP,
+	}
+	itcp := &layers.TCP{
+		SrcPort: 1024, DstPort: layers.TCPPort(innerDstPort),
+		Window: 65535, SYN: true, Seq: 1,
+	}
+	_ = itcp.SetNetworkLayerForChecksum(inner)
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{
+		ComputeChecksums: true, FixLengths: true,
+	}, eth, outer, udp, vx, inner, itcp); err != nil {
+		t.Fatalf("gopacket.SerializeLayers (vxlan inner): %v", err)
 	}
 	return buf.Bytes()
 }
@@ -630,7 +684,7 @@ func BuildEthIPv4UDPGeneve(t testing.TB, vni uint32) []byte {
 	d := Defaults()
 	eth := &layers.Ethernet{SrcMAC: d.SrcMAC, DstMAC: d.DstMAC, EthernetType: layers.EthernetTypeIPv4}
 	v4 := &layers.IPv4{
-		Version:  4, IHL: 5, TTL: 64,
+		Version: 4, IHL: 5, TTL: 64,
 		SrcIP:    d.SrcIP.To4(),
 		DstIP:    d.DstIP.To4(),
 		Protocol: layers.IPProtocolUDP,

--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -55,6 +55,40 @@ func TestNestedBoolEq(t *testing.T) {
 	both.MustMatch(t, pkt(80, 80), "(F==F=T) == (T==T=T) -> T")
 }
 
+// TestMplsChainBoundaries pins the bounded mpls{n,m} quantifier's count
+// boundaries. MPLS has no self-dispatch ethertype (NO_CHECK), so the
+// label-stack length is defined by the bottom-of-stack s-bit alone: the
+// static chain must reject a stack shorter than n (under-run) and longer
+// than m (over-run) on the s-bit itself, not lean on the next layer's
+// self-validation to mop up the mis-parse.
+func TestMplsChainBoundaries(t *testing.T) {
+	mpls := func(labels ...uint32) []byte {
+		o := Defaults()
+		o.MPLS = labels
+		return Build(t, o)
+	}
+
+	r14 := New(t, "eth/mpls{1,4}/ipv4/tcp")
+	r14.MustMatch(t, mpls(16), "{1,4} 1 label")
+	r14.MustMatch(t, mpls(16, 17, 18, 19), "{1,4} 4 labels")
+	r14.MustReject(t, mpls(), "{1,4} 0 labels (under-run)")
+	r14.MustReject(t, mpls(16, 17, 18, 19, 20), "{1,4} 5 labels (over-run)")
+	// 5th label whose top nibble is 0x4 would mimic an ipv4 version if the
+	// over-run leaked to the next layer; the s-bit guard rejects it first.
+	r14.MustReject(t, mpls(16, 17, 18, 19, 0x40000), "{1,4} 5 labels (crafted over-run)")
+
+	r22 := New(t, "eth/mpls{2,2}/ipv4/tcp")
+	r22.MustMatch(t, mpls(16, 17), "{2,2} 2 labels")
+	r22.MustReject(t, mpls(16), "{2,2} 1 label (under-run)")
+	r22.MustReject(t, mpls(16, 17, 18), "{2,2} 3 labels (over-run)")
+
+	r23 := New(t, "eth/mpls{2,3}/ipv4/tcp")
+	r23.MustMatch(t, mpls(16, 17), "{2,3} 2 labels")
+	r23.MustMatch(t, mpls(16, 17, 18), "{2,3} 3 labels")
+	r23.MustReject(t, mpls(16), "{2,3} 1 label (under-run)")
+	r23.MustReject(t, mpls(16, 17, 18, 19), "{2,3} 4 labels (over-run)")
+}
+
 // TestEthIPv4TCPDportPredicate exercises a primary-header predicate
 // (`tcp[dport==443]`). Confirms the predicate path runs in the
 // scratch-buffer wrapper and that byte-swap-at-codegen handles the

--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -24,6 +24,37 @@ func TestEthIPv4TCPMatch(t *testing.T) {
 	r.MustReject(t, BuildEthIPv4UDP(t, 12345, 53, []byte("query")), "UDP against eth/ipv4/tcp filter")
 }
 
+// TestNestedBoolEq covers bool-eq `(cmp) == (cmp)` (XNOR) and its nesting
+// on either operand. genBoolEq parks each level's LHS in a distinct arith
+// slot (top-down by nesting depth); a single fixed slot let a nested
+// bool-eq clobber an enclosing one — the right/both-nested cases pin that.
+func TestNestedBoolEq(t *testing.T) {
+	pkt := func(dp, sp uint16) []byte {
+		o := Defaults()
+		o.DstPort, o.SrcPort = dp, sp
+		return Build(t, o)
+	}
+
+	flat := New(t, "eth/ipv4/tcp where (tcp.dport == 443) == (tcp.sport == 443)")
+	flat.MustMatch(t, pkt(443, 443), "T == T")
+	flat.MustMatch(t, pkt(80, 12345), "F == F")
+	flat.MustReject(t, pkt(443, 12345), "T == F")
+	flat.MustReject(t, pkt(80, 443), "F == T")
+
+	left := New(t, "eth/ipv4/tcp where ((tcp.dport == 443) == (tcp.sport == 443)) == (tcp.dport == 80)")
+	left.MustMatch(t, pkt(80, 12345), "(F==F=T) == (T) -> T")
+	left.MustReject(t, pkt(443, 443), "(T==T=T) == (F) -> F")
+
+	right := New(t, "eth/ipv4/tcp where (tcp.dport == 80) == ((tcp.dport == 443) == (tcp.sport == 443))")
+	right.MustMatch(t, pkt(80, 12345), "(T) == (F==F=T) -> T")
+	right.MustReject(t, pkt(443, 443), "(F) == (T==T=T) -> F")
+
+	both := New(t, "eth/ipv4/tcp where ((tcp.dport == 443) == (tcp.sport == 443)) == ((tcp.dport == 80) == (tcp.sport == 80))")
+	both.MustReject(t, pkt(80, 12345), "(F==F=T) == (T==F=F) -> F")
+	both.MustMatch(t, pkt(443, 80), "(T==F=F) == (F==F=T)... -> T")
+	both.MustMatch(t, pkt(80, 80), "(F==F=T) == (T==T=T) -> T")
+}
+
 // TestEthIPv4TCPDportPredicate exercises a primary-header predicate
 // (`tcp[dport==443]`). Confirms the predicate path runs in the
 // scratch-buffer wrapper and that byte-swap-at-codegen handles the
@@ -341,7 +372,7 @@ func TestAuxStackSrv6SegmentsDynamicIndex(t *testing.T) {
 func TestAuxStackIpv6ExtsIndex0(t *testing.T) {
 	r := New(t, "eth/ipv6/tcp where ipv6.exts[0].next_header == 6")
 	pkt := BuildIPv6WithExts(t, IPv6WithExtsOpts{
-		FirstNextHeader: 0,  // HBH
+		FirstNextHeader: 0, // HBH
 		Exts:            []IPv6Ext{{NextHeader: 6, HdrExtLen: 0, Options: bytes16("hbh-payload")}},
 		FinalNextHeader: 6, // TCP
 	})

--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -58,9 +58,11 @@ func TestNestedBoolEq(t *testing.T) {
 // TestMplsChainBoundaries pins the bounded mpls{n,m} quantifier's count
 // boundaries. MPLS has no self-dispatch ethertype (NO_CHECK), so the
 // label-stack length is defined by the bottom-of-stack s-bit alone: the
-// static chain must reject a stack shorter than n (under-run) and longer
-// than m (over-run) on the s-bit itself, not lean on the next layer's
-// self-validation to mop up the mis-parse.
+// chain must reject a stack shorter than n (under-run) and longer than m
+// (over-run) on the s-bit itself, not lean on the next layer's
+// self-validation to mop up the mis-parse. Covers both the static unroll
+// (m <= staticChainCap) and the bpf_loop path (m = 10), the latter for the
+// single-label under-run that bypassed its RangeMin floor.
 func TestMplsChainBoundaries(t *testing.T) {
 	mpls := func(labels ...uint32) []byte {
 		o := Defaults()
@@ -87,6 +89,15 @@ func TestMplsChainBoundaries(t *testing.T) {
 	r23.MustMatch(t, mpls(16, 17, 18), "{2,3} 3 labels")
 	r23.MustReject(t, mpls(16), "{2,3} 1 label (under-run)")
 	r23.MustReject(t, mpls(16, 17, 18, 19), "{2,3} 4 labels (over-run)")
+
+	// {2,10} exceeds staticChainCap so it takes the bpf_loop path. Its
+	// pre-loop chain-end check must reject a single-label under-run instead
+	// of jumping past the post-loop RangeMin floor (which would wrongly
+	// accept it, since the 1-label stack lands the next layer correctly).
+	r210 := New(t, "eth/mpls{2,10}/ipv4/tcp")
+	r210.MustMatch(t, mpls(16, 17), "{2,10} 2 labels")
+	r210.MustMatch(t, mpls(16, 17, 18, 19, 20, 21), "{2,10} 6 labels")
+	r210.MustReject(t, mpls(16), "{2,10} 1 label (bpf_loop under-run)")
 }
 
 // TestEthIPv4TCPDportPredicate exercises a primary-header predicate


### PR DESCRIPTION
## What

Three corpus-found codegen bugs and the packet-level test suite that found them.

The verifier corpus (`filterset_corpus_test.go`) only asserted that each expression *compiles and loads*. Loadability is not correctness — a filter can load yet read the wrong bytes. Giving the corpus a `BPF_PROG_TEST_RUN` match/reject oracle surfaced three filters that loaded fine while matching the wrong packets.

## Fixes

1. **`fix(codegen): terminate mpls chain quantifiers on the s-bit`**
   The static-unroll path (`{n,m}`, `m ≤ 4`) had no chain-end check, so `mpls{1,4}` only matched a full 4-label stack, and `mpls+` / `mpls*` consumed a phantom first label before their `bpf_loop`. MPLS distinguishes the next label by the bottom-of-stack s-bit, not a self-dispatch ethertype like VLAN, so both codegen paths now share one `chainEndCheck` over a `chainFrame` (frame-register abstraction). VLAN keeps terminating on its ethertype peek; the two mechanisms are unified behind one call.

2. **`fix(codegen): give each nested bool-eq its own scratch slot`**
   `genBoolEq` parked its LHS truth value in a fixed arith scratch slot that the RHS operand's own compare reused, so a flat `(tcp.dport==443) == (tcp.sport==443)` always mis-compared and nesting bool-eq on either operand corrupted the enclosing one. LHS is now parked at the top of the arith region, growing one slot down per nesting level; pathological over-nesting is rejected rather than silently miscompiled.

3. **`test(program): packet-level correctness suite over the verifier corpus`**
   `TestBpfFilterCorpusCorrectness` runs each corpus expression through the dsltest harness against hand-built packets and asserts match/reject. Expression strings stay single-sourced in `VerifierCorpus`; entries supply only packets. A bidirectional drift guard forces every corpus ID into exactly one of a correctness case or a documented load-only reason (the three capture clauses) and rejects stale IDs. dsltest gains a `TTL` field on `PacketOpts`, an ICMPv6 checksum fix, and `BuildVXLANInnerIPv4TCP`.

## Test

- `make test` (root-free): compiles; the BPF run-tests skip when not root.
- Under root: all 65 corpus correctness cases pass, `TestNestedBoolEq` passes, and the chain-quantifier dsltest cases (`+`=1+, `*`=0+, `{1,4}`=1-4, `{2,2}`=2, `?`=0-1) pass.

Quantifier/bool-eq codegen stays at the existing kernel floor (no new instructions on the static path); `bpf_loop`-based quantifiers remain 5.17+ as before.