### PR TITLE
docs(todo): drop resolved items from the backlog

### DIFF
--- a/docs/ja/TODO.md
+++ b/docs/ja/TODO.md
@@ -37,9 +37,6 @@
 
 ## 機能
 
-- [x] `-p <prog-id>` でプログラム ID から直接アタッチ
-- [x] 統合テストの自動化 (`scripts/test/run_tests.sh`)
-
 - [ ] pcapng の Interface Description Block に XDP プログラム情報を記録
   - プログラム名、ID、mode (entry/exit) などをメタデータとして埋め込む
 


### PR DESCRIPTION
バックログ (`docs/ja/TODO.md`) から解決済み項目を削り、未着手の作業だけを残す。

## 削除した項目 (いずれも実装済み)
- `-p <prog-id>` でプログラム ID から直接アタッチ
- 統合テストの自動化 (`scripts/test/run_tests.sh`)

チェック済みのまま置いておくとノイズになるため削除。挙動・コードへの影響はなし。