### PR TITLE
feat(attach): follow redirect/tail-call chains transitively in --list-progs

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -63,7 +63,7 @@ var flags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:  "list-progs",
-		Usage: "list programs reachable from the target: tail calls + CPUMAP/DEVMAP redirect targets, then exit",
+		Usage: "list programs reachable from the target: tail calls + CPUMAP/DEVMAP/DEVMAP_HASH redirect targets (followed transitively), then exit",
 	},
 	&cli.StringSliceFlag{
 		Name:  "arg-filter",
@@ -371,17 +371,28 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	defer func() { _ = info.Program.Close() }()
 
 	// --list-progs: show reachable programs (tail calls +
-	// CPUMAP/DEVMAP redirect targets), then exit
+	// CPUMAP/DEVMAP/DEVMAP_HASH redirect targets, followed
+	// transitively), then exit
 	if cmd.Bool("list-progs") {
 		fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
 
-		targets, err := attach.ListReachablePrograms(info.Program)
+		progs, err := attach.WalkReachablePrograms(info.Program, info.ProgID)
 		if err != nil {
 			return err
 		}
-		for _, t := range targets {
-			fmt.Fprintf(os.Stderr, "id=%-6d %s (%s[%d])\n", t.ProgID, t.ProgName, t.Via, t.Key)
+		byParent := map[uint32][]attach.ReachableProgram{}
+		for _, p := range progs {
+			byParent[p.ParentID] = append(byParent[p.ParentID], p)
 		}
+		var printTree func(parent uint32, indent string)
+		printTree = func(parent uint32, indent string) {
+			for _, c := range byParent[parent] {
+				fmt.Fprintf(os.Stderr, "%sid=%-6d %s (%s[%s])\n",
+					indent, c.ProgID, c.ProgName, c.Via, formatKeyRanges(c.Keys))
+				printTree(c.ProgID, indent+"  ")
+			}
+		}
+		printTree(info.ProgID, "  ")
 		return nil
 	}
 
@@ -959,6 +970,32 @@ func loadProbe(isFexit bool, info *attach.ProgInfo, filterExpr string, argFilter
 	return program.LoadEntry(info.Program, info.FuncName, filterExpr, argFilters, useDSL)
 }
 
+
+// formatKeyRanges renders a sorted key list compactly, collapsing runs of
+// consecutive keys: [0,1,2,3] -> "0-3", [0,1,3,4,5] -> "0-1,3-5".
+func formatKeyRanges(keys []uint32) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	rng := func(a, b uint32) string {
+		if a == b {
+			return fmt.Sprintf("%d", a)
+		}
+		return fmt.Sprintf("%d-%d", a, b)
+	}
+	var parts []string
+	start, prev := keys[0], keys[0]
+	for _, k := range keys[1:] {
+		if k == prev+1 {
+			prev = k
+			continue
+		}
+		parts = append(parts, rng(start, prev))
+		start, prev = k, k
+	}
+	parts = append(parts, rng(start, prev))
+	return strings.Join(parts, ",")
+}
 
 func logVerbose(cmd *cli.Command, format string, args ...any) {
 	if cmd.Bool("verbose") {

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -4,6 +4,7 @@ package attach
 import (
 	"encoding/binary"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/cilium/ebpf"
@@ -183,13 +184,14 @@ func ListReachablePrograms(prog *ebpf.Program) ([]ProgTarget, error) {
 	}
 
 	var targets []ProgTarget
+	cache := progNameCache{}
 	for _, mapID := range mapIDs {
 		m, err := ebpf.NewMapFromID(mapID)
 		if err != nil {
 			return nil, fmt.Errorf("opening map %d: %w", mapID, err)
 		}
 
-		found, err := scanMapForPrograms(m, mapID)
+		found, err := scanMapForPrograms(m, mapID, cache)
 		_ = m.Close()
 		if err != nil {
 			return nil, fmt.Errorf("scanning map %d: %w", mapID, err)
@@ -200,9 +202,103 @@ func ListReachablePrograms(prog *ebpf.Program) ([]ProgTarget, error) {
 	return targets, nil
 }
 
+// ReachableProgram is a program reachable from a root program, deduped so
+// each program id appears once. Via/Keys/ParentID describe the first edge
+// that reached it; Depth is its distance from the root (root children are
+// depth 1). Keys collects every parent map key that reaches it (e.g. all
+// per-CPU CPUMAP slots), sorted ascending.
+type ReachableProgram struct {
+	ProgID   uint32
+	ProgName string
+	Via      string
+	Keys     []uint32
+	Depth    int
+	ParentID uint32
+}
+
+// WalkReachablePrograms transitively follows tail-call and redirect-map
+// edges from root, returning every reachable program deduped by id in
+// breadth-first order. This descends through multi-stage dispatchers (e.g.
+// cpu_dispatch -> CPUMAP -> entry_jump -> PROG_ARRAY -> handler), unlike
+// ListReachablePrograms which only reports the direct (one-hop) targets.
+// The root program is not closed; programs opened while descending are.
+func WalkReachablePrograms(root *ebpf.Program, rootID uint32) ([]ReachableProgram, error) {
+	type item struct {
+		id    uint32
+		prog  *ebpf.Program
+		depth int
+		owns  bool // close after scanning (children we opened by id)
+	}
+
+	visited := map[uint32]bool{rootID: true}
+	var out []ReachableProgram
+	queue := []item{{id: rootID, prog: root, depth: 0}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		targets, err := ListReachablePrograms(cur.prog)
+		if cur.owns {
+			_ = cur.prog.Close()
+		}
+		if err != nil {
+			return nil, fmt.Errorf("walking program id=%d: %w", cur.id, err)
+		}
+
+		for _, g := range groupTargets(targets) {
+			if visited[g.ProgID] {
+				continue
+			}
+			visited[g.ProgID] = true
+
+			g.Depth = cur.depth + 1
+			g.ParentID = cur.id
+			out = append(out, g)
+
+			child, err := ebpf.NewProgramFromID(ebpf.ProgramID(g.ProgID))
+			if err != nil {
+				continue // recorded, but can't descend into it
+			}
+			queue = append(queue, item{id: g.ProgID, prog: child, depth: cur.depth + 1, owns: true})
+		}
+	}
+
+	return out, nil
+}
+
+// groupTargets collapses one program's direct targets by (via, program id),
+// merging the map keys so a program reached through many slots (e.g. a
+// per-CPU CPUMAP) becomes a single entry with all keys.
+func groupTargets(targets []ProgTarget) []ReachableProgram {
+	type gk struct {
+		via string
+		id  uint32
+	}
+	var order []gk
+	byKey := map[gk]*ReachableProgram{}
+	for _, t := range targets {
+		k := gk{t.Via, t.ProgID}
+		g, ok := byKey[k]
+		if !ok {
+			g = &ReachableProgram{ProgID: t.ProgID, ProgName: t.ProgName, Via: t.Via}
+			byKey[k] = g
+			order = append(order, k)
+		}
+		g.Keys = append(g.Keys, t.Key)
+	}
+	out := make([]ReachableProgram, 0, len(order))
+	for _, k := range order {
+		g := byKey[k]
+		slices.Sort(g.Keys)
+		out = append(out, *g)
+	}
+	return out
+}
+
 // scanMapForPrograms extracts program targets from a single map, routing
 // on its type. Non-dispatch maps yield nothing.
-func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
+func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID, cache progNameCache) ([]ProgTarget, error) {
 	mapInfo, err := m.Info()
 	if err != nil {
 		return nil, fmt.Errorf("getting map %d info: %w", mapID, err)
@@ -210,13 +306,13 @@ func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 
 	switch mapInfo.Type {
 	case ebpf.ProgramArray:
-		return scanProgArray(m, mapID)
+		return scanProgArray(m, mapID, cache)
 	case ebpf.CPUMap:
-		return scanRedirectMap(m, mapID, "cpumap", mapInfo.KeySize, mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "cpumap", mapInfo.KeySize, mapInfo.ValueSize, cache)
 	case ebpf.DevMap:
-		return scanRedirectMap(m, mapID, "devmap", mapInfo.KeySize, mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "devmap", mapInfo.KeySize, mapInfo.ValueSize, cache)
 	case ebpf.DevMapHash:
-		return scanRedirectMap(m, mapID, "devmap_hash", mapInfo.KeySize, mapInfo.ValueSize)
+		return scanRedirectMap(m, mapID, "devmap_hash", mapInfo.KeySize, mapInfo.ValueSize, cache)
 	default:
 		return nil, nil
 	}
@@ -225,7 +321,7 @@ func scanMapForPrograms(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 // scanProgArray reads tail-call targets from a PROG_ARRAY. Values are the
 // target program IDs. Array-backed maps enumerate every slot, so unset
 // entries surface as id 0 and are skipped.
-func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
+func scanProgArray(m *ebpf.Map, mapID ebpf.MapID, cache progNameCache) ([]ProgTarget, error) {
 	var targets []ProgTarget
 	var key, val uint32
 	iter := m.Iterate()
@@ -233,7 +329,7 @@ func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 		if val == 0 {
 			continue // empty tail-call slot
 		}
-		t, err := resolveProgTarget("tailcall", key, val)
+		t, err := resolveProgTarget("tailcall", key, val, cache)
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +351,7 @@ func scanProgArray(m *ebpf.Map, mapID ebpf.MapID) ([]ProgTarget, error) {
 // enforces key_size == 4); any other key width is an unexpected layout we
 // don't decode. The value is read as a byte buffer sized from map info so
 // a shorter (pre-attached-program) layout carries no program.
-func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSize uint32) ([]ProgTarget, error) {
+func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSize uint32, cache progNameCache) ([]ProgTarget, error) {
 	const progIDOffset = 4
 	if keySize != 4 || valueSize < progIDOffset+4 {
 		return nil, nil
@@ -270,7 +366,7 @@ func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSi
 		if progID == 0 {
 			continue // entry has no attached program
 		}
-		t, err := resolveProgTarget(via, key, progID)
+		t, err := resolveProgTarget(via, key, progID, cache)
 		if err != nil {
 			return nil, err
 		}
@@ -282,24 +378,41 @@ func scanRedirectMap(m *ebpf.Map, mapID ebpf.MapID, via string, keySize, valueSi
 	return targets, nil
 }
 
-// resolveProgTarget opens the target program to read its name.
-func resolveProgTarget(via string, key, progID uint32) (*ProgTarget, error) {
-	targetProg, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
-	if err != nil {
-		return nil, fmt.Errorf("opening %s target (id=%d): %w", via, progID, err)
-	}
-	defer func() { _ = targetProg.Close() }()
+// progNameCache memoizes program id -> name so a single scan doesn't
+// re-open the same program once per map entry. Maps that point many keys
+// at one program (per-CPU CPUMAPs, repeated tail-call slots) otherwise
+// cost one bpf_prog_get_fd_by_id + BPF_OBJ_GET_INFO syscall pair each.
+type progNameCache map[uint32]string
 
-	targetInfo, err := targetProg.Info()
-	if err != nil {
-		return nil, fmt.Errorf("getting %s target info (id=%d): %w", via, progID, err)
+func (c progNameCache) name(progID uint32) (string, error) {
+	if n, ok := c[progID]; ok {
+		return n, nil
 	}
+	prog, err := ebpf.NewProgramFromID(ebpf.ProgramID(progID))
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = prog.Close() }()
 
+	info, err := prog.Info()
+	if err != nil {
+		return "", err
+	}
+	c[progID] = info.Name
+	return info.Name, nil
+}
+
+// resolveProgTarget resolves the target program's name (via the cache).
+func resolveProgTarget(via string, key, progID uint32, cache progNameCache) (*ProgTarget, error) {
+	name, err := cache.name(progID)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %s target (id=%d): %w", via, progID, err)
+	}
 	return &ProgTarget{
 		Via:      via,
 		Key:      key,
 		ProgID:   progID,
-		ProgName: targetInfo.Name,
+		ProgName: name,
 	}, nil
 }
 

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -2,6 +2,7 @@ package attach
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -114,7 +115,7 @@ func TestScanRedirectMapCPUMap(t *testing.T) {
 		t.Skipf("populating CPUMAP with program (kernel may lack support): %v", err)
 	}
 
-	targets, err := scanMapForPrograms(cpumap, 0)
+	targets, err := scanMapForPrograms(cpumap, 0, progNameCache{})
 	if err != nil {
 		t.Fatalf("scanMapForPrograms: %v", err)
 	}
@@ -155,7 +156,7 @@ func TestScanRedirectMapSkipsEmptyEntry(t *testing.T) {
 		t.Skipf("populating CPUMAP: %v", err)
 	}
 
-	targets, err := scanMapForPrograms(cpumap, 0)
+	targets, err := scanMapForPrograms(cpumap, 0, progNameCache{})
 	if err != nil {
 		t.Fatalf("scanMapForPrograms: %v", err)
 	}
@@ -295,7 +296,7 @@ func TestScanRedirectMapDevMap(t *testing.T) {
 		t.Skipf("populating DEVMAP with program (device may not support XDP): %v", err)
 	}
 
-	targets, err := scanMapForPrograms(devmap, 0)
+	targets, err := scanMapForPrograms(devmap, 0, progNameCache{})
 	if err != nil {
 		t.Fatalf("scanMapForPrograms: %v", err)
 	}
@@ -352,7 +353,7 @@ func TestScanRedirectMapDevMapHash(t *testing.T) {
 		t.Skipf("populating DEVMAP_HASH with program (device may not support XDP): %v", err)
 	}
 
-	targets, err := scanMapForPrograms(devmap, 0)
+	targets, err := scanMapForPrograms(devmap, 0, progNameCache{})
 	if err != nil {
 		t.Fatalf("scanMapForPrograms: %v", err)
 	}
@@ -415,7 +416,7 @@ func TestScanProgArraySkipsEmptySlot(t *testing.T) {
 		t.Skipf("populating PROG_ARRAY: %v", err)
 	}
 
-	targets, err := scanMapForPrograms(progArray, 0)
+	targets, err := scanMapForPrograms(progArray, 0, progNameCache{})
 	if err != nil {
 		t.Fatalf("scanMapForPrograms on sparse PROG_ARRAY: %v", err)
 	}
@@ -431,5 +432,229 @@ func TestScanProgArraySkipsEmptySlot(t *testing.T) {
 	}
 	if got.ProgID != uint32(wantID) {
 		t.Errorf("ProgID = %d, want %d", got.ProgID, uint32(wantID))
+	}
+}
+
+// TestWalkReachableProgramsTransitive builds a two-stage dispatch chain
+// (dispatcher -> CPUMAP -> mid -> PROG_ARRAY -> leaf) and verifies the
+// walk descends through both hops, deduping and assigning depths.
+func TestWalkReachableProgramsTransitive(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	// leaf: final tail-call target.
+	leaf, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name:         "leaf_prog",
+		Type:         ebpf.XDP,
+		Instructions: asm.Instructions{asm.Mov.Imm(asm.R0, 2), asm.Return()},
+		License:      "GPL",
+	})
+	if err != nil {
+		t.Fatalf("leaf prog: %v", err)
+	}
+	t.Cleanup(func() { _ = leaf.Close() })
+	leafInfo, _ := leaf.Info()
+	leafID, ok := leafInfo.ID()
+	if !ok {
+		t.Fatal("leaf has no ID")
+	}
+
+	progArray, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type: ebpf.ProgramArray, KeySize: 4, ValueSize: 4, MaxEntries: 4,
+	})
+	if err != nil {
+		t.Skipf("prog array: %v", err)
+	}
+	t.Cleanup(func() { _ = progArray.Close() })
+	if err := progArray.Put(uint32(1), uint32(leaf.FD())); err != nil {
+		t.Skipf("prog array put: %v", err)
+	}
+
+	// mid: a CPUMAP-eligible program that references the PROG_ARRAY.
+	mid, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name:       "mid_jump",
+		Type:       ebpf.XDP,
+		AttachType: ebpf.AttachXDPCPUMap,
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R1, progArray.FD()),
+			asm.Mov.Imm(asm.R0, 2),
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Skipf("mid prog (kernel may lack BPF_XDP_CPUMAP): %v", err)
+	}
+	t.Cleanup(func() { _ = mid.Close() })
+	midInfo, _ := mid.Info()
+	midID, ok := midInfo.ID()
+	if !ok {
+		t.Fatal("mid has no ID")
+	}
+
+	cpumap, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type: ebpf.CPUMap, KeySize: 4, ValueSize: 8, MaxEntries: 2,
+	})
+	if err != nil {
+		t.Skipf("cpumap: %v", err)
+	}
+	t.Cleanup(func() { _ = cpumap.Close() })
+	cval := make([]byte, 8)
+	binary.NativeEndian.PutUint32(cval[0:4], 192)
+	binary.NativeEndian.PutUint32(cval[4:8], uint32(mid.FD()))
+	// two slots -> same mid prog, must collapse to one entry.
+	if err := cpumap.Put(uint32(0), cval); err != nil {
+		t.Skipf("cpumap put: %v", err)
+	}
+	if err := cpumap.Put(uint32(1), cval); err != nil {
+		t.Skipf("cpumap put: %v", err)
+	}
+
+	dispatcher, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "root_dispatch",
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R1, cpumap.FD()),
+			asm.Mov.Imm(asm.R0, 2),
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("dispatcher prog: %v", err)
+	}
+	t.Cleanup(func() { _ = dispatcher.Close() })
+	dInfo, _ := dispatcher.Info()
+	dID, _ := dInfo.ID()
+
+	progs, err := WalkReachablePrograms(dispatcher, uint32(dID))
+	if err != nil {
+		t.Fatalf("WalkReachablePrograms: %v", err)
+	}
+
+	byID := map[uint32]ReachableProgram{}
+	for _, p := range progs {
+		byID[p.ProgID] = p
+	}
+
+	m, ok := byID[uint32(midID)]
+	if !ok {
+		t.Fatalf("mid (id=%d) not reached; got %+v", uint32(midID), progs)
+	}
+	if m.Via != "cpumap" || m.Depth != 1 || m.ParentID != uint32(dID) {
+		t.Errorf("mid edge = %+v, want via=cpumap depth=1 parent=%d", m, uint32(dID))
+	}
+	if len(m.Keys) != 2 || m.Keys[0] != 0 || m.Keys[1] != 1 {
+		t.Errorf("mid keys = %v, want [0 1] (collapsed CPUMAP slots)", m.Keys)
+	}
+
+	l, ok := byID[uint32(leafID)]
+	if !ok {
+		t.Fatalf("leaf (id=%d) not reached transitively; got %+v", uint32(leafID), progs)
+	}
+	if l.Via != "tailcall" || l.Depth != 2 || l.ParentID != uint32(midID) {
+		t.Errorf("leaf edge = %+v, want via=tailcall depth=2 parent=%d", l, uint32(midID))
+	}
+}
+
+// tailProgVia builds a tiny XDP program that references map m (so m shows
+// up in its MapIDs), used to chain tail-call stages in tests.
+func tailProgVia(t *testing.T, name string, m *ebpf.Map) *ebpf.Program {
+	t.Helper()
+	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: name,
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R1, m.FD()),
+			asm.Mov.Imm(asm.R0, 2),
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("prog %s: %v", name, err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func newProgArray(t *testing.T) *ebpf.Map {
+	t.Helper()
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type: ebpf.ProgramArray, KeySize: 4, ValueSize: 4, MaxEntries: 4,
+	})
+	if err != nil {
+		t.Skipf("prog array: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+// TestWalkReachableProgramsDeepChain proves the walk has no depth cap: a
+// 5-stage tail-call chain (root -> p1 -> p2 -> p3 -> p4 -> p5) is fully
+// discovered, each at the expected depth.
+func TestWalkReachableProgramsDeepChain(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	const stages = 5
+
+	// Build from the leaf backwards so each stage can reference the map
+	// holding the already-loaded next stage.
+	leafArray := newProgArray(t)
+	leaf, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name:         "stage5",
+		Type:         ebpf.XDP,
+		Instructions: asm.Instructions{asm.Mov.Imm(asm.R0, 2), asm.Return()},
+		License:      "GPL",
+	})
+	if err != nil {
+		t.Fatalf("leaf: %v", err)
+	}
+	t.Cleanup(func() { _ = leaf.Close() })
+	if err := leafArray.Put(uint32(0), uint32(leaf.FD())); err != nil {
+		t.Skipf("leaf array put: %v", err)
+	}
+
+	// wantDepth[progID] = expected depth from root.
+	wantDepth := map[uint32]int{}
+	li, _ := leaf.Info()
+	if id, ok := li.ID(); ok {
+		wantDepth[uint32(id)] = stages
+	}
+
+	// next stage references the current stage's array; wire successively.
+	curArray := leafArray
+	for s := stages - 1; s >= 1; s-- {
+		prog := tailProgVia(t, fmt.Sprintf("stage%d", s), curArray)
+		pi, _ := prog.Info()
+		if id, ok := pi.ID(); ok {
+			wantDepth[uint32(id)] = s
+		}
+		arr := newProgArray(t)
+		if err := arr.Put(uint32(1), uint32(prog.FD())); err != nil {
+			t.Skipf("stage%d array put: %v", s, err)
+		}
+		curArray = arr
+	}
+
+	root := tailProgVia(t, "stage0_root", curArray)
+	ri, _ := root.Info()
+	rootID, _ := ri.ID()
+
+	progs, err := WalkReachablePrograms(root, uint32(rootID))
+	if err != nil {
+		t.Fatalf("WalkReachablePrograms: %v", err)
+	}
+
+	gotDepth := map[uint32]int{}
+	for _, p := range progs {
+		gotDepth[p.ProgID] = p.Depth
+	}
+	if len(gotDepth) != stages {
+		t.Fatalf("discovered %d programs, want %d: %+v", len(gotDepth), stages, progs)
+	}
+	for id, want := range wantDepth {
+		if gotDepth[id] != want {
+			t.Errorf("prog id=%d depth = %d, want %d", id, gotDepth[id], want)
+		}
 	}
 }


### PR DESCRIPTION
## 概要

PR #47 は推移探索のフォローアップコミットが乗る前の状態で squash マージされてしまい、リリース済み v0.12.0 の `--list-progs` は「1ホップ + 直下 redirect」までしか辿れない。多段 dispatcher (cpu_dispatch → CPUMAP → entry_jump → PROG_ARRAY → handler) の実ハンドラに到達できない状態。

本 PR で取りこぼした推移探索を main に載せ直す。

## 変更点

- `WalkReachablePrograms`: tail-call / redirect-map エッジを **深さ制限なしの BFS** で辿り、プログラム単位で dedup。depth/parent を持たせて CLI が tree 表示。
- `groupTargets` でプログラム単位にキーを集約、`formatKeyRanges` で範囲表示 (`cpumap[0-15]`)。
- `progNameCache` で prog id → name を 1 回だけ解決 (16 スロット per-CPU CPUMAP でも 1 open)。
- `--list-progs` の help text / コメントに DEVMAP_HASH を明記。

## 出力例

```
id=1564   cpu_dispatch
  id=1568  pgwu_entry_jump (cpumap[0-15])
    id=1601  handler (tailcall[2])
```

## テスト

`internal/attach/attach_test.go` に追加 (root で全 PASS):
- `TestWalkReachableProgramsTransitive` — 2段 (CPUMAP → PROG_ARRAY) 降下・dedup・キー集約
- `TestWalkReachableProgramsDeepChain` — 5段 tail-call チェーンで深さ制限なしを実証

`make test` / `go vet` / `golangci-lint` (0 issues) / lefthook 全 green。

## 経緯

推移探索・キャッシュ・DEVMAP_HASH doc は元々 #47 のブランチに実装・レビュー済みだったが、squash マージが古い HEAD (`8d003e7`) を取り込んだため main に届かなかった。本 PR はその差分のみ。
