### PR TITLE
fix(capture): round per-shard ringbuf size to a power of two

### DIFF
--- a/internal/program/sharded_ringbuf.go
+++ b/internal/program/sharded_ringbuf.go
@@ -10,6 +10,7 @@ package program
 
 import (
 	"fmt"
+	"math/bits"
 	"runtime"
 	"sync"
 
@@ -17,14 +18,27 @@ import (
 	"github.com/cilium/ebpf/asm"
 )
 
+// shardRingbufSize returns the per-shard BPF ringbuf byte size for a total
+// budget split across numCPUs shards. A BPF_MAP_TYPE_RINGBUF requires its
+// byte size to be a power of two (and a multiple of PAGE_SIZE; any power of
+// two >= 4096 satisfies that), so an even division like 4 MiB / 6 =
+// 699050 is rejected by the kernel. Floor each shard at 64 KiB, then round
+// down to the nearest power of two so the size is always valid regardless
+// of CPU count.
+func shardRingbufSize(total uint32, numCPUs int) uint32 {
+	perShard := max(total/uint32(numCPUs), 65536)
+	return uint32(1) << (bits.Len32(perShard) - 1)
+}
+
 // createShardedRingbuf builds the outer ARRAY_OF_MAPS + per-CPU inner
 // RingBuf pair used by every attach mode. label is a short prefix
 // ("xdp", "entry", "exit") that shows up in the map name for bpftool
 // readability.
 //
-// Total ringbuf capacity = RingbufSize MiB split evenly across CPUs,
-// floored at 64 KiB per shard so we always have at least one page of
-// data area on systems with > 1024 CPUs.
+// Total ringbuf capacity = RingbufSize split evenly across CPUs, floored
+// at 64 KiB per shard and rounded down to a power of two (see
+// shardRingbufSize) so the per-shard size is a valid BPF ringbuf byte
+// size on any CPU count, not just powers of two.
 //
 // On error the caller receives no half-built state: any inner created
 // before the failure is closed before returning. Inner maps are
@@ -32,7 +46,7 @@ import (
 // 100s-of-µs range; 64 CPUs serial takes ~tens of ms.
 func createShardedRingbuf(label string) (outer *ebpf.Map, inners []*ebpf.Map, err error) {
 	numCPUs := runtime.NumCPU()
-	innerSize := max(RingbufSize/uint32(numCPUs), 65536)
+	innerSize := shardRingbufSize(RingbufSize, numCPUs)
 	innerSpec := &ebpf.MapSpec{
 		Name: fmt.Sprintf("ninja_%s_rb_in", label), Type: ebpf.RingBuf, MaxEntries: innerSize,
 	}

--- a/internal/program/sharded_ringbuf_test.go
+++ b/internal/program/sharded_ringbuf_test.go
@@ -1,0 +1,65 @@
+package program
+
+import (
+	"math/bits"
+	"testing"
+)
+
+// isValidRingbufSize mirrors the kernel constraint on BPF_MAP_TYPE_RINGBUF
+// byte size: a power of two that is also a multiple of the page size (any
+// power of two >= 4096 satisfies both).
+func isValidRingbufSize(sz uint32) bool {
+	return sz >= 4096 && bits.OnesCount32(sz) == 1
+}
+
+func TestShardRingbufSize(t *testing.T) {
+	cases := []struct {
+		total   uint32
+		numCPUs int
+		want    uint32
+	}{
+		// 4 MiB / 6 = 699050 (the reported failure) -> round down to 512 KiB.
+		{4 * 1024 * 1024, 6, 512 * 1024},
+		// power-of-two CPU count divides cleanly.
+		{64 * 1024 * 1024, 8, 8 * 1024 * 1024},
+		{64 * 1024 * 1024, 16, 4 * 1024 * 1024},
+		// already a power of two per shard stays put.
+		{8 * 1024 * 1024, 4, 2 * 1024 * 1024},
+		// odd CPU counts.
+		{16 * 1024 * 1024, 3, 4 * 1024 * 1024}, // 5.33 MiB -> 4 MiB
+		{16 * 1024 * 1024, 12, 1024 * 1024},    // 1.33 MiB -> 1 MiB
+		// tiny budget / huge CPU count floors at 64 KiB.
+		{1 * 1024 * 1024, 4096, 64 * 1024},
+	}
+
+	for _, c := range cases {
+		got := shardRingbufSize(c.total, c.numCPUs)
+		if got != c.want {
+			t.Errorf("shardRingbufSize(%d, %d) = %d, want %d", c.total, c.numCPUs, got, c.want)
+		}
+		if !isValidRingbufSize(got) {
+			t.Errorf("shardRingbufSize(%d, %d) = %d is not a valid ringbuf size", c.total, c.numCPUs, got)
+		}
+	}
+}
+
+// TestShardRingbufSizeAlwaysValid sweeps every plausible CPU count against
+// several budgets and asserts the result is always a kernel-valid ringbuf
+// size, guarding against the "not a multiple of page size" regression.
+func TestShardRingbufSizeAlwaysValid(t *testing.T) {
+	budgets := []uint32{
+		1 * 1024 * 1024,
+		4 * 1024 * 1024,
+		16 * 1024 * 1024,
+		64 * 1024 * 1024,
+		256 * 1024 * 1024,
+	}
+	for _, total := range budgets {
+		for cpus := 1; cpus <= 512; cpus++ {
+			got := shardRingbufSize(total, cpus)
+			if !isValidRingbufSize(got) {
+				t.Fatalf("shardRingbufSize(%d, %d) = %d is not a valid ringbuf size", total, cpus, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 問題

CPU 数が 2 のべき乗でないホストで attach 時に失敗する:

```
error: creating inner ringbuf 0: creating map: map create: invalid argument
(ring map size 699050 not a multiple of page size 4096)
```

`createShardedRingbuf` が per-shard サイズを `RingbufSize / numCPUs` の生の商で決めており、`4 MiB / 6 = 699050` のように **2 のべき乗でもページ倍数でもない**値になる。BPF_MAP_TYPE_RINGBUF は byte size が 2 のべき乗 (かつ PAGE_SIZE の倍数) である必要があるため kernel が弾く。8/16 コアなど 2 べきの機では割り切れて偶然通っていた潜在バグ。

## 修正

`shardRingbufSize(total, numCPUs)` を追加:
- 各 shard を 64 KiB で floor
- **2 のべき乗に切り下げ** (4096 以上の 2 べきはページ倍数も満たす)

これで CPU 数によらず常に有効サイズ。2 べきコア数は挙動不変。

## テスト

- `TestShardRingbufSize` — 報告ケース (4 MiB / 6 → 512 KiB) 含む表テスト
- `TestShardRingbufSizeAlwaysValid` — 5 種の budget × CPU 数 1..512 を総当たりし、結果が常に kernel 有効サイズ (2 べき ≥ 4096) であることを保証

root 不要 (純関数)。BPF ロードパス (TestBpfEntryLoad/ExitLoad/XDPNativeLoad) も root で PASS 確認済み。
