### PR TITLE
feat(capture): merge per-CPU shards into a single pcap-ng file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,16 +108,18 @@ sudo xdp-ninja --cbpf -i eth0 "host 10.0.0.1 and tcp port 80"
 
 ### Sharded output
 
-For high-rate captures, xdp-ninja uses a per-CPU sharded ringbuf and writes one pcap-ng file per CPU. With `-w capture.pcap`:
+For high-rate captures, xdp-ninja uses a per-CPU sharded ringbuf and each CPU writes its own pcap-ng file with no lock. With `-w capture.pcap`:
 
 ```
-capture.pcap          # SHB+IDB marker (0 packets — for single-file consumers)
-capture.pcap.cpu0     # CPU 0 packets
-capture.pcap.cpu1     # CPU 1 packets
+capture.pcap          # all shards merged, time-ordered (ready to use)
+capture.pcap.cpu0     # CPU 0 packets (kept)
+capture.pcap.cpu1     # CPU 1 packets (kept)
 ...
 ```
 
-Read a single shard with `tcpdump -r capture.pcap.cpu0`, or merge all shards with `mergecap -w merged.pcap capture.pcap.cpu*` (from the Wireshark toolkit). `xdp-ninja convert` handles `--raw-dump` `.raw` shards, not pcap-ng shards.
+When capture stops (Ctrl-C or `-c`), xdp-ninja merges the per-CPU shards into `capture.pcap` as a single time-ordered pcap-ng, so the base path is ready to open directly (`tcpdump -r capture.pcap`). The `.cpuN` shards are left in place; you can also read one with `tcpdump -r capture.pcap.cpu0` or merge them yourself with `mergecap -w merged.pcap capture.pcap.cpu*`. `xdp-ninja convert` handles `--raw-dump` `.raw` shards, not pcap-ng shards.
+
+Without `-w` (streaming to stdout), all CPUs are merged into a single pcap-ng stream (serialized), so `sudo xdp-ninja ... | tcpdump -r -` shows every core's packets. Use `-w` for high-rate captures — stdout serialization is for the interactive path.
 
 ### Performance flags (high-rate captures)
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -530,15 +530,28 @@ func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label 
 	if len(probe.InnerMaps) == 0 {
 		return fmt.Errorf("probe has no inner ringbufs — sharded ringbuf hoist (R22) should populate them for every attach mode")
 	}
-	// Create a base-path SHB-only marker file when -w is set, so
-	// downstream tools that expect a single file at that path see a
-	// readable pcap-ng even though packets land in per-CPU shards.
-	writer, err := output.NewWriter(cmd.String("write"), isFexit)
-	if err != nil {
+	if err := captureLoopSharded(cmd, probe.InnerMaps, isFexit, label); err != nil {
 		return err
 	}
-	_ = writer.Close()
-	return captureLoopSharded(cmd, probe.InnerMaps, isFexit, label)
+
+	// After capture, merge the per-CPU shard files into a single
+	// time-ordered pcap-ng at the base path, so `-w out.pcap` yields one
+	// ready-to-use file (the .cpuN shards are left in place). Only the
+	// normal pcap path produces shard files; --raw-dump has its own
+	// offline `convert`, --null-output writes nothing, and stdout is
+	// already a single merged stream.
+	basePath := cmd.String("write")
+	if basePath != "" && !cmd.Bool("raw-dump") && !cmd.Bool("null-output") {
+		// captureLoopSharded returns on Ctrl-C (or -c). Announce the
+		// post-capture merge so the pause isn't mistaken for a hang.
+		fmt.Fprintf(os.Stderr, "merging %d shard(s) into %s ...\n", len(probe.InnerMaps), basePath)
+		if err := output.MergeShardFiles(basePath, len(probe.InnerMaps), isFexit); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: merging shards into %s: %v\n", basePath, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "merged into %s (per-CPU .cpuN kept)\n", basePath)
+		}
+	}
+	return nil
 }
 
 // captureLoopSharded: per-CPU shard goroutines, each writes to its
@@ -552,28 +565,63 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 		return captureLoopShardedRaw(cmd, inners, label, basePath)
 	}
 
+	// stdout (no -w) merges every shard into a single pcap-ng stream,
+	// serialized by sharedMu so no per-core packets are dropped. With -w
+	// each shard writes its own mutex-free .cpuN file (the high-throughput
+	// path); merge offline with mergecap.
+	stdoutMerge := basePath == "" && !null
+
 	writers := make([]*output.Writer, len(inners))
+	var sharedW *output.Writer
+	var sharedMu sync.Mutex
 	if !null {
-		for i := range inners {
-			var path string
-			if basePath != "" {
-				path = fmt.Sprintf("%s.cpu%d", basePath, i)
-			} else if i > 0 {
-				continue
-			}
-			w, err := output.NewWriter(path, isFexit)
+		if stdoutMerge {
+			w, err := output.NewWriter("", isFexit)
 			if err != nil {
-				return fmt.Errorf("opening per-CPU writer %d: %w", i, err)
+				return fmt.Errorf("opening stdout writer: %w", err)
 			}
-			writers[i] = w
-		}
-		defer func() {
-			for _, w := range writers {
-				if w != nil {
-					_ = w.Close()
+			sharedW = w
+		} else {
+			for i := range inners {
+				w, err := output.NewWriter(fmt.Sprintf("%s.cpu%d", basePath, i), isFexit)
+				if err != nil {
+					return fmt.Errorf("opening per-CPU writer %d: %w", i, err)
 				}
+				writers[i] = w
 			}
-		}()
+		}
+	}
+	defer func() {
+		if sharedW != nil {
+			_ = sharedW.Close()
+		}
+		for _, w := range writers {
+			if w != nil {
+				_ = w.Close()
+			}
+		}
+	}()
+
+	// Pick the write strategy once: null = drop, stdout = one writer
+	// serialized by sharedMu, -w = mutex-free per-CPU writer. Keeps the
+	// shared/per-CPU/null distinction out of the per-batch hot path.
+	var writeShard func(shardIdx int, pkts []capture.Packet) error
+	switch {
+	case null:
+		writeShard = func(int, []capture.Packet) error { return nil }
+	case sharedW != nil:
+		writeShard = func(_ int, pkts []capture.Packet) error {
+			sharedMu.Lock()
+			defer sharedMu.Unlock()
+			return sharedW.WriteBatch(pkts)
+		}
+	default:
+		writeShard = func(shardIdx int, pkts []capture.Packet) error {
+			if writers[shardIdx] != nil {
+				return writers[shardIdx].WriteBatch(pkts)
+			}
+			return nil
+		}
 	}
 
 	fastReader := cmd.Bool("fast-reader")
@@ -586,13 +634,11 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 		if count > 0 && captured.Load() >= count {
 			return nil
 		}
-		if !null && writers[shardIdx] != nil {
-			if err := writers[shardIdx].WriteBatch(pkts); err != nil {
-				writeErrCount.Add(1)
-				if firstWriteErr.Load() == nil {
-					msg := fmt.Sprintf("shard %d: %v", shardIdx, err)
-					firstWriteErr.CompareAndSwap(nil, &msg)
-				}
+		if err := writeShard(shardIdx, pkts); err != nil {
+			writeErrCount.Add(1)
+			if firstWriteErr.Load() == nil {
+				msg := fmt.Sprintf("shard %d: %v", shardIdx, err)
+				firstWriteErr.CompareAndSwap(nil, &msg)
 			}
 		}
 		captured.Add(int64(len(pkts)))

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -574,6 +574,18 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 	writers := make([]*output.Writer, len(inners))
 	var sharedW *output.Writer
 	var sharedMu sync.Mutex
+	// Registered before opening any writer so a mid-loop open failure still
+	// closes the writers already created (no fd leak on partial setup).
+	defer func() {
+		if sharedW != nil {
+			_ = sharedW.Close()
+		}
+		for _, w := range writers {
+			if w != nil {
+				_ = w.Close()
+			}
+		}
+	}()
 	if !null {
 		if stdoutMerge {
 			w, err := output.NewWriter("", isFexit)
@@ -591,16 +603,6 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 			}
 		}
 	}
-	defer func() {
-		if sharedW != nil {
-			_ = sharedW.Close()
-		}
-		for _, w := range writers {
-			if w != nil {
-				_ = w.Close()
-			}
-		}
-	}()
 
 	// Pick the write strategy once: null = drop, stdout = one writer
 	// serialized by sharedMu, -w = mutex-free per-CPU writer. Keeps the

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -515,12 +515,10 @@ func resolveFilterSyntax(cmd *cli.Command) (useDSL bool, err error) {
 // sharded path is the only live path; captureLoopSharded owns the
 // per-shard writer lifecycle.
 //
-// We still call output.NewWriter(basePath, isFexit) here to ensure
-// the base path exists as a valid (SHB-only) pcap-ng file. Single-
-// file consumers (`tcpdump -r out.pcap`) point at the base path; the
-// per-CPU `.cpuN` companions hold the actual packets and are merged
-// offline via `xdp-ninja convert`. Integration tests
-// (run_pcap_test) rely on the base file's existence.
+// For `-w path`, packets land in per-CPU `path.cpuN` shard files during
+// capture; afterward output.MergeShardFiles merges them into a single
+// time-ordered pcap-ng at `path` (the shards are left in place). Integration
+// tests (run_pcap_test) read the `.cpuN` shards.
 func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label string) error {
 	defer func() {
 		if cerr := probe.Close(); cerr != nil {
@@ -554,9 +552,11 @@ func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label 
 	return nil
 }
 
-// captureLoopSharded: per-CPU shard goroutines, each writes to its
-// own pcap file (no mutex). --null-output skips file writes for
-// benchmarking; --raw-dump switches to the raw-bytes path.
+// captureLoopSharded: per-CPU shard goroutines. With -w each shard writes
+// its own .cpuN pcap file with no mutex (the high-throughput path); to
+// stdout all shards funnel into one writer serialized by a mutex.
+// --null-output skips file writes for benchmarking; --raw-dump switches to
+// the raw-bytes path.
 func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, label string) error {
 	basePath := cmd.String("write")
 	null := cmd.Bool("null-output")

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -568,7 +568,7 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 	// stdout (no -w) merges every shard into a single pcap-ng stream,
 	// serialized by sharedMu so no per-core packets are dropped. With -w
 	// each shard writes its own mutex-free .cpuN file (the high-throughput
-	// path); merge offline with mergecap.
+	// path); runCaptureLoop merges those into the base path after capture.
 	stdoutMerge := basePath == "" && !null
 
 	writers := make([]*output.Writer, len(inners))

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -396,27 +396,29 @@ DSL / tcpdump の両方とも `--mode xdp` で完全に load 可能です。kuna
 R22 以降、ringbuf は per-CPU shard (`BPF_MAP_TYPE_ARRAY_OF_MAPS` の inner は個別の `BPF_MAP_TYPE_RINGBUF`) で構成されます。user-space 側も shard ごとに 1 goroutine + 1 file で受けるので、`-w path.pcap` を指定したときの出力は次のようになります。
 
 ```
-path.pcap         ← SHB+IDB のみの marker file (0 packets)
-path.pcap.cpu0    ← CPU 0 が受けた packets
-path.pcap.cpu1    ← CPU 1 が受けた packets
+path.pcap         ← 全 shard を時刻順にマージした単一 pcap-ng (そのまま使える)
+path.pcap.cpu0    ← CPU 0 が受けた packets (残置)
+path.pcap.cpu1    ← CPU 1 が受けた packets (残置)
 ...
 path.pcap.cpuN    ← (N = nproc - 1)
 ```
 
-`tcpdump -r path.pcap` は marker を読むだけで packets は出ません。各 `cpuN` ファイルは独立した valid pcap-ng として開けます。
+キャプチャ停止時 (Ctrl-C または `-c`) に、xdp-ninja は per-CPU shard を時刻順に k-way マージして base の `path.pcap` を単一 pcap-ng として書き出します。停止直後に `merging N shard(s) into path.pcap ...` と表示されるので、そこがマージ中です。`tcpdump -r path.pcap` でそのまま全パケットを時刻順に読めます。`.cpuN` は残るので、個別に読む・自分で mergecap することもできます。
 
 ```bash
+# base をそのまま読む (全 CPU 分・時刻順)
+tcpdump -r path.pcap
+
 # CPU 12 が受けた分だけ読む
 tcpdump -r path.pcap.cpu12
 
-# 全 shard を mergecap でまとめる
+# 自分で mergecap したい場合 (base と同等)
 mergecap -w merged.pcap path.pcap.cpu*
-
-# 確認: shard ごとの packet count
-for f in path.pcap.cpu*; do echo "$(basename $f): $(tcpdump -r $f 2>/dev/null | wc -l)"; done
 ```
 
-注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。shards をまとめたい場合は wireshark 同梱の `mergecap` を使います。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます。
+`-w` を付けない場合 (stdout ストリーミング) は、全 CPU を 1 本の pcap-ng ストリームに直列化してマージするので、`sudo xdp-ninja ... | tcpdump -r -` で全コア分が見えます。高レートでは `-w` を使ってください (stdout 直列化はインタラクティブ経路向け)。
+
+注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます (raw-dump は自動マージの対象外)。
 
 ## Performance flags
 

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -1,0 +1,105 @@
+// Merge per-CPU shard pcap-ng files (<base>.cpuN) into a single
+// time-ordered pcap-ng at <base>. Each shard is written in timestamp
+// order by its single producer, so a k-way merge across shards yields a
+// globally ordered file without loading every packet into memory.
+package output
+
+import (
+	"container/heap"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/gopacket/pcapgo"
+
+	"github.com/takehaya/xdp-ninja/internal/capture"
+)
+
+type mergeItem struct {
+	ts   time.Time
+	data []byte
+	idx  int // which shard reader to pull the next packet from
+}
+
+// mergeHeap is a min-heap on packet timestamp.
+type mergeHeap []mergeItem
+
+func (h mergeHeap) Len() int           { return len(h) }
+func (h mergeHeap) Less(i, j int) bool { return h[i].ts.Before(h[j].ts) }
+func (h mergeHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *mergeHeap) Push(x any)        { *h = append(*h, x.(mergeItem)) }
+func (h *mergeHeap) Pop() any {
+	old := *h
+	n := len(old)
+	it := old[n-1]
+	*h = old[:n-1]
+	return it
+}
+
+// MergeShardFiles merges <basePath>.cpu0..cpu(numShards-1) into a single
+// time-ordered pcap-ng written to basePath. Missing or empty shard files
+// are skipped. The shard files are left in place.
+func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
+	var closers []*os.File
+	var readers []*pcapgo.NgReader
+	defer func() {
+		for _, f := range closers {
+			_ = f.Close()
+		}
+	}()
+
+	for i := range numShards {
+		p := fmt.Sprintf("%s.cpu%d", basePath, i)
+		f, err := os.Open(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("opening shard %s: %w", p, err)
+		}
+		r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
+		if err != nil {
+			_ = f.Close()
+			return fmt.Errorf("reading shard %s: %w", p, err)
+		}
+		closers = append(closers, f)
+		readers = append(readers, r)
+	}
+
+	out, err := NewWriter(basePath, isFexit)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	h := &mergeHeap{}
+	for i, r := range readers {
+		if it, ok := nextItem(r, i); ok {
+			heap.Push(h, it)
+		}
+	}
+
+	for h.Len() > 0 {
+		it := heap.Pop(h).(mergeItem)
+		if err := out.Write(capture.Packet{Timestamp: it.ts, Data: it.data}); err != nil {
+			return fmt.Errorf("writing merged packet: %w", err)
+		}
+		if next, ok := nextItem(readers[it.idx], it.idx); ok {
+			heap.Push(h, next)
+		}
+	}
+	return nil
+}
+
+// nextItem reads the next packet from a shard reader. Returns ok=false at
+// EOF (or on any read error, which ends that shard's contribution). The
+// packet bytes are copied because pcapgo reuses its read buffer.
+func nextItem(r *pcapgo.NgReader, idx int) (mergeItem, bool) {
+	data, ci, err := r.ReadPacketData()
+	if err != nil {
+		return mergeItem{}, false
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return mergeItem{ts: ci.Timestamp, data: cp, idx: idx}, true
+}

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -85,9 +85,14 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 		}
 	}()
 
+	// One reusable buffer per shard. The heap holds at most one item per
+	// shard at a time, and a shard's next packet is only read after its
+	// current item has been popped and written, so overwriting the buffer
+	// is safe and avoids a per-packet allocation across the whole merge.
+	bufs := make([][]byte, len(readers))
 	h := &mergeHeap{}
 	for i, r := range readers {
-		if it, ok := nextItem(r, i); ok {
+		if it, ok := nextItem(r, i, &bufs[i]); ok {
 			heap.Push(h, it)
 		}
 	}
@@ -100,7 +105,7 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 		if err := out.Write(capture.Packet{Timestamp: it.ts, Data: it.data, Action: it.action}); err != nil {
 			return fmt.Errorf("writing merged packet: %w", err)
 		}
-		if next, ok := nextItem(readers[it.idx], it.idx); ok {
+		if next, ok := nextItem(readers[it.idx], it.idx, &bufs[it.idx]); ok {
 			heap.Push(h, next)
 		}
 	}
@@ -117,15 +122,20 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 	return nil
 }
 
-// nextItem reads the next packet from a shard reader. Returns ok=false at
-// EOF (or on any read error, which ends that shard's contribution). The
-// packet bytes are copied because pcapgo reuses its read buffer.
-func nextItem(r *pcapgo.NgReader, idx int) (mergeItem, bool) {
+// nextItem reads the next packet from a shard reader into the shard's
+// reusable buffer *buf (grown as needed). Returns ok=false at EOF (or on
+// any read error, which ends that shard's contribution). The bytes are
+// copied out because pcapgo reuses its own internal read buffer.
+func nextItem(r *pcapgo.NgReader, idx int, buf *[]byte) (mergeItem, bool) {
 	data, ci, err := r.ReadPacketData()
 	if err != nil {
 		return mergeItem{}, false
 	}
-	cp := make([]byte, len(data))
-	copy(cp, data)
-	return mergeItem{ts: ci.Timestamp, data: cp, action: uint32(ci.InterfaceIndex), idx: idx}, true
+	if cap(*buf) < len(data) {
+		*buf = make([]byte, len(data))
+	} else {
+		*buf = (*buf)[:len(data)]
+	}
+	copy(*buf, data)
+	return mergeItem{ts: ci.Timestamp, data: *buf, action: uint32(ci.InterfaceIndex), idx: idx}, true
 }

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -40,7 +40,7 @@ func (h *mergeHeap) Pop() any {
 // MergeShardFiles merges <basePath>.cpu0..cpu(numShards-1) into a single
 // time-ordered pcap-ng written to basePath. Missing or empty shard files
 // are skipped. The shard files are left in place.
-func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
+func MergeShardFiles(basePath string, numShards int, isFexit bool) (err error) {
 	var closers []*os.File
 	var readers []*pcapgo.NgReader
 	defer func() {
@@ -73,7 +73,13 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
+	// Surface a Close (flush) failure — a short write / disk-full must not
+	// let a truncated merge be reported as success.
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing merged file: %w", cerr)
+		}
+	}()
 
 	h := &mergeHeap{}
 	for i, r := range readers {

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -16,9 +16,10 @@ import (
 )
 
 type mergeItem struct {
-	ts   time.Time
-	data []byte
-	idx  int // which shard reader to pull the next packet from
+	ts     time.Time
+	data   []byte
+	action uint32 // source interface index = XDP action (fexit); preserved on write
+	idx    int    // which shard reader to pull the next packet from
 }
 
 // mergeHeap is a min-heap on packet timestamp.
@@ -59,8 +60,10 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 		}
 		r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
 		if err != nil {
+			// A truncated / 0-byte shard (e.g. from a crash mid-write)
+			// shouldn't abort the whole merge — skip it, as documented.
 			_ = f.Close()
-			return fmt.Errorf("reading shard %s: %w", p, err)
+			continue
 		}
 		closers = append(closers, f)
 		readers = append(readers, r)
@@ -81,7 +84,10 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 
 	for h.Len() > 0 {
 		it := heap.Pop(h).(mergeItem)
-		if err := out.Write(capture.Packet{Timestamp: it.ts, Data: it.data}); err != nil {
+		// Action carries the source interface index so fexit merges keep
+		// the per-action interface (xdp:PASS/DROP/...); output.Writer maps
+		// action->interface identically to how the shards were written.
+		if err := out.Write(capture.Packet{Timestamp: it.ts, Data: it.data, Action: it.action}); err != nil {
 			return fmt.Errorf("writing merged packet: %w", err)
 		}
 		if next, ok := nextItem(readers[it.idx], it.idx); ok {
@@ -101,5 +107,5 @@ func nextItem(r *pcapgo.NgReader, idx int) (mergeItem, bool) {
 	}
 	cp := make([]byte, len(data))
 	copy(cp, data)
-	return mergeItem{ts: ci.Timestamp, data: cp, idx: idx}, true
+	return mergeItem{ts: ci.Timestamp, data: cp, action: uint32(ci.InterfaceIndex), idx: idx}, true
 }

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -40,7 +40,7 @@ func (h *mergeHeap) Pop() any {
 // MergeShardFiles merges <basePath>.cpu0..cpu(numShards-1) into a single
 // time-ordered pcap-ng written to basePath. Missing or empty shard files
 // are skipped. The shard files are left in place.
-func MergeShardFiles(basePath string, numShards int, isFexit bool) (err error) {
+func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 	var closers []*os.File
 	var readers []*pcapgo.NgReader
 	defer func() {
@@ -69,15 +69,19 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) (err error) {
 		readers = append(readers, r)
 	}
 
-	out, err := NewWriter(basePath, isFexit)
+	// Write to a temp file and rename on success so a mid-merge failure
+	// (disk full / short write) never leaves a truncated base file over the
+	// still-valid per-CPU shards — the merge is atomic.
+	tmpPath := basePath + ".merging"
+	out, err := NewWriter(tmpPath, isFexit)
 	if err != nil {
 		return err
 	}
-	// Surface a Close (flush) failure — a short write / disk-full must not
-	// let a truncated merge be reported as success.
+	committed := false
 	defer func() {
-		if cerr := out.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("closing merged file: %w", cerr)
+		if !committed {
+			_ = out.Close()
+			_ = os.Remove(tmpPath)
 		}
 	}()
 
@@ -100,6 +104,16 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) (err error) {
 			heap.Push(h, next)
 		}
 	}
+
+	// Flush+close the temp before renaming so all bytes are on disk; a
+	// close (flush) failure must fail the merge, not silently truncate.
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing merged file: %w", err)
+	}
+	if err := os.Rename(tmpPath, basePath); err != nil {
+		return fmt.Errorf("renaming merged file into place: %w", err)
+	}
+	committed = true
 	return nil
 }
 

--- a/internal/output/merge_test.go
+++ b/internal/output/merge_test.go
@@ -1,0 +1,97 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/pcapgo"
+
+	"github.com/takehaya/xdp-ninja/internal/capture"
+)
+
+// writeShardFile writes a single-shard pcap-ng with packets at the given
+// second offsets from base, each a minimal 20-byte frame.
+func writeShardFile(t *testing.T, path string, base time.Time, secs []int) {
+	t.Helper()
+	w, err := NewWriter(path, false)
+	if err != nil {
+		t.Fatalf("NewWriter(%s): %v", path, err)
+	}
+	for _, s := range secs {
+		frame := make([]byte, 20)
+		frame[0] = byte(s) // tag the frame so we can check ordering
+		if err := w.Write(capture.Packet{Timestamp: base.Add(time.Duration(s) * time.Second), Data: frame}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close(%s): %v", path, err)
+	}
+}
+
+// TestMergeShardFiles verifies that per-CPU shards are merged into a single
+// globally time-ordered pcap-ng, and that missing shard indices are
+// skipped without error.
+func TestMergeShardFiles(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "out.pcap")
+	epoch := time.Unix(1700000000, 0).UTC()
+
+	// Interleaved across shards; shard 1 has no file (gap tolerated).
+	writeShardFile(t, base+".cpu0", epoch, []int{1, 3, 5})
+	writeShardFile(t, base+".cpu2", epoch, []int{2, 4})
+
+	// numShards=3 so .cpu1 (nonexistent) exercises the skip path.
+	if err := MergeShardFiles(base, 3, false); err != nil {
+		t.Fatalf("MergeShardFiles: %v", err)
+	}
+
+	f, err := os.Open(base)
+	if err != nil {
+		t.Fatalf("open merged: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
+	if err != nil {
+		t.Fatalf("NgReader: %v", err)
+	}
+
+	var order []int
+	for {
+		data, _, err := r.ReadPacketData()
+		if err != nil {
+			break
+		}
+		order = append(order, int(data[0]))
+	}
+
+	want := []int{1, 2, 3, 4, 5}
+	if len(order) != len(want) {
+		t.Fatalf("merged packet count = %d, want %d (order=%v)", len(order), len(want), order)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("merged order = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestMergeShardFilesEmpty verifies merging when no shard files exist
+// produces a valid (empty) pcap-ng rather than erroring.
+func TestMergeShardFilesEmpty(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "none.pcap")
+	if err := MergeShardFiles(base, 4, false); err != nil {
+		t.Fatalf("MergeShardFiles with no shards: %v", err)
+	}
+	f, err := os.Open(base)
+	if err != nil {
+		t.Fatalf("open merged: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions); err != nil {
+		t.Fatalf("merged empty file is not valid pcap-ng: %v", err)
+	}
+}

--- a/internal/output/merge_test.go
+++ b/internal/output/merge_test.go
@@ -78,6 +78,59 @@ func TestMergeShardFiles(t *testing.T) {
 	}
 }
 
+// TestMergeShardFilesFexitPreservesAction verifies that in fexit mode the
+// merged base keeps each packet's per-action interface (xdp:PASS/DROP/...),
+// i.e. the source interface index survives the merge rather than collapsing
+// to interface 0.
+func TestMergeShardFilesFexitPreservesAction(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "exit.pcap")
+	epoch := time.Unix(1700000000, 0).UTC()
+
+	// shard 0: two packets with actions 2 (PASS) and 1 (DROP).
+	w0, err := NewWriter(base+".cpu0", true) // isFexit
+	if err != nil {
+		t.Fatalf("NewWriter fexit: %v", err)
+	}
+	if err := w0.Write(capture.Packet{Timestamp: epoch.Add(1 * time.Second), Data: make([]byte, 20), Action: 2}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w0.Write(capture.Packet{Timestamp: epoch.Add(3 * time.Second), Data: make([]byte, 20), Action: 1}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w0.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if err := MergeShardFiles(base, 1, true); err != nil {
+		t.Fatalf("MergeShardFiles fexit: %v", err)
+	}
+
+	f, err := os.Open(base)
+	if err != nil {
+		t.Fatalf("open merged: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	r, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions)
+	if err != nil {
+		t.Fatalf("NgReader: %v", err)
+	}
+
+	var ifaces []int
+	for {
+		_, ci, err := r.ReadPacketData()
+		if err != nil {
+			break
+		}
+		ifaces = append(ifaces, ci.InterfaceIndex)
+	}
+	// interface index == action (identity map in initExitMode): 2 then 1.
+	want := []int{2, 1}
+	if len(ifaces) != len(want) || ifaces[0] != want[0] || ifaces[1] != want[1] {
+		t.Fatalf("merged interface indices = %v, want %v (action interface lost)", ifaces, want)
+	}
+}
+
 // TestMergeShardFilesEmpty verifies merging when no shard files exist
 // produces a valid (empty) pcap-ng rather than erroring.
 func TestMergeShardFilesEmpty(t *testing.T) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -150,6 +150,11 @@ func (w *Writer) Write(pkt capture.Packet) error {
 			ci.InterfaceIndex = id
 		}
 	}
+	// Serialize with the stdout flusher goroutine (Flush also holds flushMu)
+	// so writes and periodic flushes don't race on the pcapng buffer. For
+	// file writers there is no flusher, so this lock is uncontended.
+	w.flushMu.Lock()
+	defer w.flushMu.Unlock()
 	if err := w.pcapWriter.WritePacket(ci, pkt.Data); err != nil {
 		return fmt.Errorf("writing pcap packet: %w", err)
 	}
@@ -170,6 +175,10 @@ func (w *Writer) WriteBatch(pkts []capture.Packet) error {
 		}
 		return nil
 	}
+	// One lock for the whole batch (see Write): mutual exclusion with the
+	// stdout flusher; uncontended for file writers.
+	w.flushMu.Lock()
+	defer w.flushMu.Unlock()
 	var ci gopacket.CaptureInfo
 	for i := range pkts {
 		p := &pkts[i]


### PR DESCRIPTION
## 概要

per-CPU sharded ringbuf は各コアが `FILE.cpuN` を無排他で書く(高スループット)が、その代償で:
- `-w FILE` の base は 0 パケットの SHB placeholder で、実データは nproc 個の `.cpuN` に散っていた
- stdout(`-w` なし)は **shard0 だけ**書き、他コアのパケットを黙って落としていた

これを「単一ファイルに合算」して使いやすくする。

## 変更点

- **stdout(`-w` なし)**: 全 shard を 1 本の pcap-ng ストリームに mutex 直列化で合算。`| tcpdump -r -` で全コア分が見える。
- **`-w FILE`**: キャプチャ終了時(Ctrl-C / `-c`)に `.cpuN` を **時刻順 k-way マージ**して base `FILE` に単一 pcap-ng を書き出す(`output.MergeShardFiles`)。各 shard は既に時刻順なので min-heap で 1 shard=1 パケットずつ流し、全載せせずストリーミング。`.cpuN` は残置。終了直後に `merging N shard(s) into FILE ...` を表示(Ctrl-C 後の停止に見えないよう)。
- `--raw-dump`(オフライン convert)/ `--null-output` は対象外。

## 出力例

```
$ sudo xdp-ninja -i eth0 -w cap.pcap -c 100
...
merging 64 shard(s) into cap.pcap ...
merged into cap.pcap (per-CPU .cpuN kept)
$ tcpdump -r cap.pcap   # 全コア分・時刻順
```

## テスト

`internal/output/merge_test.go`:
- `TestMergeShardFiles` — 時刻交互の 2 shard(+存在しない shard index)を合算し、全体時刻順・件数・欠損 shard スキップを検証
- `TestMergeShardFilesEmpty` — shard 皆無でも valid な空 pcap-ng を出す

veth+ping で `-w`(base に全件・時刻順)と stdout(全件)の e2e も手動確認。`make test` / `go vet` / `golangci-lint`(0 issues)green。README + docs/ja/dsl-usage.md 更新。

## 補足

`/simplify`(4観点並列レビュー)適用済み: 1要素スライス WriteBatch → `Writer.Write`、defer 統合、hot path の shared/per-CPU/null 分岐を setup 側 closure に集約。altitude 指摘の「mode enum + shard-sink 抽象化」大改修は本 PR スコープ外として見送り。
