### PR TITLE
feat(codegen): lower any()/all() aux-list walks to bpf_loop

### DIFF
--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -64,7 +64,7 @@ var FilterSet = []FilterSpec{
 	{ID: "F7", Expr: "eth/ipv4@outer/udp/gtp/ipv4@inner/tcp where inner.dst == 10.0.0.1",
 		WantInsns: 405, Notes: "GTP-U inner IPv4 dst (5G core)"},
 	{ID: "F8", Expr: "eth/ipv6/srv6 where any(srv6.segments.addr == fc00::1)",
-		WantInsns: 450, Notes: "SRv6 segment-list any-quantifier (5G/SDN)"},
+		WantInsns: 316, Notes: "SRv6 segment-list any-quantifier (5G/SDN); bpf_loop callback (flat in capacity)"},
 	{ID: "F9", Expr: "eth/ipv4@outer/udp/geneve/eth/ipv4@inner/tcp where inner.dst == 10.0.0.1",
 		WantInsns: 351, Notes: "Geneve inner IPv4 dst (Cilium overlay / cloud VPC); inner offset resolved past the opt_len*4 options section via the counter-driven bulk-advance fallback"},
 	{ID: "F10", Expr: "eth/ipv4/tcp where tcp.options.MSS.value == 1460",

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -352,11 +352,12 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	// layer-level mismatch. `where` may include conditions merged in
 	// from per-capture clauses (see computeCapture).
 	if where != nil {
-		whereInsns, err := genCondition(where, caps.Lang, p, qo, dslReject)
+		whereInsns, whereCbs, err := genCondition(where, caps.Lang, p, qo, dslReject)
 		if err != nil {
 			return Output{}, err
 		}
 		insns = append(insns, whereInsns...)
+		callbacks = append(callbacks, whereCbs...)
 	}
 
 	// Accept path: R2=1 and jump over the reject block.
@@ -1613,6 +1614,59 @@ func emitDynamicStackAddress(ref *ir.FieldRef, base layerAnchor, failLabel strin
 		asm.Add.Reg(asm.R5, asm.R3),
 	)
 	return insns, nil
+}
+
+// emitRuntimeAuxElementAddr loads `size` bytes of an aux-stack element
+// field at the bpf_loop runtime index, for use INSIDE an aux-walk
+// callback (genAuxWalkCallback). It mirrors the element-address
+// arithmetic of emitDynamicStackAddress but takes the index from R1
+// (the bpf_loop iteration variable) rather than a primary-header field,
+// and addresses against the callback frame: R2 = &ctx, R4 = scratchStart,
+// R5 = scratchEnd. The element's byte offset from scratch start is
+//
+//	scalar = ctx.layerEntry + OffsetInLayer + R1*ElemSize + fieldByteOff
+//
+// computed in R3, then boundedScalarLoad reads `size` bytes into R0. On
+// return R0 holds the loaded value; R3 is clobbered; R1/R2/R4/R5 are
+// preserved — note this deliberately avoids R2 (= &ctx in the callback)
+// as scratch, unlike ipv6AuxHalfCheck which uses it. The defensive
+// JGE R1,Capacity keeps R1.umax tight for the verifier even though
+// bpf_loop already bounds the index by max_iter.
+func emitRuntimeAuxElementAddr(target *ir.QuantTarget, fieldByteOff int, size asm.Size, failLabel string) asm.Instructions {
+	insns := asm.Instructions{
+		asm.LoadMem(asm.R0, asm.R2, bpfLoopCbCtxLayerEntryField, asm.DWord),
+		asm.Add.Imm(asm.R0, int32(target.OffsetInLayer+fieldByteOff)),
+		asm.Mov.Reg(asm.R3, asm.R1),
+		asm.JGE.Imm(asm.R3, int32(target.Capacity), failLabel),
+		asm.Mul.Imm(asm.R3, int32(target.ElemSize)),
+		asm.Add.Reg(asm.R3, asm.R0),
+	}
+	// boundedScalarLoad writes dst=R0 and reads scalar=R3 (distinct regs).
+	return append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R3, asm.R5, size, failLabel)...)
+}
+
+// emitRuntimeAuxElementAddrOwner is the owner-option counterpart of
+// emitRuntimeAuxElementAddr: it addresses an aux element inside a TCP/IPv4
+// option (TCP SACK, IPv4 record-route) whose base the parser stashed as a
+// scalar in main-frame slot `ownerSlot`. The element byte offset from
+// scratch start is
+//
+//	scalar = optionBase + offsetAfterOwner + R1*ElemSize + fieldByteOff
+//
+// optionBase is read via the ctx pointer (R2 + mainStackOffsetFromCb),
+// and an absent option (sentinel) jumps to failLabel. Register contract
+// matches the primary helper: loads into R0; R3 scratch; R2/R4/R5 kept.
+func emitRuntimeAuxElementAddrOwner(ownerSlot int16, target *ir.QuantTarget, offsetAfterOwner, fieldByteOff int, size asm.Size, failLabel string) asm.Instructions {
+	insns := asm.Instructions{
+		asm.LoadMem(asm.R0, asm.R2, mainStackOffsetFromCb(ownerSlot), asm.DWord),
+		asm.JEq.Imm(asm.R0, dynamicAuxSentinel, failLabel),
+		asm.Add.Imm(asm.R0, int32(offsetAfterOwner+fieldByteOff)),
+		asm.Mov.Reg(asm.R3, asm.R1),
+		asm.JGE.Imm(asm.R3, int32(target.Capacity), failLabel),
+		asm.Mul.Imm(asm.R3, int32(target.ElemSize)),
+		asm.Add.Reg(asm.R3, asm.R0),
+	}
+	return append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R3, asm.R5, size, failLabel)...)
 }
 
 // auxLoadAt loads `size` bytes from the addressed aux element at

--- a/pkg/kunai/codegen/where.go
+++ b/pkg/kunai/codegen/where.go
@@ -27,6 +27,12 @@ type whereCtx struct {
 	// uses it to pick a distinct LHS-save slot per level so a nested
 	// bool-eq operand does not clobber an enclosing one.
 	boolEqDepth int
+	// callbacks accumulates bpf_loop callback subprograms emitted while
+	// generating the where clause (currently the aux-walk any()/all()
+	// loop). They are returned out of genCondition and appended to
+	// Output.Callbacks after the main program's return, alongside the
+	// per-layer chain callbacks.
+	callbacks asm.Instructions
 }
 
 func (c *whereCtx) freshLabel(prefix string) string {
@@ -73,10 +79,10 @@ func (c *whereCtx) layerAnchorFor(l *ir.LayerInstance) (layerAnchor, error) {
 // to true and jump to failLabel when it evaluates to false. Errors
 // surface with the condition's source position prefixed so users see
 // which `where` atom blew up.
-func genCondition(w *ir.Condition, lang LangCaps, p *ir.Program, qo queriedOptions, failLabel string) (asm.Instructions, error) {
+func genCondition(w *ir.Condition, lang LangCaps, p *ir.Program, qo queriedOptions, failLabel string) (asm.Instructions, asm.Instructions, error) {
 	ctx := &whereCtx{p: p, lang: lang, anchors: make(map[*ir.LayerInstance]layerAnchor), queried: qo}
 	insns, err := ctx.gen(w, failLabel)
-	return insns, withPos(err, w.Pos)
+	return insns, ctx.callbacks, withPos(err, w.Pos)
 }
 
 func (c *whereCtx) gen(w *ir.Condition, failLabel string) (asm.Instructions, error) {
@@ -250,6 +256,11 @@ func (c *whereCtx) genAny(w *ir.Condition, failLabel string) (asm.Instructions, 
 	if w.QuantTarget == nil {
 		return nil, fmt.Errorf("codegen: any() lacks a resolved iteration target")
 	}
+	if use, err := useBpfLoopAuxWalk(w); err != nil {
+		return nil, err
+	} else if use {
+		return c.genQuantBpfLoop(w, failLabel, true)
+	}
 	matchLabel := c.freshLabel("any_match")
 	insns, err := c.genQuantUnroll(w, matchLabel, failLabel, true)
 	if err != nil {
@@ -268,6 +279,11 @@ func (c *whereCtx) genAny(w *ir.Condition, failLabel string) (asm.Instructions, 
 func (c *whereCtx) genAll(w *ir.Condition, failLabel string) (asm.Instructions, error) {
 	if w.QuantTarget == nil {
 		return nil, fmt.Errorf("codegen: all() lacks a resolved iteration target")
+	}
+	if use, err := useBpfLoopAuxWalk(w); err != nil {
+		return nil, err
+	} else if use {
+		return c.genQuantBpfLoop(w, failLabel, false)
 	}
 	insns, err := c.genQuantUnroll(w, "" /* no per-iter accept */, failLabel, false)
 	if err != nil {

--- a/pkg/kunai/codegen/where_auxloop.go
+++ b/pkg/kunai/codegen/where_auxloop.go
@@ -1,0 +1,393 @@
+package codegen
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+
+	"github.com/takehaya/xdp-ninja/pkg/kunai/ast"
+	"github.com/takehaya/xdp-ninja/pkg/kunai/ir"
+)
+
+// staticAuxCap is the largest declared stack capacity for which an
+// any()/all() walk stays on the static unroll (genQuantUnroll). Above
+// it the walk lowers to a bpf_loop callback whose instruction count is
+// flat in the capacity, mirroring staticChainCap for chain quantifiers.
+// Kept small: a 1-2 element list is cheaper unrolled than paying the
+// bpf_loop ctx setup + a separate bpf2bpf subprogram.
+const staticAuxCap = 2
+
+// useBpfLoopAuxWalk reports whether the quantifier should lower to a
+// bpf_loop callback instead of the static unroll. The decision is by
+// SHAPE, not protocol name: it accepts any aux-list walk whose inner is
+// a single `<iterator-field> == <network-literal>` and that has a
+// runtime element count (primary-header @kunai_stack_count OR an
+// option-internal length). Field width (IPv4/IPv6/MAC) and count source
+// (primary/owner) are both handled by the callback, so any future P4
+// protocol declaring a large counted list gets the flat lowering for
+// free. Richer inner conditions (or/not, !=, ordered, integer arith)
+// and count-less stacks (gtp.exts/ipv6.exts) stay on the unroll path,
+// which already supports them, so no shape regresses to a hard error.
+func useBpfLoopAuxWalk(w *ir.Condition) (bool, error) {
+	t := w.QuantTarget
+	if t == nil || t.Capacity <= staticAuxCap {
+		return false, nil
+	}
+	in := w.Inner
+	if in == nil || in.Kind != ast.WAtomLiteralCmp || in.LiteralOp != ast.CmpEq {
+		return false, nil
+	}
+	ref := in.LiteralField
+	if ref == nil || ref.Aux == nil || ref.Aux.Stack == nil || !ref.Aux.Stack.IsIterator {
+		return false, nil
+	}
+	if _, ok := auxWalkLiteralWidth(in.LiteralValue); !ok {
+		return false, nil
+	}
+	cs, err := stackCountSource(w)
+	if err != nil {
+		return false, err
+	}
+	return cs != nil, nil
+}
+
+// auxWalkLiteralWidth reports the comparison's field byte width for the
+// literal kinds the callback compare supports, and false otherwise. It
+// is the gate's single source of truth for "supported shape" and must
+// stay in sync with the switch in auxWalkCompare (whose default returns
+// ErrNotImplemented as a backstop if the two ever diverge).
+func auxWalkLiteralWidth(v *ast.Value) (int, bool) {
+	switch v.Kind {
+	case ast.ValIPv4:
+		return 4, true
+	case ast.ValIPv6:
+		return 16, true
+	case ast.ValMAC:
+		return 6, true
+	case ast.ValCIDR:
+		if v.AF == 4 {
+			return 4, true
+		}
+		return 16, true
+	}
+	return 0, false
+}
+
+// genQuantBpfLoop lowers an any()/all() walk over an aux header stack to
+// a bpf_loop callback (instead of unrolling Capacity copies). The flat
+// instruction count and cap-32 ceiling match how chain quantifiers are
+// handled, removing the SRv6-capped-at-8 vs MPLS-scales-to-32 asymmetry.
+//
+// Flag plumbing reuses the bpf_loop ctx `offset` slot: an aux-walk has
+// no running byte offset (it indexes by R1*ElemSize), so the slot is
+// free to carry the result flag — any()'s "matched", all()'s "failed".
+// The main program zero-inits it, the callback writes 1 on the decisive
+// element, and the main program reads it after the loop.
+//
+// Two addressing modes are supported. A primary-counted stack (SRv6
+// segments) is addressed relative to the owning layer's start, stored
+// into ctx.layerEntry. An owner-option stack (TCP SACK, IPv4
+// record-route) is addressed relative to the option base the parser
+// stashed in a dynamic-aux slot, which the callback reads via the ctx
+// pointer.
+func (c *whereCtx) genQuantBpfLoop(w *ir.Condition, failLabel string, anySemantics bool) (asm.Instructions, error) {
+	target := w.QuantTarget
+	countSrc, err := stackCountSource(w)
+	if err != nil {
+		return nil, err
+	}
+	if countSrc == nil {
+		return nil, fmt.Errorf("%w: bpf_loop aux walk needs a runtime count source", ErrNotImplemented)
+	}
+	if target.Capacity > bpfLoopChainCap {
+		return nil, fmt.Errorf("%w: aux walk capacity %d exceeds verifier-safe cap %d", ErrNotImplemented, target.Capacity, bpfLoopChainCap)
+	}
+
+	var ownerSlot int16
+	if countSrc.Owner != nil {
+		slot, ok := c.queried.dynamicAuxSlotForLayout(countSrc.Layer, countSrc.Owner)
+		if !ok {
+			return nil, fmt.Errorf("codegen: aux walk owner option %q not in demand set for layer %q", countSrc.Owner.OutParam, countSrc.Layer.Spec.Name)
+		}
+		ownerSlot = slot
+	}
+	anchor, err := c.layerAnchorFor(target.Layer)
+	if err != nil {
+		return nil, err
+	}
+
+	cbSym := c.freshLabel("auxwalk_cb")
+	cb, err := c.genAuxWalkCallback(w, countSrc, ownerSlot, cbSym, anySemantics)
+	if err != nil {
+		return nil, err
+	}
+	c.callbacks = append(c.callbacks, cb...)
+
+	// Seed ctx: scratchStart (R0) / scratchEnd (R1) / layerEntry, and
+	// zero the flag (reused offset slot). Then bpf_loop(max_iter=Capacity,
+	// &cb, &ctx, 0). R0..R5 are caller-saved across the helper.
+	main := asm.Instructions{
+		asm.StoreMem(asm.R10, bpfLoopCtxScratchStartSlot, asm.R0, asm.DWord),
+		asm.StoreMem(asm.R10, bpfLoopCtxScratchEndSlot, asm.R1, asm.DWord),
+	}
+	main = append(main, emitLayerEntryToReg(anchor, asm.R3)...)
+	main = append(main,
+		asm.StoreMem(asm.R10, bpfLoopCtxLayerEntrySlot, asm.R3, asm.DWord),
+		asm.Mov.Imm(asm.R3, 0),
+		asm.StoreMem(asm.R10, bpfLoopCtxOffsetSlot, asm.R3, asm.DWord), // flag = 0
+		asm.Mov.Imm(asm.R1, int32(target.Capacity)),
+		loadFunctionRef(asm.R2, cbSym),
+		asm.Mov.Reg(asm.R3, asm.R10),
+		asm.Add.Imm(asm.R3, bpfLoopCtxBaseOffset),
+		asm.Mov.Imm(asm.R4, 0),
+		asm.FnLoop.Call(),
+	)
+	// Restore the scratch-window pointers the helper dropped, then read
+	// the flag and branch. offsetBase is not restored: the where clause
+	// addresses fields via scratchStart (R0) + a static/slot offset, not
+	// via the running offsetBase, so the aux walk does not need it back.
+	main = append(main,
+		asm.LoadMem(asm.R0, asm.R10, bpfLoopCtxScratchStartSlot, asm.DWord),
+		asm.LoadMem(asm.R1, asm.R10, bpfLoopCtxScratchEndSlot, asm.DWord),
+		asm.LoadMem(asm.R3, asm.R10, bpfLoopCtxOffsetSlot, asm.DWord),
+	)
+	if anySemantics {
+		main = append(main, asm.JEq.Imm(asm.R3, 0, failLabel)) // no element matched → reject
+	} else {
+		main = append(main, asm.JNE.Imm(asm.R3, 0, failLabel)) // an element failed → reject
+	}
+	return main, nil
+}
+
+// emitLayerEntryToReg materialises the owning layer's scalar start
+// offset (bytes from scratch start) into dst, for storing into the
+// bpf_loop ctx so the callback can address elements relative to it.
+func emitLayerEntryToReg(anchor layerAnchor, dst asm.Register) asm.Instructions {
+	switch {
+	case anchor.UseR4:
+		return asm.Instructions{asm.Mov.Reg(dst, offsetBase)}
+	case anchor.UseSlot:
+		return asm.Instructions{asm.LoadMem(dst, asm.R10, anchor.SlotOff, asm.DWord)}
+	default:
+		return asm.Instructions{asm.Mov.Imm(dst, int32(anchor.AbsOffset))}
+	}
+}
+
+// genAuxWalkCallback builds the bpf2bpf subprogram bpf_loop calls per
+// element. Frame: R1 = element index, R2 = &ctx, R4 = scratchStart,
+// R5 = scratchEnd (loaded up front); R0/R3 are scratch. Per iteration:
+// stop at the runtime element count, compare the element field to the
+// literal, and on the decisive element write the ctx flag and break.
+func (c *whereCtx) genAuxWalkCallback(w *ir.Condition, countSrc *quantCountSource, ownerSlot int16, cbSym string, anySemantics bool) (asm.Instructions, error) {
+	target := w.QuantTarget
+	inner := w.Inner
+	ref := inner.LiteralField // pre-checked by useBpfLoopAuxWalk
+	if ref.Aux.FieldBitOff%8 != 0 {
+		return nil, fmt.Errorf("%w: aux walk field %s not byte-aligned", ErrNotImplemented, ref.Field.Name)
+	}
+	fieldByteOff := ref.Aux.FieldBitOff / 8
+
+	breakLabel := cbSym + "_break"
+	mismatchLabel := cbSym + "_mismatch"
+
+	// load addresses the iterator element field at the runtime index R1.
+	// Primary stacks use the layer-entry anchor; owner-option stacks use
+	// the option base stashed in a dynamic-aux slot (read via ctx).
+	var load elemLoader
+	if countSrc.Owner != nil {
+		load = func(off int, size asm.Size, fail string) asm.Instructions {
+			return emitRuntimeAuxElementAddrOwner(ownerSlot, target, ref.Aux.OffsetAfterOwner, fieldByteOff+off, size, fail)
+		}
+	} else {
+		load = func(off int, size asm.Size, fail string) asm.Instructions {
+			return emitRuntimeAuxElementAddr(target, fieldByteOff+off, size, fail)
+		}
+	}
+
+	first := asm.LoadMem(asm.R4, asm.R2, bpfLoopCbCtxScratchStartField, asm.DWord).WithSymbol(cbSym)
+	first = btf.WithFuncMetadata(first, chainCallbackFunc(cbSym))
+	insns := asm.Instructions{
+		first,
+		asm.LoadMem(asm.R5, asm.R2, bpfLoopCbCtxScratchEndField, asm.DWord),
+	}
+	guard, err := auxWalkCountGuard(countSrc, ownerSlot, breakLabel)
+	if err != nil {
+		return nil, err
+	}
+	insns = append(insns, guard...)
+	cmp, err := auxWalkCompare(load, inner.LiteralValue, mismatchLabel)
+	if err != nil {
+		return nil, err
+	}
+	insns = append(insns, cmp...)
+
+	// Fall-through == this element matched. The flag (ctx.offset slot)
+	// and the bpf_loop return value invert between the two semantics:
+	//   any(): match → flag=1, return 1 (break); miss → return 0
+	//          (continue); exhaust → return 1. Flag stays 0 with no
+	//          match, which the main program reads as "reject".
+	//   all(): match → return 0 (continue); miss → flag=1, return 1
+	//          (break, reject); exhaust → return 1. Flag 0 == "accept".
+	if anySemantics {
+		insns = append(insns,
+			asm.Mov.Imm(asm.R0, 1),
+			asm.StoreMem(asm.R2, bpfLoopCbCtxOffsetField, asm.R0, asm.DWord), // flag = matched
+			asm.Mov.Imm(asm.R0, 1),
+			asm.Return(), // break: a match is enough
+			asm.Mov.Imm(asm.R0, 0).WithSymbol(mismatchLabel),
+			asm.Return(), // continue to next element
+			asm.Mov.Imm(asm.R0, 1).WithSymbol(breakLabel),
+			asm.Return(), // exhausted: stop, flag reflects prior matches
+		)
+	} else {
+		insns = append(insns,
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(), // continue: this element satisfies all()
+			asm.Mov.Imm(asm.R0, 1).WithSymbol(mismatchLabel),
+			asm.StoreMem(asm.R2, bpfLoopCbCtxOffsetField, asm.R0, asm.DWord), // flag = failed
+			asm.Mov.Imm(asm.R0, 1),
+			asm.Return(), // break: one failure rejects all()
+			asm.Mov.Imm(asm.R0, 1).WithSymbol(breakLabel),
+			asm.Return(), // exhausted: every real element matched
+		)
+	}
+	if err := assertCallbackComplexity(insns, cbSym); err != nil {
+		return nil, err
+	}
+	return insns, nil
+}
+
+// elemLoader loads `size` bytes of the iterator element field at
+// `fieldByteOff` past the field start, for the bpf_loop index, into R0.
+// It preserves R2 (=&ctx), R4 (scratchStart), R5 (scratchEnd) and uses
+// R3 as scratch; an out-of-window read jumps to the supplied label.
+type elemLoader func(fieldByteOff int, size asm.Size, fail string) asm.Instructions
+
+// auxWalkCountGuard emits the per-iteration check that the element index
+// (R1) is below the stack's runtime element count, breaking the loop
+// when it is not. Primary stacks read the count from a layer field;
+// owner-option stacks derive it from the option length byte.
+func auxWalkCountGuard(countSrc *quantCountSource, ownerSlot int16, breakLabel string) (asm.Instructions, error) {
+	if countSrc.Owner != nil {
+		// count = (optionLength - SubBefore) >> RShAfter; optionLength is
+		// the byte at optionBase + ByteOff. optionBase scalar lives in the
+		// dynamic-aux slot the parser stashed, read via the ctx pointer.
+		insns := asm.Instructions{
+			asm.LoadMem(asm.R0, asm.R2, mainStackOffsetFromCb(ownerSlot), asm.DWord),
+			asm.JEq.Imm(asm.R0, dynamicAuxSentinel, breakLabel),
+			asm.Add.Imm(asm.R0, int32(countSrc.ByteOff)),
+			asm.Mov.Reg(asm.R3, asm.R0),
+		}
+		insns = append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R3, asm.R5, asm.Byte, breakLabel)...)
+		insns = append(insns,
+			asm.JLT.Imm(asm.R0, int32(countSrc.SubBefore), breakLabel),
+			asm.Sub.Imm(asm.R0, int32(countSrc.SubBefore)),
+			asm.RSh.Imm(asm.R0, int32(countSrc.RShAfter)),
+			asm.JGE.Reg(asm.R1, asm.R0, breakLabel),
+		)
+		return insns, nil
+	}
+	// Primary: count = layer[ByteOff] + addend.
+	insns := asm.Instructions{
+		asm.LoadMem(asm.R0, asm.R2, bpfLoopCbCtxLayerEntryField, asm.DWord),
+		asm.Add.Imm(asm.R0, int32(countSrc.ByteOff)),
+		asm.Mov.Reg(asm.R3, asm.R0),
+	}
+	insns = append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R3, asm.R5, asm.Byte, breakLabel)...)
+	insns = append(insns,
+		asm.Add.Imm(asm.R0, int32(countSrc.Offset)),
+		asm.JGE.Reg(asm.R1, asm.R0, breakLabel),
+	)
+	return insns, nil
+}
+
+// auxWalkCompare emits the element-vs-literal comparison inside the
+// callback, dispatching on the literal kind/width. Fall-through means
+// the element matched; any mismatch (or out-of-window load) jumps to
+// mismatchLabel. Mirrors the main-frame compares but loads via the
+// supplied elemLoader and keeps the comparison in R0/R3 so the callback
+// frame's R2/R4/R5 survive.
+func auxWalkCompare(load elemLoader, v *ast.Value, mismatchLabel string) (asm.Instructions, error) {
+	switch v.Kind {
+	case ast.ValIPv4:
+		host := uint32(byteSwap(uint64(binary.BigEndian.Uint32(v.V4[:])), 4))
+		return auxWalkWord(load, 0, ^uint32(0), host, mismatchLabel), nil
+	case ast.ValMAC:
+		highLE := uint32(byteSwap(uint64(binary.BigEndian.Uint32(v.MAC[0:4])), 4))
+		lowLE := uint16(byteSwap(uint64(binary.BigEndian.Uint16(v.MAC[4:6])), 2))
+		insns := auxWalkWord(load, 0, ^uint32(0), highLE, mismatchLabel)
+		return append(insns, auxWalkHalfWord(load, 4, lowLE, mismatchLabel)...), nil
+	case ast.ValIPv6:
+		hi := binary.BigEndian.Uint64(v.V6[0:8])
+		lo := binary.BigEndian.Uint64(v.V6[8:16])
+		insns := auxWalkHalf(load, 0, ^uint64(0), hi, mismatchLabel)
+		return append(insns, auxWalkHalf(load, 8, ^uint64(0), lo, mismatchLabel)...), nil
+	case ast.ValCIDR:
+		if v.AF == 4 {
+			if v.Prefix < 0 || v.Prefix > 32 {
+				return nil, fmt.Errorf("codegen: IPv4 CIDR prefix %d out of [0,32]", v.Prefix)
+			}
+			if v.Prefix == 0 {
+				return nil, nil // /0 matches every element
+			}
+			maskBE := ipv4PrefixMaskBE(v.Prefix)
+			host := uint32(byteSwap(uint64(binary.BigEndian.Uint32(v.V4[:])&maskBE), 4))
+			mask := uint32(byteSwap(uint64(maskBE), 4))
+			return auxWalkWord(load, 0, mask, host, mismatchLabel), nil
+		}
+		if v.Prefix < 0 || v.Prefix > 128 {
+			return nil, fmt.Errorf("codegen: IPv6 CIDR prefix %d out of [0,128]", v.Prefix)
+		}
+		mh, ml := ipv6PrefixMaskBE(v.Prefix)
+		var insns asm.Instructions
+		if mh != 0 {
+			insns = append(insns, auxWalkHalf(load, 0, mh, binary.BigEndian.Uint64(v.V6[0:8])&mh, mismatchLabel)...)
+		}
+		if ml != 0 {
+			insns = append(insns, auxWalkHalf(load, 8, ml, binary.BigEndian.Uint64(v.V6[8:16])&ml, mismatchLabel)...)
+		}
+		return insns, nil
+	}
+	return nil, fmt.Errorf("%w: aux walk literal kind %v not supported", ErrNotImplemented, v.Kind)
+}
+
+// auxWalkHalf compares one 8-byte half (DWord) of the element field,
+// optionally masked, to the literal half. R0 = value, R3 = scratch.
+func auxWalkHalf(load elemLoader, off int, mask, host uint64, mismatchLabel string) asm.Instructions {
+	insns := load(off, asm.DWord, mismatchLabel)
+	if mask != ^uint64(0) {
+		insns = append(insns,
+			asm.LoadImm(asm.R3, int64(byteSwap(mask, 8)), asm.DWord),
+			asm.And.Reg(asm.R0, asm.R3),
+		)
+	}
+	insns = append(insns,
+		asm.LoadImm(asm.R3, int64(byteSwap(host, 8)), asm.DWord),
+		asm.JNE.Reg(asm.R0, asm.R3, mismatchLabel),
+	)
+	return insns
+}
+
+// auxWalkWord compares one 4-byte (Word) chunk, optionally masked. The
+// host value is already host-order (little-endian of the wire bytes).
+func auxWalkWord(load elemLoader, off int, mask, host uint32, mismatchLabel string) asm.Instructions {
+	insns := load(off, asm.Word, mismatchLabel)
+	if mask != ^uint32(0) {
+		insns = append(insns, asm.And.Imm(asm.R0, int32(mask)))
+	}
+	return append(insns,
+		asm.LoadImm(asm.R3, int64(uint64(host)), asm.DWord),
+		asm.JNE.Reg(asm.R0, asm.R3, mismatchLabel),
+	)
+}
+
+// auxWalkHalfWord compares one 2-byte (Half) chunk to a host-order value.
+func auxWalkHalfWord(load elemLoader, off int, host uint16, mismatchLabel string) asm.Instructions {
+	insns := load(off, asm.Half, mismatchLabel)
+	return append(insns,
+		asm.LoadImm(asm.R3, int64(uint64(host)), asm.DWord),
+		asm.JNE.Reg(asm.R0, asm.R3, mismatchLabel),
+	)
+}


### PR DESCRIPTION
## What

Lowers aux-list quantifier walks — `any()`/`all()` over a header stack such as SRv6 segments — to a `bpf_loop` callback instead of a fixed unroll, giving a **flat instruction count** and the same **cap-32** ceiling that chain quantifiers already get.

## Why

Aux-walks unrolled up to the `.p4` array capacity, so the instruction count grew with the capacity and SRv6 was effectively **capped at 8** while chain quantifiers (`mpls+`) scaled to 32 via `bpf_loop`. This asymmetry meant a long SRv6 segment list either truncated or bloated the bytecode.

## Approach

A walk above a small threshold (`staticAuxCap`) lowers to a `bpf_loop` callback, **uniformly with chain quantifiers**. Routing is **by shape, not protocol**: any aux-walk whose inner is a single `<iterator> == <network-literal>` with a runtime element count takes the callback.

- **Field width** (IPv4 / IPv6 / MAC, `==` / CIDR) and **count source** (primary-header `@kunai_stack_count` or option-internal length) are both handled, so a **new P4 protocol declaring a large counted list gets the lowering without a compiler change**.
- Richer inner conditions (`or`/`not`/`!=`/ordered/integer arith) and count-less stacks stay on the unroll path, unchanged — no shape regresses to a hard error.
- The callback reuses the `bpf_loop` ctx `offset` slot for the result flag (an aux walk has no running offset), so **no new stack slot** is needed.

## Validation

- Verifier-accepted across **six kernels (6.1–7.0) × XDP/tc** (vimto matrix).
- Packet-correct for **SRv6 segments** (primary count, 128-bit) and **IPv4 record-route** (owner-option count, 32-bit) via `BPF_PROG_TEST_RUN`.
- No regression: chain quantifiers, SACK, and all other shapes unchanged; full no-root suite + golangci-lint green.
- `F8` raw insns: **450 → 316** (flat in capacity).

## Note

Stacked on `feat/geneve-option-filters-pr` (this work builds on that branch's codegen). Re-target to `main` once the base merges. Paper/figure updates are intentionally **not** in this PR (code only).