### PR TITLE
test(program): differential correctness + verifier-load envelope coverage

### DIFF
--- a/internal/program/envelope_load_test.go
+++ b/internal/program/envelope_load_test.go
@@ -27,8 +27,9 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-// envelopeExprs returns the structural-extreme expressions, labelled to
-// line up with the two axes of TestM2Envelope / fig_envelope.tex.
+// envelopeExprs returns the structural-extreme expressions, labelled by the
+// three lowering-path axes (A: chain quantifier, B: SRv6 aux-walk stack,
+// C: counter-driven Geneve option walk) exercised below.
 func envelopeExprs() []struct{ id, expr string } {
 	out := []struct{ id, expr string }{
 		// Axis A — chain quantifier past the static-unroll cap (4), in the

--- a/internal/program/envelope_load_test.go
+++ b/internal/program/envelope_load_test.go
@@ -1,0 +1,86 @@
+package program
+
+// Verifier-load coverage for the structural extremes of the generator's
+// bpf_loop-bearing lowering paths. The regression corpus exercises each
+// only at its minimal shape (the chain quantifier at the unroll cap, the
+// aux-list walk at one walk, the parser-machine self-loop at one queried
+// option); this test actually loads the deepest bytecode the generator
+// emits, so the verifier — not just a static instruction counter — sees
+// the extremes:
+//
+//   - Axis A: the bounded bpf_loop chain at high caps, up to the
+//     bpfLoopChainCap (32) boundary.
+//   - Axis B: 2..8 stacked SRv6 aux-walk callbacks (the eight-walk case).
+//   - Axis C: a counter-driven TLV option walk querying multiple options
+//     (Geneve OVN+GWLB), which fattens the per-iteration callback body.
+//     (The lookahead-only TCP-options accumulator path is loaded by
+//     tcp_accumulator_load_test.go, TestBpfTCPAccumulator.)
+//
+// TestBpf-prefixed and host-doubled (XDP + tc) so it rides the same
+// vimto matrix as TestBpfFilterSet* in .github/workflows/bpf_load_test.yaml;
+// a rejection on any of the matrix kernels fails the matching subtest.
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+// envelopeExprs returns the structural-extreme expressions, labelled to
+// line up with the two axes of TestM2Envelope / fig_envelope.tex.
+func envelopeExprs() []struct{ id, expr string } {
+	out := []struct{ id, expr string }{
+		// Axis A — chain quantifier past the static-unroll cap (4), in the
+		// bpf_loop regime, up to the bpfLoopChainCap boundary (32). The
+		// mechanism itself is already loaded via mpls+/mpls* (D02/D03,
+		// default depth 8); these pin the bounded {1,m>4} shape at its
+		// largest caps.
+		{"A_mpls_1_5", "eth/mpls{1,5}/ipv4/tcp"},
+		{"A_mpls_1_8", "eth/mpls{1,8}/ipv4/tcp"},
+		{"A_mpls_1_32", "eth/mpls{1,32}/ipv4/tcp"},
+	}
+	// Axis B — k stacked SRv6 segment aux-walks, each a bpf_loop callback.
+	// The loaded corpus has only k=1 (G00/G01); k=2..8 is the headline
+	// "eight stacked walks" case and was previously count-only.
+	for k := 2; k <= 8; k++ {
+		expr := "eth/ipv6/srv6 where "
+		for i := 0; i < k; i++ {
+			if i > 0 {
+				expr += " and "
+			}
+			expr += fmt.Sprintf("any(srv6.segments.addr == fc00::%d)", i+1)
+		}
+		out = append(out, struct{ id, expr string }{fmt.Sprintf("B_srv6_walks_%d", k), expr})
+	}
+
+	// Axis C — TLV option walk (parser-machine self-loop) querying multiple
+	// options. Geneve's counter-driven 2-key dispatch carries several
+	// queried options on its native path. (The lookahead-only TCP-options
+	// accumulator path is loaded separately by tcp_accumulator_load_test.go,
+	// TestBpfTCPAccumulator, so it is not duplicated here.)
+	out = append(out,
+		struct{ id, expr string }{
+			"C_geneve_opts_2",
+			"eth/ipv4/udp/geneve where geneve.options.OVN.egress_port == 42 and geneve.options.GWLB.flow_cookie == 0x12345678",
+		},
+	)
+	return out
+}
+
+func TestBpfEnvelopeXDP(t *testing.T) {
+	runEnvelopeMatrix(t, loadDummyXDP(t), xdpFuncName)
+}
+
+func TestBpfEnvelopeTC(t *testing.T) {
+	runEnvelopeMatrix(t, loadDummyTC(t), tcFuncName)
+}
+
+func runEnvelopeMatrix(t *testing.T, hostProg *ebpf.Program, funcName string) {
+	t.Helper()
+	for _, c := range envelopeExprs() {
+		t.Run(c.id, func(t *testing.T) {
+			loadProbeOrFail(t, hostProg, funcName, c.expr, false /*exit*/, true /*useDSL*/)
+		})
+	}
+}

--- a/internal/program/filterset_differential_test.go
+++ b/internal/program/filterset_differential_test.go
@@ -90,6 +90,9 @@ func diffPackets(t *testing.T, id string) [][]byte {
 		// checksum, so the in-place edit is sufficient.
 		const icmpTypeOff = 14 + 20
 		reply := cp(asICMP)(t)
+		if len(reply) <= icmpTypeOff {
+			t.Fatalf("F6: packet is %d bytes, too short for the ICMP type at offset %d (builder/offset drift)", len(reply), icmpTypeOff)
+		}
 		if reply[icmpTypeOff] != 8 {
 			t.Fatalf("F6: expected ICMP type 8 at offset %d, got %d (builder/offset drift)", icmpTypeOff, reply[icmpTypeOff])
 		}

--- a/internal/program/filterset_differential_test.go
+++ b/internal/program/filterset_differential_test.go
@@ -1,0 +1,150 @@
+package program
+
+// Differential correctness for the pcap-expressible filters (F1-F4, F6).
+//
+// filterset_corpus_correctness_test.go asserts match/reject against
+// hand-written expectations: the oracle is the author's own intent, so a
+// protocol misunderstanding baked into both the .p4 definition and the
+// test packet would agree and pass undetected. This file removes that
+// self-judged circularity for the filters that pcap-filter can also
+// express. It compiles the equivalent pcap-filter to cBPF with libpcap
+// (the filter engine behind tcpdump) and runs it on the same packets
+// through an x/net/bpf VM, an implementation that shares no code with
+// kunai's eBPF backend. The two engines must agree on every packet;
+// agreement is corroboration that does not depend on hand-built
+// expectations.
+//
+// Root only (kunai side needs BPF_PROG_TEST_RUN / CAP_SYS_ADMIN); runs
+// under `make test-bpf` via the TestBpf prefix.
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"golang.org/x/net/bpf"
+
+	dt "github.com/takehaya/xdp-ninja/pkg/kunai/dsltest"
+)
+
+// compilePcapVM compiles a pcap-filter expression to cBPF via libpcap
+// and returns an independent x/net/bpf interpreter for it. This is the
+// same pcap -> cBPF path the paper's pcap-filter baseline uses
+// (internal/program/program.go), evaluated here in a pure-Go VM so the
+// reference verdict never touches kunai's compiler.
+func compilePcapVM(t *testing.T, expr string) *bpf.VM {
+	t.Helper()
+	raw, err := pcap.CompileBPFFilter(layers.LinkTypeEthernet, 65535, expr)
+	if err != nil {
+		t.Fatalf("pcap.CompileBPFFilter(%q): %v", expr, err)
+	}
+	insns := make([]bpf.Instruction, len(raw))
+	for i, in := range raw {
+		insns[i] = bpf.RawInstruction{Op: in.Code, Jt: in.Jt, Jf: in.Jf, K: in.K}.Disassemble()
+	}
+	vm, err := bpf.NewVM(insns)
+	if err != nil {
+		t.Fatalf("bpf.NewVM(%q): %v", expr, err)
+	}
+	return vm
+}
+
+// diffPackets returns a diverse packet set for a filter, chosen to
+// straddle the filter's discriminating field so the differential sees
+// both a match and a reject. The packets carry no expected verdict: the
+// two engines supply each other's oracle.
+func diffPackets(t *testing.T, id string) [][]byte {
+	t.Helper()
+	switch id {
+	case "F1": // eth/ipv4/tcp where tcp.dport == 443  |  tcp dst port 443
+		return [][]byte{
+			cp(func(o *dt.PacketOpts) { o.DstPort = 443 })(t),           // match
+			cp(func(o *dt.PacketOpts) { o.DstPort = 80 })(t),            // reject: dport
+			cp(func(o *dt.PacketOpts) { o.DstPort = 443; asUDP(o) })(t), // reject: not tcp
+		}
+	case "F2": // src net 10.0.0.0/8 and tcp dst port 80
+		return [][]byte{
+			cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("10.9.9.9"); o.DstPort = 80 })(t),    // match
+			cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("192.168.1.1"); o.DstPort = 80 })(t), // reject: src out of /8
+			cp(func(o *dt.PacketOpts) { o.SrcIP = net.ParseIP("10.9.9.9"); o.DstPort = 8080 })(t),  // reject: dport
+		}
+	case "F3": // src net 2001:db8::/32 and tcp
+		return [][]byte{
+			cp(v6("2001:db8::1", "2001:db8::2"))(t),                                         // match
+			cp(v6("2001:dead::1", "2001:db8::2"))(t),                                        // reject: src out of /32
+			cp(func(o *dt.PacketOpts) { v6("2001:db8::1", "2001:db8::2")(o); asUDP(o) })(t), // reject: not tcp
+		}
+	case "F4": // vlan 100 and tcp dst port 80
+		return [][]byte{
+			cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100}; o.DstPort = 80 })(t),   // match
+			cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{100}; o.DstPort = 8080 })(t), // reject: dport
+			cp(func(o *dt.PacketOpts) { o.VLAN = []uint16{200}; o.DstPort = 80 })(t),   // reject: vlan tag
+			cp(func(o *dt.PacketOpts) { o.DstPort = 80 })(t),                           // reject: no tag
+		}
+	case "F6": // icmp[icmptype] == 8
+		// The builder always emits ICMP echo request (type 8). Patch the
+		// type byte for a reject case. Frame is eth(14)/ipv4 ihl=5(20)/icmp,
+		// so the ICMP type is at offset 34; neither engine checks the ICMP
+		// checksum, so the in-place edit is sufficient.
+		const icmpTypeOff = 14 + 20
+		reply := cp(asICMP)(t)
+		if reply[icmpTypeOff] != 8 {
+			t.Fatalf("F6: expected ICMP type 8 at offset %d, got %d (builder/offset drift)", icmpTypeOff, reply[icmpTypeOff])
+		}
+		reply[icmpTypeOff] = 0 // echo reply
+		return [][]byte{
+			cp(asICMP)(t), // match: type 8
+			reply,         // reject: type 0
+			cp(nil)(t),    // reject: tcp, not icmp
+		}
+	}
+	t.Fatalf("no differential packet set defined for %s", id)
+	return nil
+}
+
+// TestBpfFilterSetDifferential cross-checks every pcap-expressible filter
+// (F1-F4, F6) against libpcap on the same packets, giving an independent
+// reference beyond the hand-built expectations of the corpus suite.
+func TestBpfFilterSetDifferential(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("differential checks need root (BPF_PROG_TEST_RUN)")
+	}
+	for _, fs := range FilterSet {
+		if fs.CBPFCExpr == "" {
+			continue // F5, F7-F10: pcap-filter cannot express these
+		}
+		fs := fs
+		t.Run(fs.ID, func(t *testing.T) {
+			r := dt.New(t, fs.Expr)
+			vm := compilePcapVM(t, fs.CBPFCExpr)
+			pkts := diffPackets(t, fs.ID)
+
+			var nMatch, nReject int
+			for i, pkt := range pkts {
+				kunaiV := r.Match(t, pkt)
+				n, err := vm.Run(pkt)
+				if err != nil {
+					t.Fatalf("%s pkt#%d: libpcap vm.Run: %v", fs.ID, i, err)
+				}
+				pcapV := n > 0
+				if kunaiV != pcapV {
+					t.Errorf("%s pkt#%d verdict mismatch: kunai=%v libpcap=%v\n  kunai: %s\n  pcap : %s",
+						fs.ID, i, kunaiV, pcapV, fs.Expr, fs.CBPFCExpr)
+				}
+				if kunaiV {
+					nMatch++
+				} else {
+					nReject++
+				}
+			}
+			// Guard against a vacuous pass where every packet rejects on
+			// both engines: the set must exercise both verdicts.
+			if nMatch == 0 || nReject == 0 {
+				t.Fatalf("%s: differential is vacuous (match=%d reject=%d); packet set must straddle the filter",
+					fs.ID, nMatch, nReject)
+			}
+		})
+	}
+}

--- a/internal/program/filterset_differential_test.go
+++ b/internal/program/filterset_differential_test.go
@@ -131,7 +131,7 @@ func TestBpfFilterSetDifferential(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%s pkt#%d: libpcap vm.Run: %v", fs.ID, i, err)
 				}
-				pcapV := n > 0
+				pcapV := n != 0 // cBPF: 0 = reject, any non-zero = accept
 				if kunaiV != pcapV {
 					t.Errorf("%s pkt#%d verdict mismatch: kunai=%v libpcap=%v\n  kunai: %s\n  pcap : %s",
 						fs.ID, i, kunaiV, pcapV, fs.Expr, fs.CBPFCExpr)


### PR DESCRIPTION
Two kernel-matrix tests extracted from local WIP and verified to pass on
current `main` across the 6.1–7.0 vimto matrix (both `TestBpf`-prefixed, so
they ride the same matrix job as the existing filter-set load tests).

## TestBpfFilterSetDifferential

Differential correctness for the pcap-expressible filters (F1–F4, F6): each
filter is compiled, loaded, and run via `BPF_PROG_TEST_RUN` on hand-built
packets, asserting the match/reject verdict. This is an oracle-style guard
for the cbpf path — a semantic regression in codegen shows up as a wrong
verdict, not just a changed instruction count. Skips cleanly without root.

## TestBpfEnvelope{XDP,TC}

Verifier-load coverage for the structural extremes of the generator's three
`bpf_loop` lowering paths, which the regression corpus only exercises at
minimal shape:

- **Axis A** — the bounded chain quantifier at high caps, up to the
  `bpfLoopChainCap` (32) boundary (`mpls{1,5}` / `{1,8}` / `{1,32}`).
- **Axis B** — 2..8 stacked SRv6 aux-walk callbacks (the eight-walk case).
- **Axis C** — a counter-driven Geneve multi-option walk (OVN + GWLB).

The lookahead-only TCP-options accumulator path is already loaded by
`tcp_accumulator_load_test.go` (`TestBpfTCPAccumulator`, merged in #40), so
it is not duplicated here.

## Scope

Only these two were pulled from the local benchmark/paper WIP: they guard
shipped codegen (correctness + verifier-safety) and pass on `main` as-is.
The paper's instruction-count figure pins (`m2_envelope`) and the
benchmark-only drop path are intentionally left out — the former drifted
from current codegen and belongs with the paper, the latter is bench
scaffolding.