### PR TITLE
fix(capture): copy packet payload into a per-shard arena to stop batch aliasing

### DIFF
--- a/docs/ja/capture-datapath.md
+++ b/docs/ja/capture-datapath.md
@@ -1,0 +1,137 @@
+# capture datapath deep-dive フィルタ一致からパケット書き出しまで
+
+> kunai は in-kernel フィルタを生成するコンパイラで、生成物は 2 レジスタ間のパケットウィンドウに対する accept/reject 判定だけを持つ target-agnostic な命令列です。詳しくは [codegen deep-dive](./kunai-codegen-deepdive.md) を参照してください。本稿はその先を扱います。つまりフィルタが accept したパケットが、どうカーネルからユーザ空間へ運ばれ、pcap-ng として書き出されるかです。コードでいうとカーネル側で emit する `internal/program` と、ユーザ空間の `internal/capture` および `internal/output` が主題になります。
+
+## データパスの全体像
+
+1 パケットがたどる経路は次の 5 ステージです。
+
+```
+[XDP プログラム実行]
+   │  fentry / fexit / XDP-native でアタッチ
+   ▼
+① kunai (または cBPF) フィルタを inline 評価   ← accept なら続行、reject なら抜ける
+   ▼
+② capture epilogue: per-CPU ringbuf に reserve → metadata 16B + パケット本体を書く → submit
+   ▼
+③ per-CPU sharded ringbuf (ARRAY_OF_MAPS + CPU ごとの inner RingBuf)
+   ▼
+④ ユーザ空間 reader: shard ごとの goroutine が drain (default reader / fast reader の 2 実装)
+   ▼
+⑤ pcap-ng writer: Enhanced Packet Block を stdout または -w のファイルへ
+```
+
+①と②はカーネル内で動く 1 本の BPF プログラムです。kunai が出すのは①のフィルタ命令列だけで、②以降の epilogue は host 側の `internal/program` が被せます。これが kunai を target-agnostic と呼ぶことの具体的な意味です。
+
+## ステージ① フィルタの位置づけ
+
+kunai の出力は `R0` をパケット先頭、`R1` をパケット末尾として入力に取り、accept なら 1、reject なら 0 を `R2` に書いて `filter_result` ラベルへ到達する、というレジスタ規約だけを仮定します。ABI の詳細は [codegen deep-dive](./kunai-codegen-deepdive.md) にあります。
+
+host 側はアタッチモードごとにこの規約を満たす前処理を被せます。
+
+- tracing つまり fentry と fexit の場合、トレーシングプログラムは `xdp_buff` のパケット領域を直接は触れません。そのためまずパケット先頭を `PTR_TO_MAP_VALUE` である per-CPU の filter scratch map へコピーし、その scratch を `R0` と `R1` として渡します。この処理は `internal/program/program.go` の `loadProbe` と `buildTracingInsns` にあります。
+- XDP-native の場合、パケットに直接アクセスできるので scratch コピーは不要です。
+
+フィルタが reject すると `exit` ラベルに飛び、何も emit せずにプログラムを抜けます。accept したパケットだけがステージ②へ進みます。
+
+## ステージ② capture epilogue で ringbuf へ書き込む
+
+accept 後の書き出しは、tracing の `captureWithRingbuf` と XDP-native の `captureXDPNative` が担います。前者は `internal/program/program.go`、後者は `internal/program/program_xdp.go` にあります。両者はほぼミラーで、流れは次のとおりです。
+
+1. `bpf_ktime_get_ns()` でタイムスタンプを取り、スタックに退避します。XDP-native では HW タイムスタンプ kfunc が使えればそちらを優先します。
+2. `bpf_get_smp_processor_id()` で自分の CPU 番号を取り、それを key にして自分の CPU の inner ringbuf を outer ARRAY_OF_MAPS から `emitShardedRBReserve` で引きます。
+3. `bpf_ringbuf_reserve` で `metadataSize + maxCapLen` バイトの固定長スロットを予約します。
+4. スロット先頭 16B に、後述の on-wire 形式で metadata を書きます。
+5. パケット本体を `min(pkt_len, maxCapLen)` バイトだけスロットの 16B 目以降にコピーします。tracing は `bpf_probe_read_kernel`、XDP-native は `bpf_xdp_load_bytes` を使います。
+6. `bpf_ringbuf_submit` でスロットを consumer から見える状態にします。
+
+設計上の要点が 2 つあります。
+
+- reserve サイズはコンパイル時定数でなければ verifier が通りません。だから常に `int32(metadataSize + maxCapLen)` を即値で渡し、レジスタ由来の可変サイズは使いません。実データ長は metadata の `caplen` フィールドで伝えます。
+- reserve+submit にしているのは memcpy を 1 回減らすためです。`bpf_ringbuf_output` は内部でデータバッファをスロットへ memcpy しますが、reserve したスロットへ直接書けばその一段を省けます。
+
+> snaplen にあたる `maxCapLen` は kunai 側が決めます。`capture N` 句があればその長さを使い、`where` 節が参照するフィールドのオフセットから必要な最小プレフィックスを推論します。無指定なら 0 を返して host 側の `DefaultCapLen` である 1500B にフォールバックします。この処理は `pkg/kunai/codegen/capture.go` にあります。CLI の `--snaplen` で上書きもできます。
+
+## on-wire 形式と RawSample レイアウト
+
+ringbuf に積まれる 1 レコードである `RawSample` は次の固定レイアウトです。定義は `internal/capture/capture.go` にあります。program 側の `metadataSize` と一致することは `TestMetadataSizeMatchesCapture` でピン留めしてあります。
+
+```
+RawSample = [ metadata 16B ] [ packet bytes (caplen B) ] [ trailing slack ]
+```
+
+| offset | size | field        | 内容                                                  |
+|:------:|:----:|:-------------|:------------------------------------------------------|
+|   0    |  8   | kernel_ts_ns | `bpf_ktime_get_ns()` の値、CLOCK_MONOTONIC            |
+|   8    |  4   | action       | XDP return action、fexit のみ有効で entry と native は固定 |
+|   12   |  1   | mode         | 0=entry/fentry, 1=exit/fexit, 2=xdp-native            |
+|   13   |  1   | _pad         | 0                                                     |
+|   14   |  2   | caplen       | 後続パケット領域のうち実際に有効なバイト数             |
+
+注意点は次のとおりです。
+
+- 全マルチバイトフィールドはホストエンディアンです。BPF 側は `asm.StoreMem` でネイティブエンディアンに書くので、reader は `binary.NativeEndian` で読みます。
+- スロットは常に `metadataSize + maxCapLen` バイト予約されますが、producer が書くのは `16 + caplen` バイトだけです。残りの slack は未初期化メモリですが、submit すると予約全体が consumer から見えます。reader は `caplen` を信じてそこまでだけを読みます。
+- `action` が意味を持つのは fexit だけです。fexit は XDP プログラムの戻り値である DROP/PASS/TX/REDIRECT を観測できるので、`where action == XDP_DROP` のような述語が書けます。fentry はまだ戻り値が決まっていないので action は無効です。
+
+## ステージ③ per-CPU sharded ringbuf
+
+ringbuf は 1 本ではなく、CPU ごとに 1 本立てる per-CPU shard 構成です。実装は `internal/program/sharded_ringbuf.go` にあります。
+
+- outer は `ARRAY_OF_MAPS` で、サイズは CPU 数です。各エントリに inner の `RingBuf` を 1 本ずつ入れます。
+- 各 inner のサイズは ringbuf 総容量を CPU 数で割った値で、最低 64KiB を床にします。`--ringbuf-size` で指定する MiB を CPU 全体で等分する形です。
+- BPF プロローグは `bpf_get_smp_processor_id()` で自分の inner を引いて reserve と submit を行います。
+
+狙いはロックフリーな shard 所有です。producer はある CPU で動く XDP や tracing プログラム、consumer はユーザ空間でその CPU に pin された reader goroutine です。両者が同じ CPU の同じ shard だけを触るので、shard 間で mutex が要りません。同一 CPU が直前に書いたキャッシュラインをそのまま読むので、キャッシュの面でも有利です。
+
+## ステージ④ ユーザ空間 reader
+
+reader は shard ごとに 1 goroutine を立て、それぞれを producer CPU に pin します。`--no-cpu-affinity` を付けると pin を無効化できます。実装は 2 つあり、CLI フラグで切り替わります。
+
+### default reader
+
+この実装は `RunShards` で、`cilium/ebpf` の `ringbuf.Reader.ReadInto` を使ってレコードを 1 件ずつ読みます。1 件読んだら deadline を過去に倒してノンブロッキングにし、最大 256 件をバッチに溜めてから sink へ渡します。sink は pcap writer です。バッチで sink 呼び出し回数を償却するのが狙いです。
+
+### fast reader
+
+この実装は `RunShardsFast` で、`cilium/ebpf` の per-record API を介さず、ringbuf map を直接 mmap して consumer ページと producer ページを自前で読みます。コードは `internal/capture/fastrb` にあります。
+
+- `--no-wakeup` と組み合わせると、producer 側の epoll wakeup を省けます。
+- `--busy-poll` を付けると `epoll_wait` でブロックせずにスピンし、ringbuf を連続して drain します。ただし shard あたり 1 コアを使い切ります。
+- `--rx-cores N` の split-core モードでは、RX をコア `0..N-1` に閉じ込め、reader goroutine を上半分のコアに pin します。こうして RX softirq とコアを食い合わないようにします。
+
+性能の経緯と数値は [tuning ガイド](./tuning.md) と、ベンチ方法論をまとめた [dsl-benchmark.md](./dsl-benchmark.md) を参照してください。
+
+### タイムスタンプ
+
+既定では metadata の `kernel_ts_ns` である CLOCK_MONOTONIC の値を、起動時に 1 回測った wall_clock と monotonic の差分オフセットで wall clock に変換します。これは per-packet の精度です。`--legacy-timestamp` を付けるとバッチ単位の `time.Now()` に切り替わり、256 件のバッチが 1 つのタイムスタンプを共有します。精度は落ちますが安価です。
+
+> 所有権の契約として、`ParseRawSample` が返す `Packet.Data` は、default ではレコードバッファ、fast では mmap リングへのビューで、次のレコードを読むと上書きされます。そのまま 256 件ためてから書き出すと、バッチ内の全パケットが最後に読んだレコードのバイト列に化けてしまいます。これを避けるため、reader は shard ごとに使い回すアリーナへ各パケットの本体をコピーし、`Data` をそのアリーナの区画に張り替えてからバッチに積みます。アリーナはフラッシュのたびに先頭へ巻き戻して再利用するので、定常状態でのアロケーションはありません。sink 側は呼び出し中に `Data` を pcap へ書き出して消費しきる必要があり、バッチを跨いで `Data` を保持してはいけません。
+
+## ステージ⑤ pcap-ng への書き出し
+
+sink はバッチ内の各パケットを、pcap-ng の Enhanced Packet Block すなわち EPB として書き出します。実装は `internal/output` にあります。
+
+- 既定の高速 writer である `FastNgWriter` は EPB を手書きで組み立て、`bufio.Writer` 経由で出力します。1 パケットあたり header と data と trailer の 3 回の `Write` を bufio が束ねます。実装は `fastpcapng.go` にあります。
+- 出力先は stdout か `-w` で指定するファイルです。stdout に流して Wireshark や tshark にパイプできます。
+
+別経路として raw-dump モードもあります。これは ParseRawSample を介さず、レコードのバイト列をそのまま自前のバイナリ形式でダンプする最速経路です。後から `xdp-ninja convert` で pcap-ng に変換します。観測オーバーヘッドを最小化したいベンチ用です。
+
+## 関係するフラグのまとめ
+
+| フラグ | 効くステージ | 役割 |
+|:--|:--|:--|
+| `--snaplen N` | ② | キャプチャ長 (maxCapLen) を上書き |
+| `--ringbuf-size N` | ③ | ringbuf 総容量 (MiB)、CPU 数で等分 |
+| `--no-wakeup` | ②③ | producer 側 wakeup を省く (fast reader 前提) |
+| `--busy-poll` | ④ | epoll をブロックせずスピン drain |
+| `--rx-cores N` | ④ | split-core モード (RX とコアを分離) |
+| `--no-cpu-affinity` | ④ | reader goroutine の CPU pin を無効化 (診断用) |
+| `--legacy-timestamp` | ④ | per-packet kernel ts ではなくバッチ単位の userspace ts |
+
+## 関連ドキュメント
+
+- [kunai overview](./kunai-overview-article.md) は kunai の全体像をまとめています。
+- [kunai codegen deep-dive](./kunai-codegen-deepdive.md) はフィルタ命令列、つまりステージ①の生成を扱います。
+- [性能チューニングガイド](./tuning.md) は fast reader や wakeup、split-core の効果を扱います。
+- [ベンチ方法論](./dsl-benchmark.md) は測定セットアップを扱います。

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -146,11 +146,11 @@ func NewReader(eventsMap *ebpf.Map, _ int) (*Reader, error) {
 // All multi-byte fields are host-endian: BPF stores via asm.StoreMem
 // produce native-endian writes, so readers must use binary.NativeEndian.
 const (
-	MetadataSize    = 16
-	OffsetKernelTs  = 0
-	OffsetAction    = 8
-	OffsetMode      = 12
-	OffsetCapLen    = 14
+	MetadataSize   = 16
+	OffsetKernelTs = 0
+	OffsetAction   = 8
+	OffsetMode     = 12
+	OffsetCapLen   = 14
 )
 
 // RecordKernelTs reads the kernel_ts_ns field from a raw ringbuf record.
@@ -290,6 +290,81 @@ func NewShardedReader(inners []*ebpf.Map) (*Reader, error) {
 	return r, nil
 }
 
+// batchSize is the target batch size: the initial Packet/arena capacity
+// and the drain bound for the default reader (RunShards stops draining
+// and flushes once the batch reaches batchSize). The fast reader
+// (RunShardsFast) drains every committed record in one ReadBatch pass
+// and flushes once afterward, so a single fast-reader batch may exceed
+// batchSize; the arena and Packet slice grow to fit.
+const batchSize = 256
+
+// arenaInitPerPacket sizes the per-shard copy arena: batchSize × this
+// many bytes is pre-allocated so a full default-reader batch of
+// MTU-sized packets fits without reallocating. Larger fast-reader
+// batches grow the arena to a high-water mark and then reuse it.
+const arenaInitPerPacket = 2048
+
+// batchBuilder accumulates a batch of Packets for one shard while
+// owning their payload bytes. ParseRawSample returns a Packet whose
+// Data aliases the source buffer — the cilium/ebpf ringbuf.Record
+// (default reader) or the mmap'd ring (fast reader) — and that backing
+// memory is overwritten by the next read. Because a batch is flushed to
+// sink only after it fills, holding those aliases would hand sink stale
+// bytes. add() therefore copies each payload into a reusable per-shard
+// arena and repoints Data into it. The arena is reset (not freed) on
+// every flush, so steady-state allocation is zero.
+type batchBuilder struct {
+	shardIdx int
+	sink     ShardSink
+	buf      []Packet
+	arena    []byte
+}
+
+func newBatchBuilder(shardIdx int, sink ShardSink) *batchBuilder {
+	return &batchBuilder{
+		shardIdx: shardIdx,
+		sink:     sink,
+		buf:      make([]Packet, 0, batchSize),
+		arena:    make([]byte, 0, batchSize*arenaInitPerPacket),
+	}
+}
+
+// full reports whether the batch has reached batchSize, signalling the
+// drain loop to stop and flush.
+func (b *batchBuilder) full() bool { return len(b.buf) >= cap(b.buf) }
+
+// add copies pkt's payload into the arena, repoints pkt.Data into it,
+// and appends pkt to the batch. add never calls sink, so it is safe to
+// invoke from inside fastrb.Reader.ReadBatch's callback, where flushing
+// would run sink I/O before the consumer position is committed and add
+// ringbuf backpressure on the producer.
+//
+// If the payload does not fit the arena's spare capacity, append grows
+// it. A reallocation does not corrupt payloads already queued in this
+// batch: their Data slices keep the old backing array (with its bytes
+// intact) alive until the batch is flushed. The arena reaches a
+// high-water mark and is reset, not freed, on flush, so steady-state
+// allocation is zero.
+func (b *batchBuilder) add(pkt Packet) {
+	n := len(pkt.Data)
+	start := len(b.arena)
+	b.arena = append(b.arena, pkt.Data...)
+	pkt.Data = b.arena[start : start+n]
+	b.buf = append(b.buf, pkt)
+}
+
+// flush hands the accumulated batch to sink and resets the buffers for
+// reuse. sink must consume (write/copy) every Packet.Data before
+// returning; once flush resets the arena those bytes are recycled.
+func (b *batchBuilder) flush() {
+	if len(b.buf) == 0 {
+		return
+	}
+	_ = b.sink(b.shardIdx, b.buf)
+	b.buf = b.buf[:0]
+	b.arena = b.arena[:0]
+}
+
 // RunShards launches per-shard goroutines pumping into sink. Returns
 // a stop function that drains and joins all shards.
 func (r *Reader) RunShards(sink ShardSink) (stop func(), err error) {
@@ -302,7 +377,7 @@ func (r *Reader) RunShards(sink ShardSink) (stop func(), err error) {
 		go func(shardIdx int, rr *ringbuf.Reader) {
 			pinReaderToCPU(shardIdx)
 			defer func() { doneCh <- struct{}{} }()
-			buf := make([]Packet, 0, 256)
+			bb := newBatchBuilder(shardIdx, sink)
 			var rec ringbuf.Record
 			pollPast := time.Unix(1, 0)
 			for {
@@ -318,15 +393,14 @@ func (r *Reader) RunShards(sink ShardSink) (stop func(), err error) {
 					continue
 				}
 				now := time.Now()
-				pkt, perr := ParseRawSample(rec.RawSample)
-				if perr == nil {
+				if pkt, perr := ParseRawSample(rec.RawSample); perr == nil {
 					if LegacyTimestamp {
 						pkt.Timestamp = now
 					}
-					buf = append(buf, pkt)
+					bb.add(pkt)
 				}
 				rr.SetDeadline(pollPast)
-				for len(buf) < cap(buf) {
+				for !bb.full() {
 					if err := rr.ReadInto(&rec); err != nil {
 						break
 					}
@@ -337,13 +411,10 @@ func (r *Reader) RunShards(sink ShardSink) (stop func(), err error) {
 					if LegacyTimestamp {
 						pkt.Timestamp = now
 					}
-					buf = append(buf, pkt)
+					bb.add(pkt)
 				}
 				rr.SetDeadline(time.Time{})
-				if len(buf) > 0 {
-					_ = sink(shardIdx, buf)
-					buf = buf[:0]
-				}
+				bb.flush()
 			}
 		}(idx, rr)
 	}
@@ -470,7 +541,7 @@ func (r *FastShardedReader) RunShardsFast(sink ShardSink) (stop func(), err erro
 		go func(shardIdx, pinCPU int, rdr *fastrb.Reader) {
 			pinReaderToCPU(pinCPU)
 			defer func() { doneCh <- struct{}{} }()
-			buf := make([]Packet, 0, 256)
+			bb := newBatchBuilder(shardIdx, sink)
 			for {
 				select {
 				case <-stopCh:
@@ -491,12 +562,9 @@ func (r *FastShardedReader) RunShardsFast(sink ShardSink) (stop func(), err erro
 					if LegacyTimestamp {
 						pkt.Timestamp = now
 					}
-					buf = append(buf, pkt)
+					bb.add(pkt)
 				})
-				if len(buf) > 0 {
-					_ = sink(shardIdx, buf)
-					buf = buf[:0]
-				}
+				bb.flush()
 			}
 		}(idx, pinCPU, rdr)
 	}

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -10,11 +10,11 @@ func TestParsePacket(t *testing.T) {
 	pktData := []byte{0xde, 0xad, 0xbe, 0xef}
 
 	raw := make([]byte, MetadataSize+len(pktData))
-	binary.NativeEndian.PutUint64(raw[0:8], 12345)                     // kernel_ts_ns
-	binary.NativeEndian.PutUint32(raw[8:12], 2)                        // action = XDP_PASS
-	raw[12] = 1                                                         // mode = exit
-	raw[13] = 0                                                         // pad
-	binary.NativeEndian.PutUint16(raw[14:16], uint16(len(pktData)))    // caplen
+	binary.NativeEndian.PutUint64(raw[0:8], 12345)                  // kernel_ts_ns
+	binary.NativeEndian.PutUint32(raw[8:12], 2)                     // action = XDP_PASS
+	raw[12] = 1                                                     // mode = exit
+	raw[13] = 0                                                     // pad
+	binary.NativeEndian.PutUint16(raw[14:16], uint16(len(pktData))) // caplen
 	copy(raw[MetadataSize:], pktData)
 
 	pkt, err := ParseRawSample(raw)
@@ -75,7 +75,7 @@ func TestParsePacketMetadataOnly(t *testing.T) {
 	raw := make([]byte, MetadataSize)
 	binary.NativeEndian.PutUint64(raw[0:8], 0)  // kernel_ts = 0
 	binary.NativeEndian.PutUint32(raw[8:12], 0) // action = 0
-	raw[12] = 0                                  // mode = entry
+	raw[12] = 0                                 // mode = entry
 
 	pkt, err := ParseRawSample(raw)
 	if err != nil {
@@ -83,5 +83,136 @@ func TestParsePacketMetadataOnly(t *testing.T) {
 	}
 	if len(pkt.Data) != 0 {
 		t.Errorf("Data length = %d, want 0", len(pkt.Data))
+	}
+}
+
+// makeRecord builds a ringbuf record with the given caplen payload
+// filled with byte value fill, mirroring the BPF reserve+submit format.
+func makeRecord(buf []byte, fill byte, caplen int) []byte {
+	raw := buf[:MetadataSize+caplen]
+	binary.NativeEndian.PutUint16(raw[OffsetCapLen:OffsetCapLen+2], uint16(caplen))
+	for i := range caplen {
+		raw[MetadataSize+i] = fill
+	}
+	return raw
+}
+
+// TestBatchBuilderOwnsPayload is the regression test for the slice-
+// aliasing bug: ParseRawSample returns a Packet whose Data aliases the
+// source record buffer, which the reader reuses across reads. Before the
+// fix, a batch flushed to sink handed every Packet the LAST record's
+// bytes. batchBuilder must copy each payload so the flushed batch
+// preserves per-packet content even when the source buffer is mutated
+// after add().
+func TestBatchBuilderOwnsPayload(t *testing.T) {
+	var got [][]byte
+	sink := func(_ int, pkts []Packet) error {
+		for _, p := range pkts {
+			cp := make([]byte, len(p.Data))
+			copy(cp, p.Data)
+			got = append(got, cp)
+		}
+		return nil
+	}
+
+	bb := newBatchBuilder(0, sink)
+
+	// One reused source buffer, exactly as the reader reuses
+	// ringbuf.Record.RawSample / the mmap ring across reads.
+	src := make([]byte, MetadataSize+64)
+	fills := []byte{0xAA, 0xBB, 0xCC}
+	for _, f := range fills {
+		raw := makeRecord(src, f, 8)
+		pkt, err := ParseRawSample(raw)
+		if err != nil {
+			t.Fatalf("ParseRawSample: %v", err)
+		}
+		bb.add(pkt)
+		// Scribble over the shared buffer to simulate the next read
+		// overwriting the previous record in place.
+		for i := range src {
+			src[i] = 0
+		}
+	}
+	bb.flush()
+
+	if len(got) != len(fills) {
+		t.Fatalf("got %d packets, want %d", len(got), len(fills))
+	}
+	for i, f := range fills {
+		for j, b := range got[i] {
+			if b != f {
+				t.Fatalf("packet %d byte %d = %#x, want %#x (aliasing regression)", i, j, b, f)
+			}
+		}
+	}
+}
+
+// TestBatchBuilderArenaOverflow feeds more total payload than the
+// arena's initial capacity to verify two properties of the overflow
+// handling: add never calls sink (critical for the fast reader, where
+// add runs inside ReadBatch's callback before consPos is committed), and
+// the arena grows via append without corrupting payloads already queued
+// — their bytes must survive the reallocation intact.
+func TestBatchBuilderArenaOverflow(t *testing.T) {
+	var got [][]byte
+	sinkCalls := 0
+	sink := func(_ int, pkts []Packet) error {
+		sinkCalls++
+		for _, p := range pkts {
+			cp := make([]byte, len(p.Data))
+			copy(cp, p.Data)
+			got = append(got, cp)
+		}
+		return nil
+	}
+
+	bb := newBatchBuilder(0, sink)
+	// Shrink the arena so the packets below overflow it well before the
+	// explicit flush, forcing append to reallocate mid-batch.
+	bb.arena = make([]byte, 0, 32)
+
+	caplens := []int{16, 16, 16, 16, 48}
+	src := make([]byte, MetadataSize+64)
+	for i, caplen := range caplens {
+		raw := makeRecord(src, byte(i+1), caplen)
+		pkt, err := ParseRawSample(raw)
+		if err != nil {
+			t.Fatalf("ParseRawSample: %v", err)
+		}
+		bb.add(pkt)
+		// Overwrite the shared source to prove the payload was copied.
+		for k := range src {
+			src[k] = 0
+		}
+	}
+
+	// add() must not have flushed despite overflowing the arena.
+	if sinkCalls != 0 {
+		t.Fatalf("sink called %d times during add (want 0; add must not flush)", sinkCalls)
+	}
+	// The total payload exceeded the initial 32 B, so the arena must
+	// have grown.
+	if cap(bb.arena) <= 32 {
+		t.Fatalf("arena cap = %d, want > 32 (append should have grown it)", cap(bb.arena))
+	}
+
+	bb.flush()
+
+	if sinkCalls != 1 {
+		t.Fatalf("sink called %d times, want 1 (single explicit flush)", sinkCalls)
+	}
+	if len(got) != len(caplens) {
+		t.Fatalf("got %d packets, want %d", len(got), len(caplens))
+	}
+	for i, caplen := range caplens {
+		if len(got[i]) != caplen {
+			t.Fatalf("packet %d len = %d, want %d", i, len(got[i]), caplen)
+		}
+		for j, b := range got[i] {
+			if b != byte(i+1) {
+				t.Fatalf("packet %d byte %d = %#x, want %#x (survived realloc)", i, j, b, byte(i+1))
+			}
+		}
 	}
 }


### PR DESCRIPTION
## 問題

`ParseRawSample` が返す `Packet.Data` は元バッファへのビューです。default reader では `cilium/ebpf` の `ringbuf.Record`、fast reader では mmap したリングを指します。両 reader はパケットを最大 256 件ためてからバッチを sink に渡しますが、その元バッファは次の read で上書きされます。

結果として、フラッシュされたバッチの全パケットが「最後に読んだレコードのバイト列」に化けていました。

- 単一サイズのフレームでは長さが揃うので malformed にならず、中身だけが静かに壊れる（取りこぼし・重複）。
- サイズが混在すると「小さい枠に大きい中身」が起きて長さ超過になり、tshark で `IPv4 total length exceeds packet length` などの malformed として表面化する。

## 修正

shard ごとに使い回す `batchBuilder` を追加しました。

- `add()` がパケット本体を再利用アリーナへコピーし、`Data` をそのアリーナ区画に張り替えてからバッチに積む。
- アリーナが溢れそうなら先にフラッシュしてから積むので、バッチ途中で再確保が起きて既存スライスが無効化されることはない。
- フラッシュごとにアリーナを先頭へ巻き戻すだけなので、定常状態でのアロケーションはゼロ。
- fast reader は `ReadBatch` コールバック内、つまり `consPos` コミット前（producer が上書きできない区間）でコピーするため、以前より安全。

## テスト

- 回帰テスト 2 本を追加。`TestBatchBuilderOwnsPayload` は `add()` 後に元バッファを 0 で上書きしてエイリアシングを再現する構成で、修正前なら確実に落ちる。`TestBatchBuilderArenaOverflow` はアリーナ溢れ→途中フラッシュ→拡張の経路を踏む。
- `go test ./...` 全 green、`go test -race ./internal/capture/...` green、`go vet` / `golangci-lint` / `gofmt` クリーン。
- BPF 側は無改変。

## ドキュメント

`docs/ja/capture-datapath.md` を追加し、フィルタ一致からパケット書き出しまでのデータパス全体と、本修正が担保する `Data` の所有権契約を記載しました。

## 残課題

非 shard の `Reader.Read` / `Reader.ReadBatch`（旧シングルリーダ API）にも同じ潜在エイリアシングが残るが、現行の実行パスからは未使用。本 PR ではスコープ外とした。

