### PR TITLE
feat(attach): list CPUMAP/DEVMAP redirect targets in --list-progs

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -370,7 +370,8 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 	defer func() { _ = info.Program.Close() }()
 
-	// --list-progs: show tail call targets, then exit
+	// --list-progs: show reachable programs (tail calls +
+	// CPUMAP/DEVMAP redirect targets), then exit
 	if cmd.Bool("list-progs") {
 		fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -63,7 +63,7 @@ var flags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:  "list-progs",
-		Usage: "list tail call targets reachable from the target program and exit",
+		Usage: "list programs reachable from the target: tail calls + CPUMAP/DEVMAP redirect targets, then exit",
 	},
 	&cli.StringSliceFlag{
 		Name:  "arg-filter",
@@ -374,12 +374,12 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if cmd.Bool("list-progs") {
 		fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
 
-		targets, err := attach.ListTailCallTargets(info.Program)
+		targets, err := attach.ListReachablePrograms(info.Program)
 		if err != nil {
 			return err
 		}
 		for _, t := range targets {
-			fmt.Fprintf(os.Stderr, "id=%-6d %s (tailcall[%d])\n", t.ProgID, t.ProgName, t.Index)
+			fmt.Fprintf(os.Stderr, "id=%-6d %s (%s[%d])\n", t.ProgID, t.ProgName, t.Via, t.Key)
 		}
 		return nil
 	}

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -223,12 +223,16 @@ func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 }
 
 // scanProgArray reads tail-call targets from a PROG_ARRAY. Values are the
-// target program IDs.
+// target program IDs. Array-backed maps enumerate every slot, so unset
+// entries surface as id 0 and are skipped.
 func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 	var targets []ProgTarget
 	var key, val uint32
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
+		if val == 0 {
+			continue // empty tail-call slot
+		}
 		t, err := resolveProgTarget("tailcall", key, val)
 		if err != nil {
 			return nil, err

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -192,7 +192,7 @@ func ListReachablePrograms(prog *ebpf.Program) ([]ProgTarget, error) {
 		found, err := scanMapForPrograms(m, mapID)
 		_ = m.Close()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scanning map %d: %w", mapID, err)
 		}
 		targets = append(targets, found...)
 	}
@@ -252,17 +252,17 @@ func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 // have a 4-byte value and carry no program.
 //
 // CPUMAP, DEVMAP and DEVMAP_HASH all use 4-byte u32 keys (the kernel
-// enforces key_size == 4). The key and value are read as raw byte
-// buffers sized from the map info and decoded explicitly, so an
-// unexpected key/value width can't silently truncate or misread.
+// enforces key_size == 4); any other key width is an unexpected layout we
+// don't decode. The value is read as a byte buffer sized from map info so
+// a shorter (pre-attached-program) layout carries no program.
 func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSize uint32) ([]ProgTarget, error) {
 	const progIDOffset = 4
-	if keySize < 4 || valueSize < progIDOffset+4 {
+	if keySize != 4 || valueSize < progIDOffset+4 {
 		return nil, nil
 	}
 
 	var targets []ProgTarget
-	key := make([]byte, int(keySize))
+	var key uint32
 	val := make([]byte, int(valueSize))
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
@@ -270,8 +270,7 @@ func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSi
 		if progID == 0 {
 			continue // entry has no attached program
 		}
-		mapKey := binary.NativeEndian.Uint32(key[:4])
-		t, err := resolveProgTarget(via, mapKey, progID)
+		t, err := resolveProgTarget(via, key, progID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -2,6 +2,7 @@
 package attach
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -156,16 +157,21 @@ func FindXDPProgram(ifaceName string) (*ProgInfo, error) {
 	}, nil
 }
 
-// TailCallTarget holds information about a program in a PROG_ARRAY map.
-type TailCallTarget struct {
-	Index    uint32
+// ProgTarget describes a program reachable from another program: a
+// tail-call target in a PROG_ARRAY, or an XDP program attached to a
+// CPUMAP / DEVMAP entry the program can bpf_redirect_map() into.
+type ProgTarget struct {
+	Via      string // "tailcall", "cpumap", "devmap", or "devmap_hash"
+	Key      uint32 // map key: tail-call index, CPU id, or devmap key
 	ProgID   uint32
 	ProgName string
 }
 
-// ListTailCallTargets finds all tail call targets reachable from the given program
-// by scanning its PROG_ARRAY maps.
-func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
+// ListReachablePrograms scans the maps referenced by prog for downstream
+// programs: tail-call targets in PROG_ARRAY maps, plus XDP programs
+// attached to CPUMAP / DEVMAP / DEVMAP_HASH entries (the redirect_map
+// datapath). Entries without an attached program are skipped.
+func ListReachablePrograms(prog *ebpf.Program) ([]ProgTarget, error) {
 	info, err := prog.Info()
 	if err != nil {
 		return nil, fmt.Errorf("getting program info: %w", err)
@@ -176,56 +182,116 @@ func ListTailCallTargets(prog *ebpf.Program) ([]TailCallTarget, error) {
 		return nil, nil
 	}
 
-	var targets []TailCallTarget
+	var targets []ProgTarget
 	for _, mapID := range mapIDs {
 		m, err := ebpf.NewMapFromID(mapID)
 		if err != nil {
 			return nil, fmt.Errorf("opening map %d: %w", mapID, err)
 		}
 
-		mapInfo, err := m.Info()
-		if err != nil {
-			_ = m.Close()
-			return nil, fmt.Errorf("getting map %d info: %w", mapID, err)
-		}
-		if mapInfo.Type != ebpf.ProgramArray {
-			_ = m.Close()
-			continue
-		}
-
-		// Iterate PROG_ARRAY entries
-		var key, val uint32
-		iter := m.Iterate()
-		for iter.Next(&key, &val) {
-			progID := val
-			targetProg, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
-			if err != nil {
-				_ = m.Close()
-				return nil, fmt.Errorf("opening tail call target (id=%d): %w", progID, err)
-			}
-
-			targetInfo, err := targetProg.Info()
-			if err != nil {
-				_ = targetProg.Close()
-				_ = m.Close()
-				return nil, fmt.Errorf("getting tail call target info (id=%d): %w", progID, err)
-			}
-
-			targets = append(targets, TailCallTarget{
-				Index:    key,
-				ProgID:   progID,
-				ProgName: targetInfo.Name,
-			})
-			_ = targetProg.Close()
-		}
-		if err := iter.Err(); err != nil {
-			_ = m.Close()
-			return nil, fmt.Errorf("iterating program array map %d: %w", mapID, err)
-		}
+		found, err := scanMapForPrograms(m, mapID)
 		_ = m.Close()
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, found...)
 	}
 
 	return targets, nil
+}
+
+// scanMapForPrograms extracts program targets from a single map, routing
+// on its type. Non-dispatch maps yield nothing.
+func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
+	mapInfo, err := m.Info()
+	if err != nil {
+		return nil, fmt.Errorf("getting map %d info: %w", mapID, err)
+	}
+
+	switch mapInfo.Type {
+	case ebpf.ProgramArray:
+		return scanProgArray(m, mapID)
+	case ebpf.CPUMap:
+		return scanRedirectMap(m, mapID, "cpumap", mapInfo.ValueSize)
+	case ebpf.DevMap:
+		return scanRedirectMap(m, mapID, "devmap", mapInfo.ValueSize)
+	case ebpf.DevMapHash:
+		return scanRedirectMap(m, mapID, "devmap_hash", mapInfo.ValueSize)
+	default:
+		return nil, nil
+	}
+}
+
+// scanProgArray reads tail-call targets from a PROG_ARRAY. Values are the
+// target program IDs.
+func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
+	var targets []ProgTarget
+	var key, val uint32
+	iter := m.Iterate()
+	for iter.Next(&key, &val) {
+		t, err := resolveProgTarget("tailcall", key, val)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, *t)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("iterating program array map %d: %w", mapID, err)
+	}
+	return targets, nil
+}
+
+// scanRedirectMap reads the downstream XDP program attached to each
+// CPUMAP / DEVMAP entry. Both bpf_cpumap_val and bpf_devmap_val lay out
+// the attached program id as the u32 at offset 4 (a union bpf_prog after
+// a leading u32 qsize / ifindex). Maps created before that field existed
+// have a 4-byte value and carry no program.
+func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, valueSize uint32) ([]ProgTarget, error) {
+	const progIDOffset = 4
+	if valueSize < progIDOffset+4 {
+		return nil, nil
+	}
+
+	var targets []ProgTarget
+	var key uint32
+	val := make([]byte, valueSize)
+	iter := m.Iterate()
+	for iter.Next(&key, &val) {
+		progID := binary.NativeEndian.Uint32(val[progIDOffset : progIDOffset+4])
+		if progID == 0 {
+			continue // entry has no attached program
+		}
+		t, err := resolveProgTarget(via, key, progID)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, *t)
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("iterating %s map %d: %w", via, mapID, err)
+	}
+	return targets, nil
+}
+
+// resolveProgTarget opens the target program to read its name.
+func resolveProgTarget(via string, key, progID uint32) (*ProgTarget, error) {
+	targetProg, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
+	if err != nil {
+		return nil, fmt.Errorf("opening %s target (id=%d): %w", via, progID, err)
+	}
+	defer func() { _ = targetProg.Close() }()
+
+	targetInfo, err := targetProg.Info()
+	if err != nil {
+		return nil, fmt.Errorf("getting %s target info (id=%d): %w", via, progID, err)
+	}
+
+	return &ProgTarget{
+		Via:      via,
+		Key:      key,
+		ProgID:   progID,
+		ProgName: targetInfo.Name,
+	}, nil
 }
 
 // FuncInfo holds metadata about a BTF function in a BPF program.

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -212,11 +212,11 @@ func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 	case ebpf.ProgramArray:
 		return scanProgArray(m, mapID)
 	case ebpf.CPUMap:
-		return scanRedirectMap(m, mapID, "cpumap", mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "cpumap", mapInfo.KeySize, mapInfo.ValueSize)
 	case ebpf.DevMap:
-		return scanRedirectMap(m, mapID, "devmap", mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "devmap", mapInfo.KeySize, mapInfo.ValueSize)
 	case ebpf.DevMapHash:
-		return scanRedirectMap(m, mapID, "devmap_hash", mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "devmap_hash", mapInfo.KeySize, mapInfo.ValueSize)
 	default:
 		return nil, nil
 	}
@@ -250,22 +250,28 @@ func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 // the attached program id as the u32 at offset 4 (a union bpf_prog after
 // a leading u32 qsize / ifindex). Maps created before that field existed
 // have a 4-byte value and carry no program.
-func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, valueSize uint32) ([]ProgTarget, error) {
+//
+// CPUMAP, DEVMAP and DEVMAP_HASH all use 4-byte u32 keys (the kernel
+// enforces key_size == 4). The key and value are read as raw byte
+// buffers sized from the map info and decoded explicitly, so an
+// unexpected key/value width can't silently truncate or misread.
+func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSize uint32) ([]ProgTarget, error) {
 	const progIDOffset = 4
-	if valueSize < progIDOffset+4 {
+	if keySize < 4 || valueSize < progIDOffset+4 {
 		return nil, nil
 	}
 
 	var targets []ProgTarget
-	var key uint32
-	val := make([]byte, valueSize)
+	key := make([]byte, int(keySize))
+	val := make([]byte, int(valueSize))
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
 		progID := binary.NativeEndian.Uint32(val[progIDOffset : progIDOffset+4])
 		if progID == 0 {
 			continue // entry has no attached program
 		}
-		t, err := resolveProgTarget(via, key, progID)
+		mapKey := binary.NativeEndian.Uint32(key[:4])
+		t, err := resolveProgTarget(via, mapKey, progID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -1,8 +1,13 @@
 package attach
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
 )
 
 func TestFindXDPProgramNoInterface(t *testing.T) {
@@ -50,5 +55,179 @@ func TestValidateSubfuncNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "process_packet") {
 		t.Errorf("error should list available functions, got: %v", err)
+	}
+}
+
+// loadCPUMapProg loads an XDP program eligible to be attached to a CPUMAP
+// entry (expected_attach_type BPF_XDP_CPUMAP).
+func loadCPUMapProg(t *testing.T) *ebpf.Program {
+	t.Helper()
+	testutil.SkipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, testutil.XDPSubfuncSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+	spec.Programs["xdp_subfunc_test"].AttachType = ebpf.AttachXDPCPUMap
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"xdp_subfunc_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Skipf("loading CPUMAP XDP program (kernel may lack BPF_XDP_CPUMAP): %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Prog.Close() })
+	return objs.Prog
+}
+
+// TestScanRedirectMapCPUMap verifies that a downstream XDP program
+// attached to a CPUMAP entry is discovered via the redirect_map path.
+func TestScanRedirectMapCPUMap(t *testing.T) {
+	prog := loadCPUMapProg(t)
+
+	progInfo, err := prog.Info()
+	if err != nil {
+		t.Fatalf("prog info: %v", err)
+	}
+	wantID, ok := progInfo.ID()
+	if !ok {
+		t.Fatal("program has no ID")
+	}
+
+	// value layout: struct bpf_cpumap_val { u32 qsize; u32 bpf_prog.fd }
+	cpumap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.CPUMap,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Skipf("creating CPUMAP (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = cpumap.Close() })
+
+	val := make([]byte, 8)
+	binary.NativeEndian.PutUint32(val[0:4], 192) // qsize
+	binary.NativeEndian.PutUint32(val[4:8], uint32(prog.FD()))
+	if err := cpumap.Put(uint32(0), val); err != nil {
+		t.Skipf("populating CPUMAP with program (kernel may lack support): %v", err)
+	}
+
+	targets, err := scanMapForPrograms(cpumap, 0)
+	if err != nil {
+		t.Fatalf("scanMapForPrograms: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d: %+v", len(targets), targets)
+	}
+	got := targets[0]
+	if got.Via != "cpumap" {
+		t.Errorf("Via = %q, want cpumap", got.Via)
+	}
+	if got.Key != 0 {
+		t.Errorf("Key = %d, want 0", got.Key)
+	}
+	if got.ProgID != uint32(wantID) {
+		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
+	}
+}
+
+// TestScanRedirectMapSkipsEmptyEntry verifies that a CPUMAP entry with no
+// attached program (prog id 0) yields no target.
+func TestScanRedirectMapSkipsEmptyEntry(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	cpumap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.CPUMap,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Skipf("creating CPUMAP (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = cpumap.Close() })
+
+	val := make([]byte, 8)
+	binary.NativeEndian.PutUint32(val[0:4], 192) // qsize, no program
+	if err := cpumap.Put(uint32(0), val); err != nil {
+		t.Skipf("populating CPUMAP: %v", err)
+	}
+
+	targets, err := scanMapForPrograms(cpumap, 0)
+	if err != nil {
+		t.Fatalf("scanMapForPrograms: %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 targets for empty entry, got %d: %+v", len(targets), targets)
+	}
+}
+
+// TestListReachableProgramsCPUMap exercises the full discovery path: a
+// dispatcher XDP program references a CPUMAP, and ListReachablePrograms
+// walks prog.Info().MapIDs() to surface the downstream program attached
+// to that CPUMAP entry.
+func TestListReachableProgramsCPUMap(t *testing.T) {
+	down := loadCPUMapProg(t)
+	downInfo, err := down.Info()
+	if err != nil {
+		t.Fatalf("downstream prog info: %v", err)
+	}
+	wantID, ok := downInfo.ID()
+	if !ok {
+		t.Fatal("downstream program has no ID")
+	}
+
+	cpumap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.CPUMap,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Skipf("creating CPUMAP (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = cpumap.Close() })
+
+	val := make([]byte, 8)
+	binary.NativeEndian.PutUint32(val[0:4], 192) // qsize
+	binary.NativeEndian.PutUint32(val[4:8], uint32(down.FD()))
+	if err := cpumap.Put(uint32(0), val); err != nil {
+		t.Skipf("populating CPUMAP with program: %v", err)
+	}
+
+	// Minimal dispatcher: load the CPUMAP pointer (creating the used_map
+	// relationship that surfaces it in MapIDs), then XDP_PASS.
+	dispatcher, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R1, cpumap.FD()),
+			asm.Mov.Imm(asm.R0, 2), // XDP_PASS
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("loading dispatcher program: %v", err)
+	}
+	t.Cleanup(func() { _ = dispatcher.Close() })
+
+	targets, err := ListReachablePrograms(dispatcher)
+	if err != nil {
+		t.Fatalf("ListReachablePrograms: %v", err)
+	}
+
+	var found *ProgTarget
+	for i := range targets {
+		if targets[i].Via == "cpumap" && targets[i].ProgID == uint32(wantID) {
+			found = &targets[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("downstream cpumap program (id=%d) not discovered; got %+v", uint32(wantID), targets)
+	}
+	if found.Key != 0 {
+		t.Errorf("Key = %d, want 0", found.Key)
 	}
 }

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -310,3 +310,63 @@ func TestScanRedirectMapDevMap(t *testing.T) {
 		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
 	}
 }
+
+// TestScanRedirectMapDevMapHash covers the DEVMAP_HASH routing branch.
+// Like DEVMAP and CPUMAP, DEVMAP_HASH requires key_size == 4 (u32 keys),
+// so the shared uint32 iteration in scanRedirectMap applies. The value
+// layout (bpf_devmap_val) is identical to DEVMAP.
+func TestScanRedirectMapDevMapHash(t *testing.T) {
+	prog := loadDevMapProg(t)
+
+	progInfo, err := prog.Info()
+	if err != nil {
+		t.Fatalf("prog info: %v", err)
+	}
+	wantID, ok := progInfo.ID()
+	if !ok {
+		t.Fatal("program has no ID")
+	}
+
+	lo, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("looking up loopback: %v", err)
+	}
+
+	devmap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.DevMapHash,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 4,
+	})
+	if err != nil {
+		t.Skipf("creating DEVMAP_HASH (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = devmap.Close() })
+
+	val := make([]byte, 8)
+	binary.NativeEndian.PutUint32(val[0:4], uint32(lo.Index))
+	binary.NativeEndian.PutUint32(val[4:8], uint32(prog.FD()))
+	// DEVMAP_HASH keys are arbitrary u32; use a non-zero sparse key.
+	const key = uint32(42)
+	if err := devmap.Put(key, val); err != nil {
+		t.Skipf("populating DEVMAP_HASH with program (device may not support XDP): %v", err)
+	}
+
+	targets, err := scanMapForPrograms(devmap, 0)
+	if err != nil {
+		t.Fatalf("scanMapForPrograms: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d: %+v", len(targets), targets)
+	}
+	got := targets[0]
+	if got.Via != "devmap_hash" {
+		t.Errorf("Via = %q, want devmap_hash", got.Via)
+	}
+	if got.Key != key {
+		t.Errorf("Key = %d, want %d", got.Key, key)
+	}
+	if got.ProgID != uint32(wantID) {
+		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
+	}
+}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -391,7 +391,10 @@ func TestScanProgArraySkipsEmptySlot(t *testing.T) {
 		t.Fatalf("target prog: %v", err)
 	}
 	t.Cleanup(func() { _ = target.Close() })
-	tInfo, _ := target.Info()
+	tInfo, err := target.Info()
+	if err != nil {
+		t.Fatalf("target prog info: %v", err)
+	}
 	wantID, ok := tInfo.ID()
 	if !ok {
 		t.Fatal("target program has no ID")

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -370,3 +370,63 @@ func TestScanRedirectMapDevMapHash(t *testing.T) {
 		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
 	}
 }
+
+// TestScanProgArraySkipsEmptySlot verifies that a sparse PROG_ARRAY (only
+// some slots populated) does not abort discovery on the empty slots, which
+// enumerate as id 0.
+func TestScanProgArraySkipsEmptySlot(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	// A tiny XDP program to serve as the single populated tail-call target.
+	target, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "tc_target",
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 2), // XDP_PASS
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("target prog: %v", err)
+	}
+	t.Cleanup(func() { _ = target.Close() })
+	tInfo, _ := target.Info()
+	wantID, ok := tInfo.ID()
+	if !ok {
+		t.Fatal("target program has no ID")
+	}
+
+	progArray, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.ProgramArray,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 4, // slots 0,1,3 stay empty
+	})
+	if err != nil {
+		t.Skipf("creating PROG_ARRAY: %v", err)
+	}
+	t.Cleanup(func() { _ = progArray.Close() })
+
+	if err := progArray.Put(uint32(2), uint32(target.FD())); err != nil {
+		t.Skipf("populating PROG_ARRAY: %v", err)
+	}
+
+	targets, err := scanMapForPrograms(progArray, 0)
+	if err != nil {
+		t.Fatalf("scanMapForPrograms on sparse PROG_ARRAY: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d: %+v", len(targets), targets)
+	}
+	got := targets[0]
+	if got.Via != "tailcall" {
+		t.Errorf("Via = %q, want tailcall", got.Via)
+	}
+	if got.Key != 2 {
+		t.Errorf("Key = %d, want 2", got.Key)
+	}
+	if got.ProgID != uint32(wantID) {
+		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
+	}
+}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -2,6 +2,7 @@ package attach
 
 import (
 	"encoding/binary"
+	"net"
 	"strings"
 	"testing"
 
@@ -229,5 +230,83 @@ func TestListReachableProgramsCPUMap(t *testing.T) {
 	}
 	if found.Key != 0 {
 		t.Errorf("Key = %d, want 0", found.Key)
+	}
+}
+
+// loadDevMapProg loads an XDP program eligible to be attached to a DEVMAP
+// entry (expected_attach_type BPF_XDP_DEVMAP).
+func loadDevMapProg(t *testing.T) *ebpf.Program {
+	t.Helper()
+	testutil.SkipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, testutil.XDPSubfuncSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+	spec.Programs["xdp_subfunc_test"].AttachType = ebpf.AttachXDPDevMap
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"xdp_subfunc_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Skipf("loading DEVMAP XDP program (kernel may lack BPF_XDP_DEVMAP): %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Prog.Close() })
+	return objs.Prog
+}
+
+// TestScanRedirectMapDevMap verifies that a downstream XDP program attached
+// to a DEVMAP entry is discovered. The value layout (bpf_devmap_val) puts
+// the program id at the same offset 4 as CPUMAP; the entry targets the
+// loopback interface.
+func TestScanRedirectMapDevMap(t *testing.T) {
+	prog := loadDevMapProg(t)
+
+	progInfo, err := prog.Info()
+	if err != nil {
+		t.Fatalf("prog info: %v", err)
+	}
+	wantID, ok := progInfo.ID()
+	if !ok {
+		t.Fatal("program has no ID")
+	}
+
+	lo, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("looking up loopback: %v", err)
+	}
+
+	devmap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.DevMap,
+		KeySize:    4,
+		ValueSize:  8,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Skipf("creating DEVMAP (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = devmap.Close() })
+
+	// value layout: struct bpf_devmap_val { u32 ifindex; u32 bpf_prog.fd }
+	val := make([]byte, 8)
+	binary.NativeEndian.PutUint32(val[0:4], uint32(lo.Index))
+	binary.NativeEndian.PutUint32(val[4:8], uint32(prog.FD()))
+	if err := devmap.Put(uint32(0), val); err != nil {
+		t.Skipf("populating DEVMAP with program (device may not support XDP): %v", err)
+	}
+
+	targets, err := scanMapForPrograms(devmap, 0)
+	if err != nil {
+		t.Fatalf("scanMapForPrograms: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d: %+v", len(targets), targets)
+	}
+	got := targets[0]
+	if got.Via != "devmap" {
+		t.Errorf("Via = %q, want devmap", got.Via)
+	}
+	if got.ProgID != uint32(wantID) {
+		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
 	}
 }


### PR DESCRIPTION
## 概要

`--list-progs` を PROG_ARRAY (tail call) だけでなく、`bpf_redirect_map` の先である **CPUMAP / DEVMAP / DEVMAP_HASH** の下段 XDP プログラムも列挙するように拡張する。

interface に dispatcher 型の XDP プログラム (例: `cpu_dispatch`) が刺さっていて、そこから CPUMAP/DEVMAP へ redirect している場合、従来は下段で実際に走るプログラムが `--list-progs` に出ず、prog ID を手で bpftool から辿る必要があった。本 PR で下段まで一覧でき、拾った ID を `-p` に渡して post-redirect のパケットを capture できる。

## 変更点

- `internal/attach/attach.go`
  - `ListTailCallTargets` → `ListReachablePrograms` に汎用化
  - `TailCallTarget` → `ProgTarget{Via, Key, ProgID, ProgName}`
  - map 種別で分岐 (`scanProgArray` / `scanRedirectMap`)。`bpf_cpumap_val` / `bpf_devmap_val` の offset 4 から下段 prog id を読み、未アタッチ (id 0) や旧レイアウト (value_size < 8) はスキップ
- `cmd/xdp-ninja/main.go` — `--list-progs` 出力を `(<via>[<key>])` 形式に。Usage 文言も更新

## 出力例

```
$ sudo xdp-ninja -i ens2f0 --list-progs
id=1519   cpu_dispatch
id=1602   down_cpumap (cpumap[3])
$ sudo xdp-ninja -p 1602 'ipv4 ...'   # redirect 先を capture
```

## テスト

`internal/attach/attach_test.go` に BPF-gated テストを追加 (root で全 PASS):

- `TestScanRedirectMapCPUMap` — CPUMAP 値デコード
- `TestScanRedirectMapSkipsEmptyEntry` — 未アタッチ entry の skip
- `TestListReachableProgramsCPUMap` — e2e (dispatcher prog → `MapIDs()` → map 走査)
- `TestScanRedirectMapDevMap` — DEVMAP 経路 (loopback 宛 entry)

加えて、実 CLI バイナリで `cpu_dispatch → CPUMAP → 下段 prog` のチェーンをローカル再現し、`--list-progs` が下段を列挙・`-p` が下段に到達することを確認済み。

## スコープ外

- 自動追従 attach (`--follow-redirect`) は別 PR。本 PR は discovery のみ。
