### PR TITLE
feat(kunai): Geneve option-TLV filtering and optional VLAN at tc

### DIFF
--- a/internal/program/filterset_corpus_correctness_test.go
+++ b/internal/program/filterset_corpus_correctness_test.go
@@ -289,6 +289,15 @@ var corpusLoadOnly = map[string]string{
 	"H00": "capture clause: changes captured output bytes, not the match/reject verdict (which equals eth/ipv4/tcp); capture-byte correctness needs a separate oracle",
 	"H01": "capture clause (capture all): same as H00",
 	"H03": "capture clause (capture absolute 96): same as H00",
+	"G03": "Geneve option TLV walk (OVN egress_port): match/reject correctness is covered packet-level in dsltest TestGeneveOptionOVNEgressPort; this corpus entry only pins verifier load",
+	"G04": "Geneve option TLV walk (AWS GWLB flow_cookie): correctness covered in dsltest TestGeneveOptionGWLBFlowCookie / TestGeneveOptionMultiCase; corpus pins verifier load only",
+	"I00": "sub-byte TCP flags (SYN): correctness covered packet-level in dsltest TestSubByteTCPFlagsSYN (needs TCP-flag control the default builder lacks); corpus pins verifier load only",
+	"I01": "sub-byte TCP data_offset: correctness in dsltest TestSubByteTCPDataOffset; corpus pins verifier load only",
+	"I02": "sub-byte IPv4 version nibble: correctness in dsltest TestSubByteIPv4Version; corpus pins verifier load only",
+	"I03": "sub-byte IPv4 ihl nibble: correctness in dsltest TestSubByteIPv4IHL; corpus pins verifier load only",
+	"I04": "sub-byte IPv4 flags (DF): correctness in dsltest TestSubByteIPv4DontFragment; corpus pins verifier load only",
+	"I05": "sub-byte IPv4 frag_offset: correctness in dsltest TestSubByteIPv4FragOffset; corpus pins verifier load only",
+	"I06": "sub-byte IPv6 traffic_class: correctness in dsltest TestSubByteIPv6TrafficClass; corpus pins verifier load only",
 }
 
 func TestBpfFilterCorpusCorrectness(t *testing.T) {

--- a/internal/program/filterset_corpus_test.go
+++ b/internal/program/filterset_corpus_test.go
@@ -2,7 +2,6 @@ package program
 
 import (
 	"errors"
-	"regexp"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -10,20 +9,19 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
 
-// vlanLayerRe matches a vlan/qinq layer token in a chain: a layer name
-// always follows a chain separator (`/`, or `(`/`|` inside an
-// alternation), so anchoring on those excludes labels like `@vlan` and
-// longer names like `vxlan` (preceded by `vx`, not a separator). The
-// trailing \b keeps it from matching a hypothetical `vlanfoo`.
-var vlanLayerRe = regexp.MustCompile(`[/(|](vlan|qinq)\b`)
-
-// exprHasVlanLayer reports whether a corpus expression carries a
-// vlan/qinq layer. The tc host rejects these at compile time because
-// the kernel extracts the outer VLAN tag into skb metadata before the
-// program runs (codegen.Capabilities.VlanInMetadata); they compile and
-// load only on XDP, where VLAN is in-band.
-func exprHasVlanLayer(expr string) bool {
-	return vlanLayerRe.MatchString(expr)
+// tcRejectingCorpus lists the VerifierCorpus expressions the tc host
+// rejects at compile time. The tc host extracts the outer VLAN tag into
+// skb metadata before the program runs (codegen.HostLayout.VlanInMetadata),
+// so a vlan/qinq layer read from packet bytes is rejected UNLESS it is
+// absent-able — an optional quantifier whose skip path the byte parser
+// can take. The optional predicate-free forms (D00 vlan?, D01 qinq?/vlan?,
+// D07 vlan? with a tcp predicate) are therefore accepted and loaded at
+// tc; only a mandatory tag or a tag inside an alternation is rejected.
+// See checkHostLayerSupport.
+var tcRejectingCorpus = map[string]bool{
+	"eth/vlan{1,3}/ipv4/tcp":   true, // D04: mandatory tag, no skip path
+	"eth/(vlan|qinq)/ipv4/tcp": true, // E00: tag inside an alternation
+	"eth/((vlan|qinq)|ipv4)":   true, // E03: tag inside an alternation
 }
 
 // VerifierCorpus is a curated set of well-typed kunai expressions that
@@ -131,11 +129,25 @@ var VerifierCorpus = []struct {
 	{"G00", "eth/ipv6/srv6 where any(srv6.segments.addr == fc00::1)"},
 	{"G01", "eth/ipv6/srv6 where any(srv6.segments.addr == 2001:db8::/32)"},
 	{"G02", "eth/ipv4/tcp where tcp.options.MSS.value == 1460"},
+	{"G03", "eth/ipv4/udp/geneve where geneve.options.OVN.egress_port == 42"},
+	{"G04", "eth/ipv4/udp/geneve where geneve.options.GWLB.flow_cookie == 0x12345678"},
 
 	// Capture clauses — exercise output-shape parser, not just chain.
 	{"H00", "eth/ipv4/tcp capture headers+64"},
 	{"H01", "eth/ipv4/tcp capture all"},
 	{"H03", "eth/ipv4/tcp capture absolute 96"},
+
+	// Sub-byte / non-byte-aligned primary field reads — covering-window
+	// load + post-load shift+mask (TCP flags/data_offset, IPv4
+	// version/ihl/flags/frag_offset, IPv6 traffic_class). Packet-level
+	// correctness is in dsltest TestSubByte*; here we pin verifier load.
+	{"I00", "eth/ipv4/tcp where tcp.flags & 0x02 != 0"},
+	{"I01", "eth/ipv4/tcp where tcp.data_offset == 5"},
+	{"I02", "eth/ipv4/tcp where ipv4.version == 4"},
+	{"I03", "eth/ipv4[ihl==5]/tcp"},
+	{"I04", "eth/ipv4/tcp where ipv4.flags & 0x2 != 0"},
+	{"I05", "eth/ipv4/tcp where ipv4.frag_offset == 0"},
+	{"I06", "eth/ipv6/tcp where ipv6.traffic_class == 0"},
 }
 
 // TestFilterCorpusCompiles is the no-root sister of TestFilterSetCompiles:
@@ -154,9 +166,9 @@ func TestFilterCorpusCompiles(t *testing.T) {
 	for _, c := range VerifierCorpus {
 		for _, h := range hosts {
 			t.Run(c.ID+"/"+h.name, func(t *testing.T) {
-				tcVlan := h.progType != ebpf.XDP && exprHasVlanLayer(c.Expr)
+				tcReject := h.progType != ebpf.XDP && tcRejectingCorpus[c.Expr]
 				_, err := compileFilter(c.Expr, true /*useDSL*/, false /*isFexit*/, h.progType)
-				if tcVlan {
+				if tcReject {
 					if !errors.Is(err, codegen.ErrNotImplemented) {
 						t.Fatalf("compile %s (%s): expected tc rejection with ErrNotImplemented (VLAN in skb metadata), got %v", c.ID, h.name, err)
 					}
@@ -190,8 +202,8 @@ func runFilterCorpusMatrix(t *testing.T, hostProg *ebpf.Program, funcName string
 	isTC := funcName == tcFuncName
 	for _, c := range VerifierCorpus {
 		t.Run(c.ID, func(t *testing.T) {
-			if isTC && exprHasVlanLayer(c.Expr) {
-				t.Skipf("%s carries a vlan/qinq layer; the tc host extracts the outer VLAN tag into skb metadata, so it is rejected at compile time (not loadable)", c.ID)
+			if isTC && tcRejectingCorpus[c.Expr] {
+				t.Skipf("%s carries a non-absent-able vlan/qinq layer (mandatory or in an alternation); the tc host rejects it at compile time (not loadable)", c.ID)
 			}
 			loadProbeOrFail(t, hostProg, funcName, c.Expr, false /*exit*/, true /*useDSL*/)
 		})

--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -66,7 +66,7 @@ var FilterSet = []FilterSpec{
 	{ID: "F8", Expr: "eth/ipv6/srv6 where any(srv6.segments.addr == fc00::1)",
 		WantInsns: 450, Notes: "SRv6 segment-list any-quantifier (5G/SDN)"},
 	{ID: "F9", Expr: "eth/ipv4@outer/udp/geneve/eth/ipv4@inner/tcp where inner.dst == 10.0.0.1",
-		WantInsns: 323, Notes: "Geneve inner IPv4 dst (Cilium overlay / cloud VPC); inner offset resolved past the opt_len*4 options section"},
+		WantInsns: 351, Notes: "Geneve inner IPv4 dst (Cilium overlay / cloud VPC); inner offset resolved past the opt_len*4 options section via the counter-driven bulk-advance fallback"},
 	{ID: "F10", Expr: "eth/ipv4/tcp where tcp.options.MSS.value == 1460",
 		WantInsns: 231, Notes: "TCP option MSS via parser-counter walk"},
 }

--- a/internal/program/vlan_tc_support_test.go
+++ b/internal/program/vlan_tc_support_test.go
@@ -1,0 +1,56 @@
+package program
+
+// tc-host VLAN support: an optional, predicate-free vlan/qinq layer is
+// matchable at the tc attach point (the kernel moves the outer tag into
+// skb metadata, and the byte parser takes the layer's skip path), while
+// a mandatory tag, a field-reading predicate, or a tag inside an
+// alternation stays rejected at compile time. The datapath rationale is
+// confirmed end-to-end in vlan_untag_datapath_test.go.
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
+)
+
+// tcAcceptedVlanExprs load & verify at the tc clsact host.
+var tcAcceptedVlanExprs = []string{
+	"eth/vlan?/ipv4/tcp",            // optional single tag
+	"eth/qinq?/vlan?/ipv4/tcp",      // recommended tag-flexible pattern
+	"eth/vlan*/ipv4/tcp",            // zero-or-more (bpf_loop)
+	"eth/vlan?/ipv4/tcp[dport==443]", // optional tag + predicate on a later layer
+}
+
+// tcRejectedVlanExprs reject at compile time on the tc host: they read a
+// tag the kernel stripped into skb metadata.
+var tcRejectedVlanExprs = []string{
+	"eth/vlan/ipv4/tcp",            // mandatory tag, no skip path
+	"eth/vlan{1,3}/ipv4/tcp",       // mandatory (RangeMin>=1)
+	"eth/qinq/vlan/ipv4/tcp",       // mandatory QinQ stack
+	"eth/vlan[tci==100]/ipv4/tcp",  // mandatory + reads tci
+	"eth/vlan[tci==100]?/ipv4/tcp", // optional but reads tci (predicate before quant)
+	"eth/(vlan|qinq)/ipv4/tcp",     // tag inside an alternation
+}
+
+func TestVlanTCOptionalLoads(t *testing.T) {
+	hostProg := loadDummyTC(t) // skips when not root
+	for _, expr := range tcAcceptedVlanExprs {
+		t.Run(expr, func(t *testing.T) {
+			loadProbeOrFail(t, hostProg, tcFuncName, expr, false /*exit*/, true /*useDSL*/)
+		})
+	}
+}
+
+func TestVlanTCFieldReadingRejects(t *testing.T) {
+	for _, expr := range tcRejectedVlanExprs {
+		t.Run(expr, func(t *testing.T) {
+			_, err := compileFilter(expr, true /*useDSL*/, false /*isFexit*/, ebpf.SchedCLS)
+			if !errors.Is(err, codegen.ErrNotImplemented) {
+				t.Fatalf("expected tc ErrNotImplemented for %q, got %v", expr, err)
+			}
+		})
+	}
+}

--- a/internal/program/vlan_untag_datapath_test.go
+++ b/internal/program/vlan_untag_datapath_test.go
@@ -1,0 +1,259 @@
+package program
+
+// Real-datapath confirmation of the premise the whole tc-VLAN design
+// rests on: by the time a tc/clsact ingress program runs, the kernel
+// has already stripped the outer 802.1Q tag out of the packet bytes
+// (skb_vlan_untag runs in __netif_receive_skb_core, before
+// sch_handle_ingress / tcx) and moved it into skb metadata
+// (vlan_present / vlan_tci).
+//
+// A veth pair carries a hand-built VLAN-tagged IPv4/TCP frame; a
+// minimal SchedCLS program attached at tcx ingress on the receiving
+// end records the ethertype it sees at L2 offset 12 plus
+// skb->vlan_present / skb->vlan_tci. If the premise holds, the program
+// sees ethertype 0x0800 (the INNER protocol — the tag bytes are gone)
+// with vlan_present=1 and vlan_tci carrying VID 100.
+//
+// Combined with the dsltest packet checks (kunai's `eth/vlan?/ipv4/tcp`
+// matches exactly this de-tagged byte layout), this closes the loop:
+// an optional VLAN chain matches a tagged frame correctly at tc.
+//
+// Root + veth + tcx required; skipped otherwise. Run via make test-bpf
+// or: sudo -E go test ./internal/program -run TestVlanUntag -v
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/link"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// __sk_buff UAPI offsets (stable; verifier rewrites these loads).
+const (
+	skbProtocol    = 16
+	skbVlanPresent = 20
+	skbVlanTCI     = 24
+	skbData        = 76
+	skbDataEnd     = 80
+)
+
+func TestVlanUntagAtTCIngress(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	// --- record map: [0]=ethertype@12, [1]=vlan_present, [2]=vlan_tci ---
+	rec, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name: "vlan_rec", Type: ebpf.Array, KeySize: 4, ValueSize: 12, MaxEntries: 1,
+	})
+	if err != nil {
+		t.Fatalf("create map: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	// --- minimal SchedCLS classifier (hand asm, no C) ---
+	// Reads ethertype at L2 offset 12 and the VLAN skb metadata, stores
+	// all three into rec[0]. Returns TC_ACT_OK (0).
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name:    "vlan_probe",
+		Type:    ebpf.SchedCLS,
+		License: "GPL",
+		Instructions: asm.Instructions{
+			// R6=ctx, R7=data, R8=data_end (R6-R9 are callee-saved, so
+			// they survive the bpf_map_lookup_elem call below; R1-R5 do
+			// not, which is why the lookup comes before the field loads).
+			asm.Mov.Reg(asm.R6, asm.R1),
+			asm.LoadMem(asm.R7, asm.R6, skbData, asm.Word),
+			asm.LoadMem(asm.R8, asm.R6, skbDataEnd, asm.Word),
+			// rec[0] lookup -> R0.
+			asm.StoreImm(asm.R10, -4, 0, asm.Word),
+			asm.Mov.Reg(asm.R2, asm.R10),
+			asm.Add.Imm(asm.R2, -4),
+			asm.LoadMapPtr(asm.R1, rec.FD()),
+			asm.FnMapLookupElem.Call(),
+			asm.JEq.Imm(asm.R0, 0, "out"),
+			// Re-establish the packet range after the call, then read.
+			asm.Mov.Reg(asm.R1, asm.R7),
+			asm.Add.Imm(asm.R1, 14),
+			asm.JGT.Reg(asm.R1, asm.R8, "out"), // need 14 bytes of L2
+			// ethertype (wire order) = data[12]<<8 | data[13]
+			asm.LoadMem(asm.R3, asm.R7, 12, asm.Byte),
+			asm.LSh.Imm(asm.R3, 8),
+			asm.LoadMem(asm.R9, asm.R7, 13, asm.Byte),
+			asm.Or.Reg(asm.R3, asm.R9),
+			asm.StoreMem(asm.R0, 0, asm.R3, asm.Word),
+			asm.LoadMem(asm.R4, asm.R6, skbVlanPresent, asm.Word),
+			asm.StoreMem(asm.R0, 4, asm.R4, asm.Word),
+			asm.LoadMem(asm.R5, asm.R6, skbVlanTCI, asm.Word),
+			asm.StoreMem(asm.R0, 8, asm.R5, asm.Word),
+			asm.Mov.Imm(asm.R0, 0).WithSymbol("out"), // TC_ACT_OK
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("verifier:\n%+v", ve)
+		}
+		t.Fatalf("load SchedCLS probe: %v", err)
+	}
+	defer func() { _ = prog.Close() }()
+
+	// --- veth pair in the current netns ---
+	la := netlink.NewLinkAttrs()
+	la.Name = "kxvlan0"
+	veth := &netlink.Veth{LinkAttrs: la, PeerName: "kxvlan1"}
+	if err := netlink.LinkAdd(veth); err != nil {
+		t.Skipf("veth unavailable (%v); skipping datapath test", err)
+	}
+	defer func() { _ = netlink.LinkDel(veth) }()
+
+	v0, err := netlink.LinkByName("kxvlan0")
+	if err != nil {
+		t.Fatalf("LinkByName kxvlan0: %v", err)
+	}
+	v1, err := netlink.LinkByName("kxvlan1")
+	if err != nil {
+		t.Fatalf("LinkByName kxvlan1: %v", err)
+	}
+	if err := netlink.LinkSetUp(v0); err != nil {
+		t.Fatalf("set up v0: %v", err)
+	}
+	if err := netlink.LinkSetUp(v1); err != nil {
+		t.Fatalf("set up v1: %v", err)
+	}
+
+	// --- attach the probe at tcx ingress on the receiving end (v1) ---
+	lnk, err := link.AttachTCX(link.TCXOptions{
+		Interface: v1.Attrs().Index,
+		Program:   prog,
+		Attach:    ebpf.AttachTCXIngress,
+	})
+	if err != nil {
+		t.Skipf("AttachTCX unavailable (%v); skipping datapath test", err)
+	}
+	defer func() { _ = lnk.Close() }()
+
+	// --- raw send a VLAN-tagged IPv4/TCP frame out v0 -> v1 receives ---
+	sendFrame(t, v0.Attrs().Index, vlanTaggedIPv4TCP(100))
+
+	eth, present, tci := pollRecord(t, rec)
+	t.Logf("tagged frame: tc saw ethertype=0x%04x vlan_present=%d vlan_tci=%d (vid=%d)",
+		eth, present, tci, tci&0x0fff)
+
+	if eth != 0x0800 {
+		t.Fatalf("ethertype at L2 offset 12 = 0x%04x; want 0x0800 (inner). The outer tag was NOT stripped from packet bytes — premise broken", eth)
+	}
+	if present != 1 {
+		t.Fatalf("vlan_present=%d; want 1 (tag should be in skb metadata)", present)
+	}
+	if tci&0x0fff != 100 {
+		t.Fatalf("vlan_tci vid = %d; want 100", tci&0x0fff)
+	}
+
+	// --- control: an untagged frame leaves no tag in metadata ---
+	if err := rec.Update(uint32(0), make([]byte, 12), ebpf.UpdateAny); err != nil {
+		t.Fatalf("reset map: %v", err)
+	}
+	sendFrame(t, v0.Attrs().Index, untaggedIPv4TCP())
+	eth2, present2, _ := pollRecord(t, rec)
+	t.Logf("untagged frame: tc saw ethertype=0x%04x vlan_present=%d", eth2, present2)
+	if eth2 != 0x0800 {
+		t.Fatalf("untagged ethertype = 0x%04x; want 0x0800", eth2)
+	}
+	if present2 != 0 {
+		t.Fatalf("untagged vlan_present=%d; want 0", present2)
+	}
+}
+
+// pollRecord reads rec[0] until ethertype is non-zero (the probe ran)
+// or the deadline elapses.
+func pollRecord(t *testing.T, rec *ebpf.Map) (eth, present, tci uint32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var v [12]byte
+		if err := rec.Lookup(uint32(0), &v); err != nil {
+			t.Fatalf("map lookup: %v", err)
+		}
+		eth = uint32(v[0]) | uint32(v[1])<<8 | uint32(v[2])<<16 | uint32(v[3])<<24
+		present = uint32(v[4]) | uint32(v[5])<<8 | uint32(v[6])<<16 | uint32(v[7])<<24
+		tci = uint32(v[8]) | uint32(v[9])<<8 | uint32(v[10])<<16 | uint32(v[11])<<24
+		if eth != 0 {
+			return eth, present, tci
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("probe did not run within deadline (no frame reached tcx ingress)")
+	return 0, 0, 0
+}
+
+// sendFrame transmits raw bytes out the given ifindex via AF_PACKET.
+func sendFrame(t *testing.T, ifindex int, frame []byte) {
+	t.Helper()
+	const ethPAll = 0x0003
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(ethPAll)))
+	if err != nil {
+		t.Fatalf("AF_PACKET socket: %v", err)
+	}
+	defer func() { _ = unix.Close(fd) }()
+	addr := &unix.SockaddrLinklayer{Ifindex: ifindex, Halen: 6}
+	copy(addr.Addr[:], frame[0:6])
+	// send a few times — the probe records the last one it sees.
+	for range 5 {
+		if err := unix.Sendto(fd, frame, 0, addr); err != nil {
+			t.Fatalf("sendto: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func htons(v uint16) uint16 { return v<<8 | v>>8 }
+
+// vlanTaggedIPv4TCP builds eth(0x8100)/vlan(vid)/ipv4/tcp:80 bytes.
+func vlanTaggedIPv4TCP(vid uint16) []byte {
+	f := []byte{
+		0x02, 0, 0, 0, 0, 0x01, // dst mac
+		0x02, 0, 0, 0, 0, 0x02, // src mac
+		0x81, 0x00, // VLAN ethertype
+		byte(vid >> 8), byte(vid), // TCI (pcp/dei 0, vid)
+		0x08, 0x00, // inner ethertype = IPv4
+	}
+	return append(f, ipv4TCP()...)
+}
+
+// untaggedIPv4TCP builds eth(0x0800)/ipv4/tcp:80 bytes.
+func untaggedIPv4TCP() []byte {
+	f := []byte{
+		0x02, 0, 0, 0, 0, 0x01,
+		0x02, 0, 0, 0, 0, 0x02,
+		0x08, 0x00, // ethertype = IPv4
+	}
+	return append(f, ipv4TCP()...)
+}
+
+// ipv4TCP returns a minimal 20-byte IPv4 header (proto=TCP) + 20-byte
+// TCP header (dport 80). Checksums are zero; tc ingress does not verify
+// them.
+func ipv4TCP() []byte {
+	ip := []byte{
+		0x45, 0x00, 0x00, 0x28, // ver/ihl, tos, total_len=40
+		0x00, 0x00, 0x00, 0x00, // id, flags/frag
+		0x40, 0x06, 0x00, 0x00, // ttl=64, proto=6 (TCP), csum=0
+		10, 0, 0, 1, // src
+		10, 0, 0, 2, // dst
+	}
+	tcp := []byte{
+		0x30, 0x39, 0x00, 0x50, // sport=12345, dport=80
+		0x00, 0x00, 0x00, 0x00, // seq
+		0x00, 0x00, 0x00, 0x00, // ack
+		0x50, 0x02, 0x20, 0x00, // data_off=5, flags=SYN, window
+		0x00, 0x00, 0x00, 0x00, // csum, urg
+	}
+	return append(ip, tcp...)
+}

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -692,12 +692,32 @@ func checkUnsupported(p *ir.Program) error {
 }
 
 // checkHostLayerSupport rejects chains the target host cannot match by
-// parsing packet bytes. Currently this guards VLAN: when the host has
+// parsing packet bytes. It guards VLAN: when the host has
 // HostLayout.VlanInMetadata set (e.g. tc, where skb_vlan_untag moves the
 // outer tag into skb metadata before the program runs), a vlan or qinq
-// layer in the chain would parse the wrong bytes. We fail at compile
-// time with a clear message instead of silently mis-matching. Reading
-// the tag from skb metadata is future work; see HostLayout.VlanInMetadata.
+// layer read from packet bytes would see the wrong bytes.
+//
+// A vlan/qinq layer is still matchable when it can be ABSENT from the
+// packet bytes — an optional quantifier (`?`, `*`, `{0,m}`) whose
+// zero-occurrence path the byte parser can take. On the post-untag
+// datapath at most one tag remains in the bytes (a single tag goes
+// entirely to metadata; a stacked QinQ frame leaves its inner tag), so
+// `eth/vlan?/...` and `eth/qinq?/vlan?/...` match untagged, single-tag,
+// and QinQ frames without reading the tag the kernel stripped. This is
+// confirmed on a live veth datapath (internal/program
+// TestVlanUntagAtTCIngress) and at the packet level (dsltest
+// TestVlanQuestionMarkOptional).
+//
+// What stays rejected, because it reads a tag the host does not expose
+// in packet bytes:
+//   - a mandatory vlan/qinq layer (no skip path),
+//   - a bracket predicate on the layer (`vlan[tci==100]?`), and
+//   - a vlan/qinq layer inside an alternation (no per-alt skip path).
+//
+// A where-clause or capture that reads a vlan field, or any field past
+// the optional tag, is already rejected upstream as a quantified-layer
+// limitation, so it needs no separate check here. Reading the tag from
+// skb metadata is future work; see HostLayout.VlanInMetadata.
 func checkHostLayerSupport(p *ir.Program, host HostLayout) error {
 	if !host.VlanInMetadata {
 		return nil
@@ -705,20 +725,33 @@ func checkHostLayerSupport(p *ir.Program, host HostLayout) error {
 	isVlan := func(l *ir.LayerInstance) bool {
 		return l != nil && l.Spec != nil && (l.Spec.Name == "vlan" || l.Spec.Name == "qinq")
 	}
+	// absentable reports whether the byte parser can take the layer's
+	// zero-occurrence path, so the tag the kernel moved to metadata is
+	// simply not in the bytes the parser walks.
+	absentable := func(l *ir.LayerInstance) bool {
+		switch l.Quant {
+		case ast.QuantOpt, ast.QuantStar:
+			return true
+		case ast.QuantRange:
+			return l.RangeMin == 0
+		}
+		return false
+	}
 	reject := func(l *ir.LayerInstance) error {
-		return withPos(fmt.Errorf("%w: layer %q cannot be matched at this host: the kernel extracts the outer VLAN tag into skb metadata before the program runs, so it is not present in the packet bytes (matching VLAN from skb metadata is future work)", ErrNotImplemented, l.Spec.Name), l.Pos)
+		return withPos(fmt.Errorf("%w: layer %q cannot be matched at this host: the kernel extracts the outer VLAN tag into skb metadata before the program runs, so it is not present in the packet bytes. Use an optional quantifier (e.g. %s? or qinq?/vlan?) to match tag-flexible traffic without reading the tag, or read the tag from skb metadata (future work)", ErrNotImplemented, l.Spec.Name, l.Spec.Name), l.Pos)
 	}
 	for _, l := range p.Layers {
-		if isVlan(l) {
-			return reject(l)
-		}
-		// vlan/qinq may also appear inside an alternation group, e.g.
-		// eth/(vlan|qinq)/ipv4/tcp; those alternatives are not
-		// top-level p.Layers entries.
+		// vlan/qinq inside an alternation group cannot take a per-alt
+		// skip path in the current codegen; keep rejecting those.
 		for _, alt := range l.Alternation {
 			if isVlan(alt) {
 				return reject(alt)
 			}
+		}
+		// A vlan/qinq layer is rejected unless it can be absent (optional
+		// quantifier) and reads none of its own fields (no predicate).
+		if isVlan(l) && (!absentable(l) || len(l.Predicates) > 0) {
+			return reject(l)
 		}
 	}
 	return nil
@@ -1225,6 +1258,66 @@ func findFieldByteOffset128(spec *vocab.ProtocolSpec, name string) (int, int, er
 	return bitOff / 8, bits / 8, nil
 }
 
+// subByteWindow computes the byte-aligned covering load window for a
+// primary field whose (bitOff, width) is not byte-clean — i.e. the
+// field starts off a byte boundary or its width is not a whole number
+// of bytes. It returns the byte offset to load from and the LDX byte
+// count (1/2/4/8) that covers the field's bits; emitFieldLoad /
+// emitBoundedLoad reads that window and slicePostAdjust narrows R3 to
+// the field bits with a post-load shift + mask. ok is false when the
+// field is already byte-clean (caller uses the normal whole-byte path)
+// or when the covering window would exceed a single 8-byte LDX, where
+// the caller's original "max 8" diagnostic is the right error.
+func subByteWindow(bitOff, width int) (byteOff, loadBytes int, ok bool) {
+	if width <= 0 {
+		return 0, 0, false
+	}
+	if bitOff%8 == 0 && width%8 == 0 {
+		return 0, 0, false
+	}
+	byteOff = bitOff / 8
+	cover := (bitOff%8 + width + 7) / 8
+	loadBytes = nextLDXSize(cover)
+	if loadBytes == 0 {
+		return 0, 0, false
+	}
+	return byteOff, loadBytes, true
+}
+
+// bareSubByteField resolves the header-relative bit geometry of a bare
+// primary field (no slice, no aux) when that geometry is not byte-clean
+// — the field starts off a byte boundary or its width is not a whole
+// number of bytes. ok is false for slice/aux refs, an empty or unknown
+// ref, and byte-clean fields, all of which take the normal whole-byte
+// path. It is the single source of the "is this a sub-byte field, and
+// what are its bits?" question that fieldIsSubByte and slicePostAdjust
+// both ask.
+func bareSubByteField(ref *ir.FieldRef) (bitOff, width int, ok bool) {
+	if ref == nil || ref.Slice != nil || ref.Aux != nil ||
+		ref.Field == nil || ref.Layer == nil || ref.Layer.Spec == nil {
+		return 0, 0, false
+	}
+	bitOff, width, err := findFieldBitOffset(ref.Layer.Spec, ref.Field.Name)
+	if err != nil || (bitOff%8 == 0 && width%8 == 0) {
+		return 0, 0, false
+	}
+	return bitOff, width, true
+}
+
+// fieldIsSubByte reports whether ref's load went through a sub-byte
+// covering window in fieldRefByteOffset, so its value needs a post-load
+// shift + mask before being compared. It mirrors exactly what
+// fieldRefByteOffset produces: a bare non-byte-clean field whose
+// covering window fits a single LDX.
+func fieldIsSubByte(ref *ir.FieldRef) bool {
+	bitOff, width, ok := bareSubByteField(ref)
+	if !ok {
+		return false
+	}
+	_, _, okWin := subByteWindow(bitOff, width)
+	return okWin
+}
+
 // fieldRefByteOffset returns the byte offset (relative to the
 // owning layer's start, anchored on offsetBase at predicate-emit
 // time) and byte width for a FieldRef. Aux references add the aux
@@ -1262,7 +1355,22 @@ func fieldRefByteOffset(ref *ir.FieldRef) (int, int, error) {
 				off = bitOff / 8
 				size = ref.Slice.Bits() / 8
 			} else {
-				return 0, 0, err
+				// No explicit slice: a non-byte-aligned or sub-byte-sized
+				// primary field still loads through a byte-aligned
+				// covering window; slicePostAdjust narrows R3 to the
+				// field's own bits after the load. subByteWindow returns
+				// ok=false for byte-clean fields (handled above) and for
+				// fields whose covering window would exceed 8 bytes, where
+				// the original error is the right diagnostic.
+				bitOff, bits, ferr := findFieldBitOffset(ref.Layer.Spec, ref.Field.Name)
+				if ferr != nil {
+					return 0, 0, ferr
+				}
+				bOff, loadBytes, okWin := subByteWindow(bitOff, bits)
+				if !okWin {
+					return 0, 0, err
+				}
+				off, size = bOff, loadBytes
 			}
 		}
 		return applySliceToOffset(ref, off, size)
@@ -1339,17 +1447,34 @@ func nextLDXSize(cover int) int {
 // position `loadBytes*8 - 1 - (lo - byteStart*8)` in the swapped
 // register. shift = loadBytes*8 - (hi - byteStart*8) drops the bits
 // below the slice; mask = (1<<width) - 1 keeps only the slice bits.
+//
+// The same math applies to a bare (sliceless) primary field whose bit
+// geometry is not byte-clean: its load went through subByteWindow, and
+// here we narrow the covering window down to the field's own bits using
+// the field's intra-byte start (bitOff%8) in place of a slice's Lo.
 func slicePostAdjust(ref *ir.FieldRef, loadBytes int) (shift int, mask uint64) {
-	if ref.Slice == nil {
-		return 0, 0
-	}
-	byteStart := ref.Slice.Lo / 8
 	loadBits := loadBytes * 8
-	hiInLoad := ref.Slice.Hi - byteStart*8
-	width := ref.Slice.Bits()
-	// Default: no adjustment when slice exactly equals the load.
-	if hiInLoad == loadBits && ref.Slice.Lo == byteStart*8 && width == loadBits {
-		return 0, 0
+	// Resolve the field/slice high bit within the loaded window and the
+	// width to keep; both the slice and the bare sub-byte field reduce
+	// to shift = loadBits - hiInLoad and mask = (1<<width)-1.
+	var hiInLoad, width int
+	switch {
+	case ref.Slice != nil:
+		byteStart := ref.Slice.Lo / 8
+		hiInLoad = ref.Slice.Hi - byteStart*8
+		width = ref.Slice.Bits()
+		// A slice that exactly fills the load needs no narrowing.
+		if hiInLoad == loadBits && ref.Slice.Lo == byteStart*8 && width == loadBits {
+			return 0, 0
+		}
+	default:
+		bitOff, w, ok := bareSubByteField(ref)
+		if !ok {
+			return 0, 0
+		}
+		// The covering window starts at the field's byte floor, so the
+		// field's high bit sits at bitOff%8 + width from the window MSB.
+		hiInLoad, width = bitOff%8+w, w
 	}
 	shift = loadBits - hiInLoad
 	mask = (uint64(1) << uint(width)) - 1

--- a/pkg/kunai/codegen/parser_loop.go
+++ b/pkg/kunai/codegen/parser_loop.go
@@ -222,13 +222,22 @@ func emitFillStackSlots(initImm int32, n int, resolve func(int) (int16, error)) 
 // rejects the load as out of packet range. boundedScalarLoad re-runs
 // the end-pointer check on the load register itself, which both hosts
 // accept; the extra check is redundant on the map-value path.
-func (c *pmCtx) emitDynamicAuxSlotPrelude(breakLabel string) (asm.Instructions, error) {
+func (c *pmCtx) emitDynamicAuxSlotPrelude(sel *vocab.SelectOp, breakLabel string) (asm.Instructions, error) {
 	demand := c.queried[c.layer]
 	if len(demand) == 0 {
 		return nil, nil
 	}
-	// R1 = kind byte at scratchStart(R4) + cursor(R3); R3/R4/R5 survive.
-	insns := boundedScalarLoad(asm.R1, asm.R4, asm.R3, asm.R5, asm.Byte, breakLabel)
+	// R1 = the dispatch kind at scratchStart(R4) + cursor(R3); R3/R4/R5
+	// survive. Read it exactly as the dispatch does so the per-option
+	// JNE below compares against the same normalized value — a wide
+	// (e.g. 24-bit Geneve class+type) key needs a multi-byte load and
+	// byte-swap, not a single-byte LDX.
+	shape, err := c.lookaheadKindShape(sel)
+	if err != nil {
+		return nil, err
+	}
+	insns := boundedScalarLoad(asm.R1, asm.R4, asm.R3, asm.R5, shape.loadSize, breakLabel)
+	insns = append(insns, shape.normalize(asm.R1)...)
 	for idx, layout := range demand {
 		slot, err := c.queried.slotForLayer(c.layer, idx+1)
 		if err != nil {
@@ -266,15 +275,18 @@ func (c *pmCtx) emitMultiStateCallback(entry *vocab.ParseState, entryIdx int, cb
 		// which lets the subsequent `pkt + R3` adds verify.
 		asm.JGT.Imm(asm.R3, int32(ScratchBufSize)-1, breakLabel),
 	}
-	// Per-case dispatch over the lookahead<bit<8>>() byte. Use the
+	// Per-case dispatch over the lookahead<bit<N>>() key. Use the
 	// existing emitSelectGeneric machinery with a callback-flavoured
-	// selectAddr that materialises the byte at R4+R3.
+	// selectAddr that materialises the bytes at R4+R3.
 	addr := callbackSelectAddr("tlvcb", breakLabel)
-	// Bound-check the 1-byte peek before any case body runs.
+	// Bound-check the peek (the widest lookahead key's load) before any
+	// case body runs. The per-case bounded load re-checks, but this
+	// coarse guard keeps the cascade off a short tail.
+	peekBytes := selectPeekBytes(entry.Trans.Select)
 	insns = append(insns,
 		asm.Mov.Reg(asm.R0, asm.R4),
 		asm.Add.Reg(asm.R0, asm.R3),
-		asm.Add.Imm(asm.R0, 1),
+		asm.Add.Imm(asm.R0, int32(peekBytes)),
 		asm.JGT.Reg(asm.R0, asm.R5, breakLabel),
 	)
 	// Slot-store prelude must run BEFORE the dispatch cascade, not
@@ -282,7 +294,7 @@ func (c *pmCtx) emitMultiStateCallback(entry *vocab.ParseState, entryIdx int, cb
 	// function of the kind byte alone so the verifier doesn't track
 	// "which case ran × which slot was written" across iters. See
 	// docs/ja/dsl-internals.md §6.5 Mechanism 7.
-	prelude, err := c.emitDynamicAuxSlotPrelude(breakLabel)
+	prelude, err := c.emitDynamicAuxSlotPrelude(entry.Trans.Select, breakLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kunai/codegen/parser_select.go
+++ b/pkg/kunai/codegen/parser_select.go
@@ -132,9 +132,9 @@ func (c *pmCtx) emitSelectGeneric(sel *vocab.SelectOp, addr selectAddr, branch f
 // selectKeyShape carries the byte-level encoding for one select key.
 // It is the codegen-friendly version of vocab.SelectKey: the bit
 // window has been resolved against the parser-bound header (primary,
-// stack element, or unconsumed lookahead) and reduced to "byte at
-// this offset, mask, shift" so a single-byte LDX + AND + cmp
-// suffices.
+// stack element, or unconsumed lookahead) and reduced to a load width
+// plus byte-swap/shift/mask, so an LDX of loadSize followed by
+// normalize() yields the right-aligned key value for the compare.
 type selectKeyShape struct {
 	// byteOffsetFromR4 is the byte offset relative to the *current*
 	// offsetBase. Negative for SelectKeyField (the field lives in a
@@ -142,12 +142,19 @@ type selectKeyShape struct {
 	// non-negative for SelectKeyLookahead (peeking at unconsumed
 	// bytes from the cursor forward).
 	byteOffsetFromR4 int
-	// maskAfterShift is the byte mask applied after shifting; it spans
-	// only the key's bits.
-	maskAfterShift uint8
+	// loadSize is the LDX width used to read the key (Byte for fields
+	// and 8-bit lookaheads; Half/Word for wider lookaheads, where the
+	// load reads the next power-of-two ≥ ceil(bits/8) bytes).
+	loadSize asm.Size
+	// bigEndian requests a HostTo(BE) byte-swap after a multi-byte
+	// load so the wire value lands right-aligned in the register.
+	bigEndian bool
+	// mask is applied (And) after shifting; 0 means "no mask needed"
+	// (the load size + shift already yield exactly the key bits).
+	mask uint64
 	// shift is the right shift to align the field to the LSB.
 	shift uint
-	// bits is the key's bit width (1..8 in MVP).
+	// bits is the key's bit width.
 	bits int
 }
 
@@ -156,18 +163,25 @@ func (c *pmCtx) resolveSelectKey(sk vocab.SelectKey) (selectKeyShape, error) {
 	case vocab.SelectKeyField:
 		return c.resolveFieldSelectKey(sk.Field)
 	case vocab.SelectKeyLookahead:
-		// MVP cap (mirrored in vocab/parser_machine.go::buildSelect):
-		// only single-byte lookahead is wired to codegen because the
-		// load below is a one-byte LDX. Wider widths require multi-
-		// byte loads + assembly of the value.
-		if sk.Bits != 8 {
-			return selectKeyShape{}, fmt.Errorf("%w: lookahead select key is %d bits; codegen only supports 8", ErrNotImplemented, sk.Bits)
+		// Read the next power-of-two ≥ ceil(bits/8) bytes at the
+		// cursor, byte-swap to host order (multi-byte only), and
+		// right-shift so the key's bits land in the LSBs. Allowed
+		// widths are gated in vocab/parser_machine.go::buildSelect
+		// (8/16/24); the value (≤ 0xFFFFFF) still fits a JNE.Imm.
+		loadBytes := loadBytesForBits(sk.Bits)
+		loadSize, err := asmSizeFor(loadBytes)
+		if err != nil {
+			return selectKeyShape{}, fmt.Errorf("%w: lookahead select key %d bits: %v", ErrNotImplemented, sk.Bits, err)
 		}
+		// After load+swap+shift the value occupies exactly sk.Bits low
+		// bits (the register zero-extends), so no mask is needed.
 		return selectKeyShape{
 			byteOffsetFromR4: 0,
-			maskAfterShift:   0xFF,
-			shift:            0,
-			bits:             8,
+			loadSize:         loadSize,
+			bigEndian:        loadBytes > 1,
+			mask:             0,
+			shift:            uint(loadBytes*8 - sk.Bits),
+			bits:             sk.Bits,
 		}, nil
 	default:
 		return selectKeyShape{}, fmt.Errorf("%w: unknown SelectKey kind %d", ErrNotImplemented, sk.Kind)
@@ -185,7 +199,12 @@ func (c *pmCtx) resolveFieldSelectKey(k vocab.FieldRef) (selectKeyShape, error) 
 	byteInHeader := k.BitOffset / 8
 	bitInByte := k.BitOffset % 8
 	shift := uint(8-k.BitWidth) - uint(bitInByte)
-	mask := uint8((1 << k.BitWidth) - 1)
+	// A full-byte field needs no mask after the shift; a sub-byte
+	// field masks down to its width.
+	var mask uint64
+	if k.BitWidth < 8 {
+		mask = (uint64(1) << k.BitWidth) - 1
+	}
 
 	// The selected header lies at [R4 - headerBytes, R4) when that
 	// header is the just-extracted one. For `stack.last`, the just-
@@ -195,10 +214,48 @@ func (c *pmCtx) resolveFieldSelectKey(k vocab.FieldRef) (selectKeyShape, error) 
 
 	return selectKeyShape{
 		byteOffsetFromR4: off,
-		maskAfterShift:   mask,
+		loadSize:         asm.Byte,
+		bigEndian:        false,
+		mask:             mask,
 		shift:            shift,
 		bits:             k.BitWidth,
 	}, nil
+}
+
+// lookaheadKindShape resolves the shape of the lookahead (kind) key in
+// a select tuple — the key the dispatch and the dynamic-aux slot
+// prelude both read. Returns an error if the select has no lookahead
+// key (a counter-only select never reaches a kind-keyed prelude).
+func (c *pmCtx) lookaheadKindShape(sel *vocab.SelectOp) (selectKeyShape, error) {
+	for _, k := range sel.Keys {
+		if k.Kind == vocab.SelectKeyLookahead {
+			return c.resolveSelectKey(k)
+		}
+	}
+	return selectKeyShape{}, fmt.Errorf("%w: dynamic-aux slot prelude with no lookahead select key", ErrNotImplemented)
+}
+
+// selectPeekBytes returns how many bytes the widest lookahead key in a
+// select tuple loads, so the pre-dispatch bounds check covers it.
+// Non-lookahead keys read no cursor bytes; at least 1 byte is peeked.
+func selectPeekBytes(sel *vocab.SelectOp) int {
+	n := 1
+	for _, k := range sel.Keys {
+		if k.Kind == vocab.SelectKeyLookahead {
+			if b := loadBytesForBits(k.Bits); b > n {
+				n = b
+			}
+		}
+	}
+	return n
+}
+
+// loadBytesForBits returns the LDX width (1/2/4 bytes) that holds a
+// lookahead key of the given bit width: the next power of two ≥
+// ceil(bits/8). The power-of-two policy lives in nextLDXSize; widths
+// are gated to 8/16/24 upstream, so this never exceeds 4.
+func loadBytesForBits(bits int) int {
+	return nextLDXSize((bits + 7) / 8)
 }
 
 // p4HeaderBytes sums a p4lite.Header's field widths in bytes.
@@ -316,19 +373,33 @@ func emitKeyCompare(addr selectAddr, shape selectKeyShape, keyIdx int, value uin
 		insns = append(insns,
 			asm.Mov.Reg(addr.dst, addr.scratchStart),
 			asm.Add.Reg(addr.dst, addr.offsetReg),
-			asm.LoadMem(addr.dst, addr.dst, int16(shape.byteOffsetFromR4), asm.Byte),
+			asm.LoadMem(addr.dst, addr.dst, int16(shape.byteOffsetFromR4), shape.loadSize),
 		)
 	} else {
 		insns = append(insns, foldOffsetIntoScalar(addr.scalarReg, addr.offsetReg, int32(shape.byteOffsetFromR4), addr.pktFailLabel)...)
-		insns = append(insns, boundedScalarLoad(addr.dst, addr.scratchStart, addr.scalarReg, addr.scratchEnd, asm.Byte, addr.pktFailLabel)...)
+		insns = append(insns, boundedScalarLoad(addr.dst, addr.scratchStart, addr.scalarReg, addr.scratchEnd, shape.loadSize, addr.pktFailLabel)...)
+	}
+	insns = append(insns, shape.normalize(addr.dst)...)
+	insns = append(insns, asm.JNE.Imm(addr.dst, int32(value), caseSkip))
+	return insns
+}
+
+// normalize turns a freshly-loaded key in dst into the right-aligned
+// key value: byte-swap (multi-byte lookahead), right-shift to the LSB,
+// and mask to the key width. Shared by emitKeyCompare and
+// emitStashSelectKeys so the load → compare and load → stash paths
+// agree bit-for-bit.
+func (shape selectKeyShape) normalize(dst asm.Register) asm.Instructions {
+	var insns asm.Instructions
+	if shape.bigEndian {
+		insns = append(insns, asm.HostTo(asm.BE, dst, shape.loadSize))
 	}
 	if shape.shift > 0 {
-		insns = append(insns, asm.RSh.Imm(addr.dst, int32(shape.shift)))
+		insns = append(insns, asm.RSh.Imm(dst, int32(shape.shift)))
 	}
-	if shape.maskAfterShift != 0xff {
-		insns = append(insns, asm.And.Imm(addr.dst, int32(shape.maskAfterShift)))
+	if shape.mask != 0 {
+		insns = append(insns, asm.And.Imm(dst, int32(shape.mask)))
 	}
-	insns = append(insns, asm.JNE.Imm(addr.dst, int32(value), caseSkip))
 	return insns
 }
 
@@ -368,13 +439,8 @@ func emitStashSelectKeys(sel *vocab.SelectOp, c *pmCtx, env stashEnv, failLabel 
 		// bound-load.
 		byteOff := int32(shape.byteOffsetFromR4)
 		insns = append(insns, foldOffsetIntoScalar(env.scalarReg, env.offset, byteOff, failLabel)...)
-		insns = append(insns, boundedScalarLoad(env.addrReg, env.scratchStart, env.scalarReg, env.scratchEnd, asm.Byte, failLabel)...)
-		if shape.shift > 0 {
-			insns = append(insns, asm.RSh.Imm(env.addrReg, int32(shape.shift)))
-		}
-		if shape.maskAfterShift != 0xff {
-			insns = append(insns, asm.And.Imm(env.addrReg, int32(shape.maskAfterShift)))
-		}
+		insns = append(insns, boundedScalarLoad(env.addrReg, env.scratchStart, env.scalarReg, env.scratchEnd, shape.loadSize, failLabel)...)
+		insns = append(insns, shape.normalize(env.addrReg)...)
 		insns = append(insns, asm.StoreMem(asm.R10, stashKeySlots[i], env.addrReg, asm.DWord))
 	}
 	return insns, nil

--- a/pkg/kunai/codegen/parser_select_width_test.go
+++ b/pkg/kunai/codegen/parser_select_width_test.go
@@ -1,0 +1,71 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+)
+
+// TestLoadBytesForBits pins the LDX width chosen per lookahead key
+// width: the next power of two ≥ ceil(bits/8).
+func TestLoadBytesForBits(t *testing.T) {
+	for _, tc := range []struct{ bits, want int }{
+		{8, 1}, {16, 2}, {24, 4},
+	} {
+		if got := loadBytesForBits(tc.bits); got != tc.want {
+			t.Errorf("loadBytesForBits(%d) = %d; want %d", tc.bits, got, tc.want)
+		}
+	}
+}
+
+// TestSelectKeyNormalize pins the load→value normalization for each
+// shape: an 8-bit lookahead needs nothing; a 24-bit lookahead loads a
+// Word, byte-swaps to host order, and right-shifts 8 (no mask, the
+// shift already zero-extends to the key bits); a sub-byte field key
+// shifts then masks.
+func TestSelectKeyNormalize(t *testing.T) {
+	countOp := func(insns asm.Instructions, pred func(asm.Instruction) bool) int {
+		n := 0
+		for _, in := range insns {
+			if pred(in) {
+				n++
+			}
+		}
+		return n
+	}
+	isEnd := func(in asm.Instruction) bool { return in.OpCode.ALUOp() == asm.Swap }
+	isRSh := func(in asm.Instruction) bool { return in.OpCode.ALUOp() == asm.RSh }
+	isAnd := func(in asm.Instruction) bool { return in.OpCode.ALUOp() == asm.And }
+
+	// 8-bit lookahead: byte load, no swap/shift/mask.
+	eight := selectKeyShape{loadSize: asm.Byte, bigEndian: false, shift: 0, mask: 0, bits: 8}
+	if got := eight.normalize(asm.R3); len(got) != 0 {
+		t.Errorf("8-bit normalize emitted %d insns; want 0 (%v)", len(got), got)
+	}
+
+	// 24-bit lookahead: Word load → HostTo(BE) → RSh 8, no mask.
+	twentyFour := selectKeyShape{loadSize: asm.Word, bigEndian: true, shift: 8, mask: 0, bits: 24}
+	got := twentyFour.normalize(asm.R3)
+	if c := countOp(got, isEnd); c != 1 {
+		t.Errorf("24-bit normalize: byte-swap count = %d; want 1 (%v)", c, got)
+	}
+	if c := countOp(got, isRSh); c != 1 {
+		t.Errorf("24-bit normalize: RSh count = %d; want 1 (%v)", c, got)
+	}
+	if c := countOp(got, isAnd); c != 0 {
+		t.Errorf("24-bit normalize: And count = %d; want 0 (%v)", c, got)
+	}
+
+	// Sub-byte field key (e.g. a 4-bit nibble): shift + mask, no swap.
+	field := selectKeyShape{loadSize: asm.Byte, bigEndian: false, shift: 2, mask: 0x0f, bits: 4}
+	gotF := field.normalize(asm.R3)
+	if c := countOp(gotF, isEnd); c != 0 {
+		t.Errorf("field normalize: byte-swap count = %d; want 0", c)
+	}
+	if c := countOp(gotF, isRSh); c != 1 {
+		t.Errorf("field normalize: RSh count = %d; want 1", c)
+	}
+	if c := countOp(gotF, isAnd); c != 1 {
+		t.Errorf("field normalize: And count = %d; want 1", c)
+	}
+}

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -134,12 +134,14 @@ func emitIntPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 		return nil, err
 	}
 	hasSlice := pred.Field != nil && pred.Field.Slice != nil
+	subByte := fieldIsSubByte(pred.Field)
 	switch {
-	case hasSlice:
-		// Slice-narrowed load: always bring the register to host
-		// order, then shift+mask. The constant stays in host order
-		// (the user wrote it that way), so we don't apply the
-		// constant-side bswap trick the equality fast-path uses.
+	case hasSlice || subByte:
+		// Slice-narrowed or sub-byte field: the load went through a
+		// covering window, so bring the register to host order then
+		// shift+mask down to the field's bits. The constant stays in
+		// host order (the user wrote it that way), so we don't apply
+		// the constant-side bswap trick the equality fast-path uses.
 		if bytes > 1 {
 			insns = append(insns, asm.HostTo(asm.BE, asm.R3, size))
 		}
@@ -618,10 +620,12 @@ func emitInPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 	dynamic := pred.Field.Aux != nil && pred.Field.Aux.Stack != nil && !pred.Field.Aux.Stack.IsStatic
 	var insns asm.Instructions
 	var bytes int
+	var size asm.Size
 	switch {
 	case dynamic:
 		bytes = pred.Field.Aux.FieldBitWidth / 8
-		size, err := asmSizeFor(bytes)
+		var err error
+		size, err = asmSizeFor(bytes)
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +640,7 @@ func emitInPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 			return nil, err
 		}
 		bytes = bs
-		size, err := asmSizeFor(bs)
+		size, err = asmSizeFor(bs)
 		if err != nil {
 			return nil, err
 		}
@@ -644,6 +648,17 @@ func emitInPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 			insns = append(insns, emitAuxGating(pred.Field.Aux.Gating, r4Anchor(), dslReject)...)
 		}
 		insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff), size, dslReject)...)
+	}
+
+	// Sub-byte field: the load read a covering window, so bring R3 to
+	// host order and narrow it to the field's bits before comparing.
+	// The alternatives then stay in host order (no constant bswap).
+	subByte := fieldIsSubByte(pred.Field)
+	if subByte {
+		if bytes > 1 {
+			insns = append(insns, asm.HostTo(asm.BE, asm.R3, size))
+		}
+		insns = append(insns, emitSliceShiftMask(pred.Field, bytes)...)
 	}
 
 	matchLabel := nextPredicateMatchLabel()
@@ -654,8 +669,9 @@ func emitInPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 		}
 		// Multi-byte fields land in R3 in network-byte order packed
 		// as little-endian; mirror emitIntPredicate by byte-swapping
-		// the constant so a single JEq still matches.
-		if bytes > 1 {
+		// the constant so a single JEq still matches. A sub-byte field
+		// is already host-order after the shift+mask above, so skip it.
+		if bytes > 1 && !subByte {
 			value = swapValueBytes(value, bytes)
 		}
 		if value > 0x7FFFFFFF {

--- a/pkg/kunai/codegen/slice_test.go
+++ b/pkg/kunai/codegen/slice_test.go
@@ -106,6 +106,90 @@ func TestSlicePostAdjustNonAligned(t *testing.T) {
 	}
 }
 
+func TestSubByteWindow(t *testing.T) {
+	cases := []struct {
+		name             string
+		bitOff, width    int
+		byteOff, loadLen int
+		ok               bool
+	}{
+		// byte-clean fields are not our path.
+		{"byte-aligned byte field", 8, 8, 0, 0, false},
+		{"byte-aligned 2-byte field", 16, 16, 0, 0, false},
+		// sub-byte starts / widths.
+		{"ipv4.version", 0, 4, 0, 1, true},
+		{"ipv4.ihl", 4, 4, 0, 1, true},
+		{"ipv4.flags", 48, 3, 6, 1, true},
+		{"ipv4.frag_offset", 51, 13, 6, 2, true},
+		{"tcp.data_offset", 96, 4, 12, 1, true},
+		{"tcp.flags", 103, 9, 12, 2, true},
+		{"ipv6.traffic_class", 4, 8, 0, 2, true},
+		// covering window wider than a single 8-byte LDX → not ours.
+		{"too wide", 1, 64, 0, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			byteOff, loadLen, ok := subByteWindow(c.bitOff, c.width)
+			if ok != c.ok || (ok && (byteOff != c.byteOff || loadLen != c.loadLen)) {
+				t.Errorf("subByteWindow(%d,%d) = (%d,%d,%v), want (%d,%d,%v)",
+					c.bitOff, c.width, byteOff, loadLen, ok, c.byteOff, c.loadLen, c.ok)
+			}
+		})
+	}
+}
+
+// subByteFieldRef builds a FieldRef over a synthetic single-field spec
+// whose field sits at the given header bit offset (padded by a leading
+// filler field) so slicePostAdjust resolves the real geometry.
+func subByteFieldRef(bitOff, width int) *ir.FieldRef {
+	fields := []vocab.Field{}
+	if bitOff > 0 {
+		fields = append(fields, vocab.Field{Name: "_pad", Bits: bitOff})
+	}
+	fields = append(fields, vocab.Field{Name: "f", Bits: width})
+	return &ir.FieldRef{
+		Layer: &ir.LayerInstance{Spec: &vocab.ProtocolSpec{Name: "p", Fields: fields}},
+		Field: &vocab.Field{Name: "f", Bits: width},
+	}
+}
+
+func TestSlicePostAdjustSubByteField(t *testing.T) {
+	cases := []struct {
+		name          string
+		bitOff, width int
+		loadBytes     int
+		shift         int
+		mask          uint64
+	}{
+		{"ipv4.version", 0, 4, 1, 4, 0xf},
+		{"ipv4.ihl", 4, 4, 1, 0, 0xf},
+		{"ipv4.flags", 48, 3, 1, 5, 0x7},
+		{"ipv4.frag_offset", 51, 13, 2, 0, 0x1fff},
+		{"tcp.data_offset", 96, 4, 1, 4, 0xf},
+		{"tcp.flags", 103, 9, 2, 0, 0x1ff},
+		{"ipv6.traffic_class", 4, 8, 2, 4, 0xff},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ref := subByteFieldRef(c.bitOff, c.width)
+			shift, mask := slicePostAdjust(ref, c.loadBytes)
+			if shift != c.shift || mask != c.mask {
+				t.Errorf("slicePostAdjust = (shift=%d, mask=%#x), want (shift=%d, mask=%#x)",
+					shift, mask, c.shift, c.mask)
+			}
+		})
+	}
+}
+
+// A byte-clean primary field (and an empty/aux ref) must stay a no-op
+// so existing F1–F10 emit is unchanged.
+func TestSlicePostAdjustByteCleanFieldNoOp(t *testing.T) {
+	ref := subByteFieldRef(16, 16) // dport-like: byte-aligned, 2 bytes
+	if shift, mask := slicePostAdjust(ref, 2); shift != 0 || mask != 0 {
+		t.Errorf("byte-clean field: got (shift=%d, mask=%#x), want (0, 0)", shift, mask)
+	}
+}
+
 func TestApplySliceToOffsetByteAligned(t *testing.T) {
 	// Byte-aligned slice on a 16-byte field narrows (off, size).
 	ref := &ir.FieldRef{

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -223,8 +223,8 @@ func TestCompileWhereBoolLitFalse(t *testing.T) {
 
 func TestCompileWhereBareBoolFieldDecay(t *testing.T) {
 	// `where tcp.dport` triggers Int<16> -> Bool decay -> `tcp.dport != 0`.
-	// (tcp.dport is byte-aligned, so codegen handles it without invoking the
-	// not-yet-implemented sub-byte field-load path that would gate flag bits.)
+	// (tcp.dport is byte-aligned; the sub-byte field-load path that gates
+	// flag bits is exercised by TestCompileSubByteField.)
 	insns, err := compileForTest("eth/ipv4/tcp where tcp.dport")
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
@@ -381,6 +381,40 @@ func TestCompileBitSliceNonAligned(t *testing.T) {
 				t.Fatal("expected non-empty instructions")
 			}
 		})
+	}
+}
+
+func TestCompileSubByteField(t *testing.T) {
+	// Non-byte-aligned / sub-byte-sized primary fields read via a
+	// covering window + post-load shift+mask, in both where clauses
+	// and bracket predicates. These were ErrNotImplemented before the
+	// field-load generalization; the bit-extraction math is pinned in
+	// codegen.slice_test.go and the packet-level correctness in
+	// dsltest. Here we only assert they compile to non-empty bytecode.
+	runCompileExprCases(t, []string{
+		"eth/ipv4/tcp where tcp.flags & 0x02 != 0", // SYN, bit<9>@103
+		"eth/ipv4/tcp where tcp.data_offset == 5",  // bit<4>@96
+		"eth/ipv4 where ipv4.version == 4",         // bit<4>@0, shift 4
+		"eth/ipv4 where ipv4.ihl >= 5",             // bit<4>@4, ordered
+		"eth/ipv4 where ipv4.flags & 0x2 != 0",     // DF, bit<3>@48
+		"eth/ipv4 where ipv4.frag_offset == 0",     // bit<13>@51, 2-byte window
+		"eth/ipv6 where ipv6.traffic_class == 0",   // bit<8>@4
+		"eth/ipv4[ihl==5]/tcp",                     // bracket predicate, eq
+		"eth/ipv4[version==4]/tcp",                 // bracket predicate, shift
+		"eth/ipv4[ihl in [5, 6]]/tcp",              // bracket 'in' predicate
+	})
+}
+
+func TestCompileSubByteRawOffsetStillRejected(t *testing.T) {
+	// kunai has no raw byte-offset escape hatch: every field is named
+	// via the P4 vocab. pcap-filter's `tcp[13]` style stays rejected by
+	// design (the §6 reverse gap), even though tcp.flags is now readable.
+	_, err := compileForTest("eth/ipv4/tcp where tcp[13] & 0x02 != 0")
+	if err == nil {
+		t.Fatal("expected raw byte-offset access to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must be qualified") {
+		t.Errorf("err = %v; want 'must be qualified'", err)
 	}
 }
 
@@ -947,18 +981,28 @@ func isHostOwned(ins asm.Instruction) bool {
 	return false
 }
 
-// TestVlanInMetadataRejectsVlanLayers asserts that a host advertising
-// VlanInMetadata (e.g. tc, where the kernel strips the outer VLAN tag
-// into skb metadata before the program runs) rejects any chain with a
-// vlan or qinq layer at compile time, rather than silently parsing the
-// wrong bytes. The same expressions must still compile under the zero
+// TestVlanInMetadataRejectsVlanLayers asserts the VlanInMetadata host
+// policy (e.g. tc, where the kernel strips the outer VLAN tag into skb
+// metadata before the program runs). A vlan/qinq layer that READS the
+// tag from packet bytes is rejected at compile time rather than
+// silently parsing the wrong bytes; an optional, predicate-free tag is
+// accepted, because the byte parser takes its skip path and never reads
+// the stripped tag. Every expression must still compile under the zero
 // (in-band) Capabilities used by XDP and the test harness.
 func TestVlanInMetadataRejectsVlanLayers(t *testing.T) {
 	rejected := []string{
-		"eth/vlan[tci==100]/ipv4/tcp where tcp.dport == 80",
-		"eth/qinq/vlan/ipv4/tcp where tcp.dport == 80",
+		"eth/vlan[tci==100]/ipv4/tcp where tcp.dport == 80", // mandatory + field
+		"eth/qinq/vlan/ipv4/tcp where tcp.dport == 80",      // mandatory QinQ
+		"eth/vlan[tci==100]?/ipv4/tcp",                      // optional but reads tci
+		"eth/(vlan|qinq)/ipv4/tcp",                          // tag in alternation
+	}
+	// Optional, predicate-free tags are matchable at a VlanInMetadata
+	// host: at most one tag survives in the bytes, and the skip path
+	// covers untagged / single-tag / QinQ traffic without reading it.
+	accepted := []string{
 		"eth/vlan?/ipv4/tcp",
-		"eth/(vlan|qinq)/ipv4/tcp",
+		"eth/qinq?/vlan?/ipv4/tcp",
+		"eth/vlan*/ipv4/tcp",
 	}
 	tcCaps := codegen.Capabilities{Host: codegen.HostLayout{VlanInMetadata: true}}
 	for _, expr := range rejected {
@@ -971,7 +1015,16 @@ func TestVlanInMetadataRejectsVlanLayers(t *testing.T) {
 				t.Fatalf("Compile(%q): expected ErrNotImplemented, got %v", expr, err)
 			}
 		})
-		t.Run("allow/"+expr, func(t *testing.T) {
+	}
+	for _, expr := range accepted {
+		t.Run("accept/"+expr, func(t *testing.T) {
+			if _, err := Compile(expr, tcCaps); err != nil {
+				t.Fatalf("Compile(%q) with VlanInMetadata: expected success, got %v", expr, err)
+			}
+		})
+	}
+	for _, expr := range append(append([]string{}, rejected...), accepted...) {
+		t.Run("inband/"+expr, func(t *testing.T) {
 			if _, err := Compile(expr, codegen.Capabilities{}); err != nil {
 				t.Fatalf("Compile(%q) with zero caps: expected success, got %v", expr, err)
 			}

--- a/pkg/kunai/dsltest/builders.go
+++ b/pkg/kunai/dsltest/builders.go
@@ -707,6 +707,64 @@ func BuildEthIPv4UDPGeneve(t testing.TB, vni uint32) []byte {
 	return buf.Bytes()
 }
 
+// GeneveOptionTLV builds one Geneve option TLV (RFC 8926): a 4-byte
+// header (option_class BE16, type, R(3)+opt_data_len(5)) followed by
+// data. data must be a whole number of 4-byte words; opt_data_len is
+// derived as len(data)/4.
+func GeneveOptionTLV(t testing.TB, optClass uint16, optType uint8, data []byte) []byte {
+	t.Helper()
+	if len(data)%4 != 0 {
+		t.Fatalf("GeneveOptionTLV: data len %d is not a multiple of 4", len(data))
+	}
+	tlv := make([]byte, 4)
+	binary.BigEndian.PutUint16(tlv[0:2], optClass)
+	tlv[2] = optType
+	tlv[3] = byte(len(data) / 4) // R bits stay 0
+	return append(tlv, data...)
+}
+
+// BuildEthIPv4UDPGeneveOpts returns Ethernet/IPv4/UDP(6081)/Geneve
+// carrying the concatenated option TLVs. opt_len is set from the total
+// option byte length (which must be a multiple of 4). Used by tests
+// that filter on geneve.options.<NAME>.<field>.
+func BuildEthIPv4UDPGeneveOpts(t testing.TB, vni uint32, opts ...[]byte) []byte {
+	t.Helper()
+	var optBytes []byte
+	for _, o := range opts {
+		optBytes = append(optBytes, o...)
+	}
+	if len(optBytes)%4 != 0 {
+		t.Fatalf("geneve options total %d bytes is not a multiple of 4", len(optBytes))
+	}
+	words := len(optBytes) / 4
+	if words > 0x3F {
+		t.Fatalf("geneve opt_len %d words exceeds the 6-bit field", words)
+	}
+
+	d := Defaults()
+	eth := &layers.Ethernet{SrcMAC: d.SrcMAC, DstMAC: d.DstMAC, EthernetType: layers.EthernetTypeIPv4}
+	v4 := &layers.IPv4{
+		Version: 4, IHL: 5, TTL: 64,
+		SrcIP:    d.SrcIP.To4(),
+		DstIP:    d.DstIP.To4(),
+		Protocol: layers.IPProtocolUDP,
+	}
+	udp := &layers.UDP{SrcPort: 12345, DstPort: 6081}
+	_ = udp.SetNetworkLayerForChecksum(v4)
+
+	geneve := geneveHeader(vni, layers.EthernetTypeIPv4)
+	geneve[0] = byte(words) // version 0, opt_len = words
+	geneve = append(geneve, optBytes...)
+
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{
+		ComputeChecksums: true, FixLengths: true,
+	}, eth, v4, udp, gopacket.Payload(geneve)); err != nil {
+		t.Fatalf("gopacket.SerializeLayers (geneve-opts): %v", err)
+	}
+	return buf.Bytes()
+}
+
 // IPIPOpts describes an Ethernet/IPv4(outer, proto=IPIP)/IPv4(inner)/
 // TCP frame. InnerOptions populate the inner IPv4 header's options
 // (lifting its IHL past 5) so tests can confirm the layered chain

--- a/pkg/kunai/dsltest/geneve_options_test.go
+++ b/pkg/kunai/dsltest/geneve_options_test.go
@@ -1,0 +1,64 @@
+package dsltest
+
+// Packet-level checks for the Geneve option-TLV walk, dispatched on the
+// 24-bit option class+type discriminator. Two widely-deployed classes
+// are exercised: OVN (OpenStack Neutron / OVN-Kubernetes, class 0x0102)
+// and AWS Gateway Load Balancer (class 0x0108).
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// ovnPortsValue packs the OVN option's 32-bit value: rsv(1) +
+// ingress(15) + egress(16), big-endian.
+func ovnPortsValue(ingress, egress uint16) []byte {
+	v := (uint32(ingress&0x7fff) << 16) | uint32(egress)
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}
+
+// gwlbCookieValue packs the AWS GWLB 32-bit flow cookie big-endian.
+func gwlbCookieValue(cookie uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, cookie)
+	return b
+}
+
+// TestGeneveOptionOVNEgressPort filters on the OVN logical egress port
+// carried in the Geneve option (class 0x0102, type 0x80).
+func TestGeneveOptionOVNEgressPort(t *testing.T) {
+	r := New(t, "eth/ipv4/udp/geneve where geneve.options.OVN.egress_port == 42")
+
+	ovn42 := GeneveOptionTLV(t, 0x0102, 0x80, ovnPortsValue(7, 42))
+	r.MustMatch(t, BuildEthIPv4UDPGeneveOpts(t, 0x123456, ovn42), "OVN egress_port == 42")
+
+	ovn99 := GeneveOptionTLV(t, 0x0102, 0x80, ovnPortsValue(7, 99))
+	r.MustReject(t, BuildEthIPv4UDPGeneveOpts(t, 0x123456, ovn99), "OVN egress_port == 99 (!= 42)")
+}
+
+// TestGeneveOptionGWLBFlowCookie filters on the 32-bit AWS GWLB flow
+// cookie (class 0x0108, type 3).
+func TestGeneveOptionGWLBFlowCookie(t *testing.T) {
+	r := New(t, "eth/ipv4/udp/geneve where geneve.options.GWLB.flow_cookie == 0x12345678")
+
+	gwlb := GeneveOptionTLV(t, 0x0108, 0x03, gwlbCookieValue(0x12345678))
+	r.MustMatch(t, BuildEthIPv4UDPGeneveOpts(t, 0x123456, gwlb), "GWLB flow_cookie matches")
+
+	other := GeneveOptionTLV(t, 0x0108, 0x03, gwlbCookieValue(0x0badf00d))
+	r.MustReject(t, BuildEthIPv4UDPGeneveOpts(t, 0x123456, other), "GWLB flow_cookie differs")
+}
+
+// TestGeneveOptionMultiCase walks past one known option to reach a
+// second — exercising the 24-bit multi-case dispatch and the
+// counter-driven loop across more than one option.
+func TestGeneveOptionMultiCase(t *testing.T) {
+	r := New(t, "eth/ipv4/udp/geneve where geneve.options.GWLB.flow_cookie == 0x55667788")
+
+	ovn := GeneveOptionTLV(t, 0x0102, 0x80, ovnPortsValue(1, 2))
+	gwlb := GeneveOptionTLV(t, 0x0108, 0x03, gwlbCookieValue(0x55667788))
+	// OVN first, then GWLB: the walk must extract OVN, decrement, and
+	// dispatch GWLB on the next iteration.
+	r.MustMatch(t, BuildEthIPv4UDPGeneveOpts(t, 0x123456, ovn, gwlb), "GWLBE after OVN")
+}

--- a/pkg/kunai/dsltest/subbyte_test.go
+++ b/pkg/kunai/dsltest/subbyte_test.go
@@ -1,0 +1,139 @@
+package dsltest
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// Packet-level correctness for non-byte-aligned / sub-byte-sized
+// primary field reads (TCP flags / data_offset, IPv4 version / ihl /
+// flags / frag_offset, IPv6 traffic_class). The bit-extraction math is
+// pinned in codegen/slice_test.go; here we prove the generated
+// bytecode loads, passes the verifier, and matches/rejects real frames
+// the way pcap-filter's `tcp[13]&2` etc. would. Requires root (New
+// skips otherwise).
+
+// serialize composes a layer stack into wire bytes with checksums and
+// lengths fixed, matching how Build emits frames.
+func serialize(t testing.TB, ls ...gopacket.SerializableLayer) []byte {
+	t.Helper()
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(buf, gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		FixLengths:       true,
+	}, ls...); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func ethIPv4() *layers.Ethernet {
+	return &layers.Ethernet{
+		SrcMAC:       mustMAC("aa:bb:cc:dd:ee:01"),
+		DstMAC:       mustMAC("aa:bb:cc:dd:ee:02"),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+}
+
+// v4tcpFrame builds an eth/ipv4/tcp frame, letting the caller mutate
+// the IPv4 and TCP layers (flags, options, frag) before serialization.
+func v4tcpFrame(t testing.TB, mut func(ip *layers.IPv4, tcp *layers.TCP)) []byte {
+	t.Helper()
+	ip := &layers.IPv4{
+		Version: 4, IHL: 5, TTL: 64,
+		SrcIP: net.IP{10, 0, 0, 1}, DstIP: net.IP{10, 0, 0, 2},
+		Protocol: layers.IPProtocolTCP,
+	}
+	tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Window: 65535, Seq: 1}
+	if mut != nil {
+		mut(ip, tcp)
+	}
+	_ = tcp.SetNetworkLayerForChecksum(ip)
+	return serialize(t, ethIPv4(), ip, tcp, gopacket.Payload([]byte("hello")))
+}
+
+func TestSubByteTCPFlagsSYN(t *testing.T) {
+	r := New(t, "eth/ipv4/tcp where tcp.flags & 0x02 != 0")
+	r.MustMatch(t, v4tcpFrame(t, func(_ *layers.IPv4, tcp *layers.TCP) { tcp.SYN = true }),
+		"SYN set")
+	r.MustReject(t, v4tcpFrame(t, func(_ *layers.IPv4, tcp *layers.TCP) { tcp.SYN, tcp.ACK = false, true }),
+		"SYN clear (ACK only)")
+	// FIN+PSH set but not SYN — adjacent bits must not leak in.
+	r.MustReject(t, v4tcpFrame(t, func(_ *layers.IPv4, tcp *layers.TCP) {
+		tcp.SYN, tcp.FIN, tcp.PSH = false, true, true
+	}), "FIN+PSH, no SYN")
+}
+
+func TestSubByteTCPDataOffset(t *testing.T) {
+	r := New(t, "eth/ipv4/tcp where tcp.data_offset == 5")
+	r.MustMatch(t, v4tcpFrame(t, nil), "no TCP options → data_offset 5")
+	r.MustReject(t, v4tcpFrame(t, func(_ *layers.IPv4, tcp *layers.TCP) {
+		tcp.Options = []layers.TCPOption{
+			{OptionType: layers.TCPOptionKindMSS, OptionLength: 4, OptionData: []byte{0x05, 0xb4}},
+		}
+	}), "MSS option → data_offset 6")
+}
+
+func TestSubByteIPv4Version(t *testing.T) {
+	frame := v4tcpFrame(t, nil)
+	New(t, "eth/ipv4/tcp where ipv4.version == 4").MustMatch(t, frame, "IPv4 version 4")
+	// Same v4 frame against ==6 must reject: proves the nibble read
+	// returns 4, not a stray adjacent value.
+	New(t, "eth/ipv4/tcp where ipv4.version == 6").MustReject(t, frame, "v4 frame, version!=6")
+}
+
+func TestSubByteIPv4IHL(t *testing.T) {
+	noOpts := v4tcpFrame(t, nil)
+	withOpts := v4tcpFrame(t, func(ip *layers.IPv4, _ *layers.TCP) {
+		ip.Options = []layers.IPv4Option{{OptionType: 148, OptionLength: 4, OptionData: []byte{0, 0}}}
+	})
+	r5 := New(t, "eth/ipv4[ihl==5]/tcp")
+	r5.MustMatch(t, noOpts, "IHL=5, no options")
+	r5.MustReject(t, withOpts, "IHL=6, Router Alert")
+	r6 := New(t, "eth/ipv4[ihl==6]/tcp")
+	r6.MustMatch(t, withOpts, "IHL=6, Router Alert")
+	r6.MustReject(t, noOpts, "IHL=5, no options")
+}
+
+func TestSubByteIPv4DontFragment(t *testing.T) {
+	r := New(t, "eth/ipv4/tcp where ipv4.flags & 0x2 != 0") // DF = 0x2 of the 3-bit flags
+	r.MustMatch(t, v4tcpFrame(t, func(ip *layers.IPv4, _ *layers.TCP) {
+		ip.Flags = layers.IPv4DontFragment
+	}), "DF set")
+	r.MustReject(t, v4tcpFrame(t, nil), "DF clear")
+}
+
+func TestSubByteIPv4FragOffset(t *testing.T) {
+	r := New(t, "eth/ipv4/tcp where ipv4.frag_offset == 0")
+	r.MustMatch(t, v4tcpFrame(t, nil), "frag_offset 0")
+	r.MustReject(t, v4tcpFrame(t, func(ip *layers.IPv4, _ *layers.TCP) {
+		ip.Flags = layers.IPv4MoreFragments
+		ip.FragOffset = 100
+	}), "frag_offset 100")
+}
+
+func TestSubByteIPv6TrafficClass(t *testing.T) {
+	build := func(tc uint8) []byte {
+		ip := &layers.IPv6{
+			Version: 6, TrafficClass: tc, HopLimit: 64,
+			SrcIP: net.ParseIP("2001:db8::1"), DstIP: net.ParseIP("2001:db8::2"),
+			NextHeader: layers.IPProtocolTCP,
+		}
+		tcp := &layers.TCP{SrcPort: 12345, DstPort: 80, Window: 65535, Seq: 1, SYN: true}
+		_ = tcp.SetNetworkLayerForChecksum(ip)
+		eth := &layers.Ethernet{
+			SrcMAC: mustMAC("aa:bb:cc:dd:ee:01"), DstMAC: mustMAC("aa:bb:cc:dd:ee:02"),
+			EthernetType: layers.EthernetTypeIPv6,
+		}
+		return serialize(t, eth, ip, tcp, gopacket.Payload([]byte("hello")))
+	}
+	r := New(t, "eth/ipv6/tcp where ipv6.traffic_class == 0")
+	r.MustMatch(t, build(0), "traffic_class 0")
+	r.MustReject(t, build(5), "traffic_class 5")
+	// DSCP-style high bits set: traffic_class spans the version/flow
+	// boundary, so a wrong shift would misread it.
+	r.MustReject(t, build(0xb8), "traffic_class 0xb8 (EF)")
+}

--- a/pkg/kunai/dsltest/vlan_tagflex_test.go
+++ b/pkg/kunai/dsltest/vlan_tagflex_test.go
@@ -1,0 +1,54 @@
+package dsltest
+
+// Packet-level behaviour of the tag-flexible optional-VLAN forms that
+// the tc host accepts. These run on the XDP harness, but the kunai
+// filter bytecode is host-agnostic, so the byte layouts here are the
+// same ones the identical bytecode sees at the tc skb window — in
+// particular an untagged frame is exactly the post-untag layout the
+// kernel hands a tc program for a singly-tagged frame
+// (vlan_untag_datapath_test.go confirms that on a live veth).
+
+import (
+	"net"
+	"testing"
+)
+
+// qinq?/vlan? is the recommended tag-flexible pattern: it matches every
+// realistic L2 tagging shape on Ethernet.
+func TestQinqVlanOptionalAllShapes(t *testing.T) {
+	r := New(t, "eth/qinq?/vlan?/ipv4/tcp")
+
+	r.MustMatch(t, BuildEthIPv4TCP(t, 12345, 80), "untagged (= tc post-untag of a single tag)")
+
+	single := Defaults()
+	single.VLAN = []uint16{100}
+	r.MustMatch(t, Build(t, single), "single C-tag")
+
+	qinq := Defaults()
+	qinq.VLAN = []uint16{100}
+	qinq.QinQ = true
+	r.MustMatch(t, Build(t, qinq), "double-tagged QinQ (S-tag + C-tag)")
+
+	// A non-IP ethertype with no tag must still reject.
+	v6 := Defaults()
+	v6.SrcIP = net.ParseIP("fe80::1")
+	v6.DstIP = net.ParseIP("fe80::2")
+	r.MustReject(t, Build(t, v6), "ipv6 ethertype, no tag")
+}
+
+// `vlan[tci==100]?` is the "if a tag is present, require tci==100; else
+// pass through" form (predicate before quantifier). On full packet
+// bytes it tests the tag only when present.
+func TestVlanOptionalPredicateSemantics(t *testing.T) {
+	r := New(t, "eth/vlan[tci==100]?/ipv4/tcp")
+
+	r.MustMatch(t, BuildEthIPv4TCP(t, 12345, 80), "no tag -> skip -> pass through")
+
+	ok := Defaults()
+	ok.VLAN = []uint16{100}
+	r.MustMatch(t, Build(t, ok), "tag tci=100 -> predicate passes")
+
+	bad := Defaults()
+	bad.VLAN = []uint16{200}
+	r.MustReject(t, Build(t, bad), "tag tci=200 -> predicate fails")
+}

--- a/pkg/kunai/protocols/geneve.p4
+++ b/pkg/kunai/protocols/geneve.p4
@@ -1,8 +1,8 @@
 // Geneve (RFC 8926). The fixed 8-byte tunnel header is followed by an
 // options section whose length is opt_len 4-byte words (excluding the
-// fixed header). The parser skips that section so the inner payload
-// resolves at the correct offset regardless of opt_len; individual
-// option TLVs are not exposed as fields (no filter inspects them).
+// fixed header). Chains that only need the inner payload (e.g.
+// eth/ipv4@outer/udp/geneve/eth/ipv4@inner/tcp) bulk-advance past the
+// options; filters that read geneve.options.<NAME> walk the TLVs.
 header geneve_h {
     bit<2>  version;
     bit<6>  opt_len;
@@ -15,20 +15,96 @@ header geneve_h {
 // Dispatch from UDP via the IANA-assigned destination port.
 const bit<16> GENEVE_UDP_DPORT = 6081;
 
-parser GeneveParser(packet_in pkt, out geneve_h hdr) {
+// Cap the option-walk bpf_loop iterations. Real Geneve frames carry a
+// handful of options (AWS GWLB uses 3; OVN uses 1), so a small bound
+// keeps the verifier's callback state-exploration in budget.
+const bit<8> GENEVE_MAX_DEPTH = 4;
+
+// Each option is a TLV: option_class(16) + type(8) + R(3)+opt_data_len(5),
+// then opt_data_len 4-byte words of value. The walk dispatches on the
+// 24-bit class+type discriminator. Two widely-deployed option classes
+// are exposed below.
+
+// OVN (IANA Geneve option class 0x0102), type 0x80: logical ingress /
+// egress port metadata used by OVN (the OpenStack Neutron default
+// backend and OVN-Kubernetes). The 32-bit value packs rsv(1) +
+// ingress(15) + egress(16); egress is byte-aligned and reachable as
+// geneve.options.OVN.egress_port. ingress straddles a byte boundary
+// (bit offset 1) so it is not exposed as a filter field.
+header geneve_opt_ovn_h {
+    bit<16> option_class;
+    bit<8>  type;
+    bit<8>  flags_len;
+    bit<1>  rsv;
+    bit<15> ingress_port;
+    bit<16> egress_port;
+}
+
+// AWS Gateway Load Balancer (IANA Geneve option class 0x0108), type 3:
+// the 32-bit flow cookie an appliance echoes back to keep a flow
+// pinned, reachable as geneve.options.GWLB.flow_cookie. (Type 1, the
+// 64-bit GWLBE/VPCE endpoint id, is also in this class; filtering a
+// 64-bit option field needs a 64-bit immediate compare — future work.)
+header geneve_opt_gwlb_h {
+    bit<16> option_class;
+    bit<8>  type;
+    bit<8>  flags_len;
+    bit<32> flow_cookie;
+}
+
+extern ParserCounter {
+    ParserCounter();
+    void set(in bit<8> value);
+    void decrement(in bit<8> value);
+    bool is_zero();
+}
+
+// Options walk shape (Mechanism 8 in dsl-internals.md §6.5, mirrors
+// ipv4.p4's IHL-driven walk): ParserCounter pc records the remaining
+// option bytes after the fixed 8-byte header (opt_len * 4). The walk
+// state's 2-key tuple-select dispatches on (pc.is_zero(), 24-bit
+// class+type): when the counter exhausts, accept; otherwise route to
+// the matching sibling extract state, decrement by the option's byte
+// size, and loop. An unknown class+type rejects (skip-by-length with a
+// variable counter decrement is future work, as in ipv4.p4).
+//
+// Both modeled options are fixed-size (opt_data_len = 1, i.e. an 8-byte
+// TLV), so the sibling decrements pc by a constant 8. A packet that
+// reuses one of these class+type values with a different opt_data_len
+// desyncs R4/pc from the real TLV size; the walk then reads trailing
+// bytes as a discriminator and falls toward the reject arm. Validating
+// opt_data_len for these options, or supporting variable-length Geneve
+// TLVs, is future work (same envelope as the variable-length note above).
+//
+// Demand-driven codegen skips the bpf_loop subprogram when no
+// geneve.options.<X> predicate is in the program: most chains
+// (eth/.../geneve/eth/ipv4@inner/...) take the bulk-advance fallback
+// over the whole options section and never pay for the walk. Only a
+// filter that reads a Geneve option pays for the TLV walk.
+parser GeneveParser(packet_in pkt,
+                    out geneve_h            hdr,
+                    out geneve_opt_ovn_h    ovn,
+                    out geneve_opt_gwlb_h   gwlb) {
+    ParserCounter() pc;
     state start {
         pkt.extract(hdr);
-        transition skip_options;
+        // Remaining option bytes = opt_len * 4. The `.set` grammar
+        // requires the `(field - K)` subtract template (cf. ipv4.p4's
+        // `ihl - 5`); opt_len already excludes the fixed header, so K=0.
+        pc.set(((bit<8>)(hdr.opt_len - 0)) << 5);
+        transition select(hdr.version) {
+            0:       walk;
+            default: reject;
+        }
     }
-    // Variable trail: skip the (opt_len * 4)-byte options section
-    // (RFC 8926 — opt_len counts 4-byte words and excludes the fixed
-    // 8-byte header). Mask 0x3F caps the runtime advance at 252 bytes
-    // so the verifier sees a static upper bound; opt_len is 6 bits so
-    // the mask preserves its full range. F9-style filters only need the
-    // inner payload offset, not the option contents. Same field-driven
-    // advance idiom as srv6.p4's segment-list skip.
-    state skip_options {
-        pkt.advance(((bit<32>)(hdr.opt_len & 0x3F)) << 5);
-        transition accept;
+    state walk {
+        transition select(pc.is_zero(), pkt.lookahead<bit<24>>()) {
+            (true,  _):        accept;
+            (false, 0x010280): parse_ovn;    // OVN class 0x0102, type 0x80
+            (false, 0x010803): parse_gwlb;   // AWS GWLB class 0x0108, type 3
+            (false, _):        reject;
+        }
     }
+    state parse_ovn  { pkt.extract(ovn);  pc.decrement(8); transition walk; }
+    state parse_gwlb { pkt.extract(gwlb); pc.decrement(8); transition walk; }
 }

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -1789,16 +1789,17 @@ parser P(packet_in pkt, out foo_h hdr) {
 	}
 }
 
-// TestSelectKeyLookaheadRejectsNon8Bit pins the MVP cap: lookahead
-// keys must be exactly 8 bits because codegen only knows how to
-// emit a single-byte LDX for the peek. Wider widths would need
-// multi-byte loads.
-func TestSelectKeyLookaheadRejectsNon8Bit(t *testing.T) {
+// TestSelectKeyLookaheadRejectsUnsupportedWidth pins the lookahead
+// width gate: codegen lowers byte-multiple widths up to 24 bits
+// (8/16/24), so a non-byte-multiple width like bit<12> is rejected
+// with a hint. The accepted widths (incl. the 24-bit Geneve
+// class+type dispatch) are exercised end to end in dsltest.
+func TestSelectKeyLookaheadRejectsUnsupportedWidth(t *testing.T) {
 	src := `header foo_h { bit<8> a; }
 parser P(packet_in pkt, out foo_h hdr) {
 	state start {
 		pkt.extract(hdr);
-		transition select(pkt.lookahead<bit<16>>()) {
+		transition select(pkt.lookahead<bit<12>>()) {
 			0: accept;
 			default: reject;
 		}
@@ -1806,7 +1807,7 @@ parser P(packet_in pkt, out foo_h hdr) {
 }`
 	fsys := fstest.MapFS{"vocab/foo.p4": &fstest.MapFile{Data: []byte(src)}}
 	_, err := Load(fsys, "vocab")
-	if err == nil || !strings.Contains(err.Error(), "must be exactly 8 bits") {
+	if err == nil || !strings.Contains(err.Error(), "must be 8, 16, or 24 bits") {
 		t.Fatalf("err = %v; want bit-width hint", err)
 	}
 }

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -702,8 +702,10 @@ const (
 	SelectKeyField SelectKeyKind = iota
 	// SelectKeyLookahead peeks at bytes the parser has not yet
 	// consumed. The byte offset is non-negative w.r.t. the current
-	// R4 and R4 is unchanged. MVP supports only `bit<8>`
-	// lookaheads (single-byte LDX in codegen).
+	// R4 and R4 is unchanged. Codegen supports byte-multiple widths
+	// up to 24 bits (e.g. a Geneve option class+type discriminator);
+	// the value is loaded as the next power-of-two LDX, byte-swapped,
+	// and shifted/masked to the key width.
 	SelectKeyLookahead
 	// SelectKeyCounterIsZero reads a ParserCounter slot and dispatches
 	// on whether it has reached zero. The matching MatchVal slots are
@@ -720,7 +722,7 @@ type SelectKey struct {
 	// SelectKeyField only.
 	Field FieldRef
 	// SelectKeyLookahead only.
-	Bits int // peek width (MVP cap = 8)
+	Bits int // peek width; byte-multiple, 8/16/24
 	// SelectKeyCounterIsZero only — counter instance name.
 	Counter string
 	Pos     p4lite.Position

--- a/pkg/kunai/vocab/parser_machine.go
+++ b/pkg/kunai/vocab/parser_machine.go
@@ -1090,11 +1090,13 @@ func buildSelect(sel *p4lite.Select, ctx *buildCtx) (*SelectOp, error) {
 			}
 			keys[i] = SelectKey{Kind: SelectKeyField, Field: ref, Pos: k.Pos}
 		case p4lite.SelectKeyLookahead:
-			// Codegen only knows how to single-byte LDX a lookahead
-			// key. Wider widths (multi-byte peeks, sub-byte slicing)
-			// would need a different load shape.
-			if k.Bits != 8 {
-				return nil, fmt.Errorf("%s:%s: `pkt.lookahead<bit<%d>>()` select keys must be exactly 8 bits; for wider peeks, slice the value inside a pkt.advance arg or extract a header first", ctx.source, k.Pos, k.Bits)
+			// Codegen loads a lookahead key as the next power-of-two
+			// LDX, byte-swaps, and shifts/masks to the key width. It
+			// supports byte-multiple widths up to 24 bits (e.g. a
+			// Geneve option class+type discriminator); a 24-bit value
+			// still fits a JNE.Imm case compare.
+			if !allowedLookaheadBits(k.Bits) {
+				return nil, fmt.Errorf("%s:%s: `pkt.lookahead<bit<%d>>()` select keys must be 8, 16, or 24 bits; for other widths, slice the value inside a pkt.advance arg or extract a header first", ctx.source, k.Pos, k.Bits)
 			}
 			keys[i] = SelectKey{Kind: SelectKeyLookahead, Bits: k.Bits, Pos: k.Pos}
 		case p4lite.SelectKeyCounterIsZero:
@@ -1253,24 +1255,32 @@ func IsMultiStateLoopEntry(states []*ParseState, idx int) bool {
 	return true
 }
 
+// allowedLookaheadBits reports whether a lookahead select-key width is
+// one codegen can lower: byte-multiple up to 24 bits (8 = TLV kind
+// byte, 24 = Geneve option class+type). The value is loaded as the
+// next power-of-two LDX, byte-swapped, then shifted/masked.
+func allowedLookaheadBits(bits int) bool {
+	return bits == 8 || bits == 16 || bits == 24
+}
+
 // isMultiStateLoopKeyShape pins the legal key tuples for a multi-state
-// loop entry: one of {Lookahead8}, {CounterIsZero},
-// or {CounterIsZero, Lookahead8} in that order. Foreign shapes
-// (lookahead width != 8, reversed tuple, more than 2 keys) reject so
-// the multi-state codegen invariants stay narrow.
+// loop entry: one of {Lookahead}, {CounterIsZero},
+// or {CounterIsZero, Lookahead} in that order. Foreign shapes
+// (unsupported lookahead width, reversed tuple, more than 2 keys)
+// reject so the multi-state codegen invariants stay narrow.
 func isMultiStateLoopKeyShape(sel *SelectOp) bool {
 	switch len(sel.Keys) {
 	case 1:
 		switch sel.Keys[0].Kind {
 		case SelectKeyLookahead:
-			return sel.Keys[0].Bits == 8
+			return allowedLookaheadBits(sel.Keys[0].Bits)
 		case SelectKeyCounterIsZero:
 			return true
 		}
 	case 2:
 		return sel.Keys[0].Kind == SelectKeyCounterIsZero &&
 			sel.Keys[1].Kind == SelectKeyLookahead &&
-			sel.Keys[1].Bits == 8
+			allowedLookaheadBits(sel.Keys[1].Bits)
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Two additions that extend kunai's filtering reach, sharing one new mechanism (N-bit lookahead dispatch).

### 1. Geneve option-TLV filtering (OVN + AWS GWLB)
Generalize the parser's lookahead select-key dispatch from a single kind byte to **byte-multiple widths (8/16/24 bit)**, then use the 24-bit form to walk Geneve option TLVs by their `option_class + type` discriminator. A filter can now read:

- `geneve.options.OVN.egress_port` — OVN logical egress port (IANA class `0x0102`, type `0x80`; OpenStack Neutron / OVN-Kubernetes)
- `geneve.options.GWLB.flow_cookie` — AWS Gateway Load Balancer flow cookie (class `0x0108`, type `3`)

The walk mirrors `ipv4.p4`'s IHL-driven options walk (`ParserCounter` + multi-state loop). A chain that does **not** read `geneve.options.<X>` keeps the demand-driven bulk-advance fallback (no `bpf_loop`), so the existing Geneve inner-chaining (`eth/.../geneve/eth/ipv4@inner/...`, F9) is unchanged.

### 2. Optional VLAN/QinQ at the tc host
Relax the tc-host VLAN guard: an **optional, predicate-free** vlan/qinq tag is matchable at tc — the kernel moves the outer tag into skb metadata (`skb_vlan_untag` before `sch_handle_ingress`), so the byte parser takes the layer's skip path. `eth/vlan?/...` and `eth/qinq?/vlan?/...` now match untagged / single-tag / QinQ traffic at tc. Mandatory tags and tag-field reads stay rejected (reading the tag value from skb metadata is future work).

## Implementation notes
- Width handling is unified: `resolveSelectKey` + `selectKeyShape.normalize()` are shared by the dispatch, the slot prelude, and the stash path, so all read the kind identically (load `loadSize` → byte-swap → shift → mask). 8-bit emits zero extra instructions; 24-bit needs no mask (the shift zero-extends).
- The N-bit width allow-set lives once in `vocab` (`allowedLookaheadBits` = 8/16/24); `asmSizeFor` backstops anything wider.
- `GENEVE_MAX_DEPTH = 4` keeps the option-walk `bpf_loop` callback inside the verifier budget.
- The 64-bit GWLBE endpoint id (type 1) is modeled but not yet filterable — a 64-bit option-field read / 64-bit immediate compare is future work; the 32-bit flow cookie is the filterable demo.

## Validation
- Verified across the **6-kernel matrix (Linux 6.1, 6.6, 6.12, 6.15, 6.18, 7.0)** at both XDP and tc hosts via vimto: load acceptance plus packet match/reject.
- New tests: `geneve_options_test.go` (OVN/GWLB match + multi-option walk), `vlan_tc_support_test.go` + `vlan_untag_datapath_test.go` (real veth datapath confirms the untag premise), `parser_select_width_test.go`, `vlan_tagflex_test.go`. Corpus G03/G04 pin verifier load at XDP+tc.
- F9 instruction-count pin updated 323 → 351 (geneve now routes through the counter-driven bulk-advance fallback).