### PR TITLE
feat(cli): add --arg-echo to print a function's integer args

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -532,9 +532,15 @@ func runArgEchoLoop(cmd *cli.Command, probe *program.Probe, funcName string) err
 	var stopped atomic.Bool
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	done := make(chan struct{})
+	defer close(done) // let the signal goroutine exit when the loop returns
 	go func() {
-		<-sigCh
-		stopped.Store(true)
+		select {
+		case <-sigCh:
+			stopped.Store(true)
+		case <-done:
+		}
 	}()
 
 	count := int64(cmd.Int("count"))

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"os/signal"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/takehaya/xdp-ninja/internal/attach"
 	"github.com/takehaya/xdp-ninja/internal/capture"
+	"github.com/takehaya/xdp-ninja/internal/capture/fastrb"
 	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/internal/output"
 	"github.com/takehaya/xdp-ninja/internal/program"
@@ -72,6 +74,10 @@ var flags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "list-params",
 		Usage: "list filterable parameters for the target function (requires --func) and exit",
+	},
+	&cli.BoolFlag{
+		Name:  "arg-echo",
+		Usage: "diagnostic: print the target function's integer args for each call (gated by --arg-filter if set) instead of capturing packets; requires --func; combine with -c N to stop after N",
 	},
 	&cli.BoolFlag{
 		Name:  "cbpf",
@@ -412,7 +418,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	// --func: override target function name.
 	// Open BTF once and share across validation and parameter extraction.
 	funcName := cmd.String("func")
-	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0
+	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0 || cmd.Bool("arg-echo")
 	var params []attach.FuncParamInfo
 	if funcName != "" {
 		spec, err := attach.BTFSpec(info.Program)
@@ -434,6 +440,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	} else if needParams {
 		if cmd.Bool("list-params") {
 			return fmt.Errorf("--list-params requires --func")
+		}
+		if cmd.Bool("arg-echo") {
+			return fmt.Errorf("--arg-echo requires --func")
 		}
 		return fmt.Errorf("--arg-filter requires --func")
 	}
@@ -467,6 +476,18 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
+	// --arg-echo: emit the function's integer args instead of capturing
+	// packets. Reuses the parsed argFilters as a gate and the resolved
+	// integer params as the echo set.
+	if cmd.Bool("arg-echo") {
+		probe, err := program.LoadArgEcho(info.Program, info.FuncName, argFilters, params, isFexit)
+		if err != nil {
+			return err
+		}
+		printProbeWarnings(probe)
+		return runArgEchoLoop(cmd, probe, info.FuncName)
+	}
+
 	filterExpr := strings.Join(cmd.Args().Slice(), " ")
 	logVerbose(cmd, "found XDP program %q (id=%d)", info.FuncName, info.ProgID)
 	if filterExpr != "" {
@@ -488,6 +509,100 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		label = fmt.Sprintf("%s on %s", label, info.IfaceName)
 	}
 	return runCaptureLoop(cmd, probe, isFexit, fmt.Sprintf("%s, mode=%s", label, mode))
+}
+
+// runArgEchoLoop reads the probe's dedicated arg-echo ringbuf and prints
+// one line per matched call, collapsing runs of identical arg tuples into
+// a single "(xN)" line. Honors -c/--count (0 = until SIGINT).
+func runArgEchoLoop(cmd *cli.Command, probe *program.Probe, funcName string) error {
+	defer func() {
+		if cerr := probe.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: closing probe: %v\n", cerr)
+		}
+	}()
+
+	// Use the in-tree fastrb reader (mmap + epoll), consistent with the
+	// capture path, rather than cilium/ebpf's ringbuf.Reader.
+	rd, err := fastrb.New(probe.EchoRing.FD(), program.EchoRingSize)
+	if err != nil {
+		return fmt.Errorf("opening arg-echo ringbuf: %w", err)
+	}
+	defer func() { _ = rd.Close() }()
+
+	var stopped atomic.Bool
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		stopped.Store(true)
+	}()
+
+	count := int64(cmd.Int("count"))
+	params := probe.EchoParams
+	recSize := len(params) * 8
+
+	fmt.Fprintf(os.Stderr, "arg-echo on %s (%d param(s)); Ctrl-C to stop\n", funcName, len(params))
+
+	var seen int64
+	var lastLine string
+	var repeat int
+	flush := func() {
+		if repeat == 0 {
+			return
+		}
+		if repeat > 1 {
+			fmt.Fprintf(os.Stderr, "%s (x%d)\n", lastLine, repeat)
+		} else {
+			fmt.Fprintln(os.Stderr, lastLine)
+		}
+		repeat = 0
+	}
+
+	for !stopped.Load() {
+		// Short timeout so a Ctrl-C between records is noticed promptly.
+		n, werr := rd.WaitForData(250)
+		if werr != nil {
+			return fmt.Errorf("waiting on arg-echo ringbuf: %w", werr)
+		}
+		if n == 0 {
+			continue // timeout, re-check stop flag
+		}
+		rd.ReadBatch(func(rec []byte) {
+			if (count > 0 && seen >= count) || len(rec) < recSize {
+				return
+			}
+			line := formatEchoArgs(funcName, params, rec)
+			if repeat > 0 && line == lastLine {
+				repeat++
+			} else {
+				flush()
+				lastLine = line
+				repeat = 1
+			}
+			seen++
+		})
+		if count > 0 && seen >= count {
+			break
+		}
+	}
+	flush()
+	return nil
+}
+
+// formatEchoArgs renders one echo record as "func: name=DEC (0xHEX) ...".
+func formatEchoArgs(funcName string, params []attach.FuncParamInfo, raw []byte) string {
+	var b strings.Builder
+	b.WriteString(funcName)
+	b.WriteByte(':')
+	for i, p := range params {
+		v := binary.NativeEndian.Uint64(raw[i*8 : i*8+8])
+		var dec any = v
+		if p.Signed {
+			dec = int64(v)
+		}
+		fmt.Fprintf(&b, " %s=%d (0x%x)", p.Name, dec, v)
+	}
+	return b.String()
 }
 
 // printProbeWarnings drains non-fatal resolver / codegen notices the

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -418,6 +418,26 @@ for f in path.pcap.cpu*; do echo "$(basename $f): $(tcpdump -r $f 2>/dev/null | 
 
 注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。shards をまとめたい場合は wireshark 同梱の `mergecap` を使います。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます。
 
+## 関数引数の値を覗く (`--arg-echo`)
+
+`--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、「そもそも引数にどんな値が乗っているか」を確認するのに使います (例: IMSI が 10 進なのか TBCD なのか)。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。
+
+```bash
+# 対象関数の絞り込み可能な整数引数を確認
+sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --list-params
+#   imsi  [8 bytes, unsigned, arg index 1]
+#   teid  [4 bytes, unsigned, arg index 2]
+
+# 1 回だけ観測して終了 (-c 1)
+sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --arg-echo -c 1
+#   pgwu_capture_point_ul: imsi=901040010000005 (0x3337db9b97685) teid=12345 (0x3039)
+```
+
+- `--func` 必須。表示対象は `--list-params` が挙げる整数引数 (10 進と 16 進を併記)。
+- `--arg-filter` と併用すると、その述語に**マッチした呼び出しだけ**を表示します。値の当たりを付けてから絞り込む、という使い方ができます。
+- 連続して同じ引数タプルが来た場合は 1 行に畳んで `(xN)` と表示します。`-c N` で N 件表示したら終了、無指定なら Ctrl-C まで。
+- リーダは capture path と同じ in-tree の `fastrb` (mmap + epoll) を使います。
+
 ## Performance flags
 
 高 rate capture (>1 Mpps 級) で使う flag 群です。通常用途では既定値で十分です。

--- a/internal/program/argecho.go
+++ b/internal/program/argecho.go
@@ -41,6 +41,12 @@ func LoadArgEcho(
 	if len(echoParams) == 0 {
 		return nil, fmt.Errorf("--arg-echo requires at least one filterable integer parameter (see --list-params)")
 	}
+	// One record is len(params)*8 bytes; it must fit in the ring (with head
+	// room for the 8-byte record header) or bpf_ringbuf_reserve always
+	// fails and nothing prints. In practice params is tiny; guard anyway.
+	if recordSize := len(echoParams) * 8; recordSize >= EchoRingSize {
+		return nil, fmt.Errorf("--arg-echo: %d params (%d B/record) exceed the %d B echo ring", len(echoParams), recordSize, EchoRingSize)
+	}
 
 	if _, err := validateTracingTarget(targetProg); err != nil {
 		return nil, err

--- a/internal/program/argecho.go
+++ b/internal/program/argecho.go
@@ -53,8 +53,10 @@ func LoadArgEcho(
 	}
 	label, attachType := tracingLabel(isFexit)
 
+	// Keep names within the 15-char BPF object-name limit so bpftool shows
+	// them intact: "nj_entry_echo" (13) / "nj_exit_echo" (12).
 	ring, err := ebpf.NewMap(&ebpf.MapSpec{
-		Name: fmt.Sprintf("ninja_%s_echo", label), Type: ebpf.RingBuf, MaxEntries: EchoRingSize,
+		Name: fmt.Sprintf("nj_%s_echo", label), Type: ebpf.RingBuf, MaxEntries: EchoRingSize,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating arg-echo ringbuf: %w", err)
@@ -67,8 +69,11 @@ func LoadArgEcho(
 		maps:       []*ebpf.Map{ring},
 	}
 
+	// "njecho_entry" (12) / "njecho_exit" (11): distinct from the capture
+	// probe's "xdp_ninja_entry"/"xdp_ninja_exit" and within the 15-char
+	// BPF name limit (so the distinguishing name isn't truncated away).
 	insns := buildArgEchoInsns(ring.FD(), argFilters, echoParams)
-	if err := attachTracingProbe(probe, targetProg, fmt.Sprintf("xdp_ninja_%s_e", label), funcName, attachType, insns); err != nil {
+	if err := attachTracingProbe(probe, targetProg, fmt.Sprintf("njecho_%s", label), funcName, attachType, insns); err != nil {
 		return nil, err
 	}
 	return probe, nil

--- a/internal/program/argecho.go
+++ b/internal/program/argecho.go
@@ -1,0 +1,110 @@
+// Package program — --arg-echo diagnostic path.
+//
+// arg-echo answers "what value does this function actually receive in a
+// given integer argument?" — the question that comes up when an
+// --arg-filter never matches because the caller encodes the value
+// differently than expected (e.g. an IMSI carried as TBCD rather than a
+// plain decimal). Instead of the packet-capture pipeline, the probe emits
+// just the target function's integer args to a dedicated ringbuf, and the
+// CLI prints them; --arg-filter (if given) still gates which calls echo.
+package program
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/filter"
+)
+
+// EchoRingSize is the byte capacity of the arg-echo ringbuf. 64 KiB is a
+// power of two and a page multiple (a valid BPF ringbuf size) — ample for
+// a low-rate diagnostic that emits len(params)*8 bytes per matched call.
+// Exported so the CLI reader (fastrb) can mmap the ring with the right
+// size.
+const EchoRingSize = 64 * 1024
+
+// LoadArgEcho builds and attaches an echo-only probe: it stores the tracing
+// args pointer, applies any argFilters as a gate, then emits the selected
+// integer args (echoParams, in order) as consecutive u64s to a dedicated
+// ringbuf. It deliberately skips the sharded packet ringbuf, scratch map
+// and packet filter used by the capture path.
+func LoadArgEcho(
+	targetProg *ebpf.Program,
+	funcName string,
+	argFilters []filter.ArgFilter,
+	echoParams []attach.FuncParamInfo,
+	isFexit bool,
+) (*Probe, error) {
+	if len(echoParams) == 0 {
+		return nil, fmt.Errorf("--arg-echo requires at least one filterable integer parameter (see --list-params)")
+	}
+
+	if _, err := validateTracingTarget(targetProg); err != nil {
+		return nil, err
+	}
+	label, attachType := tracingLabel(isFexit)
+
+	ring, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name: fmt.Sprintf("ninja_%s_echo", label), Type: ebpf.RingBuf, MaxEntries: EchoRingSize,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating arg-echo ringbuf: %w", err)
+	}
+
+	probe := &Probe{
+		IsFexit:    isFexit,
+		EchoRing:   ring,
+		EchoParams: echoParams,
+		maps:       []*ebpf.Map{ring},
+	}
+
+	insns := buildArgEchoInsns(ring.FD(), argFilters, echoParams)
+	if err := attachTracingProbe(probe, targetProg, fmt.Sprintf("xdp_ninja_%s_e", label), funcName, attachType, insns); err != nil {
+		return nil, err
+	}
+	return probe, nil
+}
+
+// buildArgEchoInsns emits: save args ptr -> (arg filter gate) -> reserve a
+// len(params)*8 byte ringbuf record -> store each arg as a u64 -> submit.
+// The record layout is one native-endian u64 per param, in echoParams
+// order, matching the CLI reader (formatEchoArgs) which decodes each u64.
+func buildArgEchoInsns(echoRingFD int, argFilters []filter.ArgFilter, params []attach.FuncParamInfo) asm.Instructions {
+	insns := asm.Instructions{
+		// stack[-48] = tracing args ptr (buildArgFilter and the arg
+		// loads below both read it from here).
+		asm.StoreMem(asm.R10, -48, asm.R1, asm.DWord),
+	}
+	// Optional gate: jumps to "exit" when the arg predicate doesn't match.
+	insns = append(insns, buildArgFilter(argFilters)...)
+
+	// reserve(echoRing, len*8, 0); R0 = slot ptr (0 on failure).
+	insns = append(insns,
+		asm.LoadMapPtr(asm.R1, echoRingFD),
+		asm.Mov.Imm(asm.R2, int32(len(params)*8)),
+		asm.Mov.Imm(asm.R3, 0),
+		asm.FnRingbufReserve.Call(),
+		asm.JEq.Imm(asm.R0, 0, "exit"),
+	)
+
+	// R1 = args ptr; copy each arg into slot[i*8]. emitArgLoad (shared with
+	// the arg-filter gate) owns the size/sign-extend logic.
+	insns = append(insns, asm.LoadMem(asm.R1, asm.R10, -48, asm.DWord))
+	for i, p := range params {
+		insns = append(insns, emitArgLoad(asm.R3, asm.R1, int16(p.Index*8), p.Size, p.Signed)...)
+		insns = append(insns, asm.StoreMem(asm.R0, int16(i*8), asm.R3, asm.DWord))
+	}
+
+	// submit(slot, 0); then exit.
+	insns = append(insns,
+		asm.Mov.Reg(asm.R1, asm.R0),
+		asm.Mov.Imm(asm.R2, 0),
+		asm.FnRingbufSubmit.Call(),
+		asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"),
+		asm.Return(),
+	)
+	return insns
+}

--- a/internal/program/argecho_test.go
+++ b/internal/program/argecho_test.go
@@ -1,0 +1,105 @@
+package program
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/capture/fastrb"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// echoTargetSrc: an XDP program calling a global noinline subfunction that
+// takes an integer arg, so --arg-echo can attach fexit/fentry to it and
+// observe the arg value.
+const echoTargetSrc = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int capture_pt(struct xdp_md *ctx, unsigned long long imsi) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 0;
+    if (imsi == 0)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int echo_target(struct xdp_md *ctx) {
+    return capture_pt(ctx, 0x1122334455667788ULL);
+}
+char _license[] SEC("license") = "GPL";
+`
+
+// TestBpfArgEchoEmitsArgValue loads a target with an int-arg subfunction,
+// attaches an arg-echo probe to that subfunction, triggers the target via
+// BPF_PROG_TEST_RUN, and asserts the echoed arg matches the value the
+// target passes.
+func TestBpfArgEchoEmitsArgValue(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, echoTargetSrc))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+	var objs struct {
+		Target *ebpf.Program `ebpf:"echo_target"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading target: %v", err)
+	}
+	defer func() { _ = objs.Target.Close() }()
+
+	params, err := attach.GetFuncParams(objs.Target, "capture_pt")
+	if err != nil {
+		t.Fatalf("GetFuncParams: %v", err)
+	}
+	if len(params) != 1 || params[0].Name != "imsi" || params[0].Size != 8 {
+		t.Fatalf("unexpected params: %+v", params)
+	}
+
+	probe, err := LoadArgEcho(objs.Target, "capture_pt", nil, params, false)
+	if err != nil {
+		t.Fatalf("LoadArgEcho: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	rd, err := fastrb.New(probe.EchoRing.FD(), EchoRingSize)
+	if err != nil {
+		t.Fatalf("fastrb.New: %v", err)
+	}
+	defer func() { _ = rd.Close() }()
+
+	// Trigger the target (and thus the attached fentry echo) via test-run.
+	in := make([]byte, 64)
+	if _, err := objs.Target.Run(&ebpf.RunOptions{Data: in}); err != nil {
+		t.Fatalf("test-run target: %v", err)
+	}
+
+	if n, err := rd.WaitForData(1000); err != nil {
+		t.Fatalf("WaitForData: %v", err)
+	} else if n == 0 {
+		t.Fatal("no arg-echo record after test-run")
+	}
+
+	var got uint64
+	var recs int
+	rd.ReadBatch(func(rec []byte) {
+		recs++
+		if len(rec) >= 8 {
+			got = binary.NativeEndian.Uint64(rec[:8])
+		}
+	})
+	if recs == 0 {
+		t.Fatal("ReadBatch delivered no records")
+	}
+	const want = uint64(0x1122334455667788)
+	if got != want {
+		t.Errorf("echoed imsi = 0x%x, want 0x%x", got, want)
+	}
+}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudflare/cbpfc"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/takehaya/xdp-ninja/internal/attach"
 	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/pkg/kunai"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
@@ -27,9 +28,16 @@ type Probe struct {
 	InnerMaps []*ebpf.Map // non-nil only in per-CPU sharded mode
 	IsFexit   bool
 	Warnings  []string // resolver / codegen non-fatal notices; CLI prints to stderr
-	maps      []*ebpf.Map
-	prog      *ebpf.Program
-	link      link.Link
+
+	// --arg-echo diagnostic mode: non-nil EchoRing means this probe emits
+	// the target function's integer args (EchoParams, in order) to a
+	// dedicated ringbuf instead of capturing packets.
+	EchoRing   *ebpf.Map
+	EchoParams []attach.FuncParamInfo
+
+	maps []*ebpf.Map
+	prog *ebpf.Program
+	link link.Link
 }
 
 // Program returns the underlying tracing program. Exposed so that
@@ -74,13 +82,9 @@ func LoadExit(targetProg *ebpf.Program, funcName string, filterExpr string, argF
 }
 
 func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, argFilters []filter.ArgFilter, isFexit, useDSL bool) (*Probe, error) {
-	info, err := targetProg.Info()
+	progType, err := validateTracingTarget(targetProg)
 	if err != nil {
-		return nil, fmt.Errorf("reading target program info: %w", err)
-	}
-	progType := info.Type
-	if progType != ebpf.XDP && progType != ebpf.SchedCLS && progType != ebpf.SchedACT {
-		return nil, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", progType)
+		return nil, err
 	}
 
 	filterOut, err := compileFilter(filterExpr, useDSL, isFexit, progType)
@@ -91,12 +95,7 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 		filterOut.Capture.MaxCapLen = SnaplenOverride
 	}
 
-	label := "entry"
-	attachType := ebpf.AttachTraceFEntry
-	if isFexit {
-		label = "exit"
-		attachType = ebpf.AttachTraceFExit
-	}
+	label, attachType := tracingLabel(isFexit)
 
 	outerMap, innerMaps, err := createShardedRingbuf(label)
 	if err != nil {
@@ -133,25 +132,58 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 		_ = probe.Close()
 		return nil, err
 	}
+	if err := attachTracingProbe(probe, targetProg, fmt.Sprintf("xdp_ninja_%s", label), funcName, attachType, insns); err != nil {
+		return nil, err
+	}
+	return probe, nil
+}
+
+// validateTracingTarget checks targetProg is a type xdp-ninja can attach a
+// fentry/fexit probe to, returning its program type.
+func validateTracingTarget(targetProg *ebpf.Program) (ebpf.ProgramType, error) {
+	info, err := targetProg.Info()
+	if err != nil {
+		return 0, fmt.Errorf("reading target program info: %w", err)
+	}
+	pt := info.Type
+	if pt != ebpf.XDP && pt != ebpf.SchedCLS && pt != ebpf.SchedACT {
+		return 0, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", pt)
+	}
+	return pt, nil
+}
+
+// tracingLabel maps entry/exit to the short label (used in map/program
+// names) and the BPF tracing attach type.
+func tracingLabel(isFexit bool) (string, ebpf.AttachType) {
+	if isFexit {
+		return "exit", ebpf.AttachTraceFExit
+	}
+	return "entry", ebpf.AttachTraceFEntry
+}
+
+// attachTracingProbe loads insns as a Tracing program named `name`,
+// attaches it to funcName on targetProg, and records prog+link on probe.
+// On failure it closes probe (unwinding any maps already registered).
+// Shared by loadProbe (capture) and LoadArgEcho (diagnostic).
+func attachTracingProbe(probe *Probe, targetProg *ebpf.Program, name, funcName string, attachType ebpf.AttachType, insns asm.Instructions) error {
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Name: fmt.Sprintf("xdp_ninja_%s", label), Type: ebpf.Tracing, AttachType: attachType,
+		Name: name, Type: ebpf.Tracing, AttachType: attachType,
 		AttachTo: funcName, AttachTarget: targetProg,
 		Instructions: insns, License: "GPL",
 	})
 	if err != nil {
 		_ = probe.Close()
-		return nil, fmt.Errorf("loading %s program: %w", label, err)
+		return fmt.Errorf("loading %s program: %w", name, err)
 	}
 	probe.prog = prog
 
 	l, err := link.AttachTracing(link.TracingOptions{Program: prog, AttachType: attachType})
 	if err != nil {
 		_ = probe.Close()
-		return nil, fmt.Errorf("attaching %s: %w", label, err)
+		return fmt.Errorf("attaching %s: %w", name, err)
 	}
 	probe.link = l
-
-	return probe, nil
+	return nil
 }
 
 // --- Filter compilation ---
@@ -597,6 +629,33 @@ func captureWithRingbuf(eventsFD int, isFexit bool, maxCapLen int) asm.Instructi
 //
 // For each filter, we load the argument value and compare it.
 // If any filter doesn't match, we jump to "exit".
+// emitArgLoad loads a size-byte integer arg at base+offset into dst,
+// sign-extending sub-word signed values to 64-bit. Byte/Half/Word loads
+// zero-extend into dst; for signed params the LSh/ArSh pair widens the
+// sign bit so JSLT/JSGT comparisons and int64 rendering are correct (e.g.
+// int8 -1 loaded as 0xFF becomes 0xFFFFFFFFFFFFFFFF). Shared by the
+// arg-filter gate and the arg-echo emitter so the sign-extend invariant
+// lives in one place.
+func emitArgLoad(dst, base asm.Register, offset int16, size uint32, signed bool) asm.Instructions {
+	var loadSize asm.Size
+	switch size {
+	case 1:
+		loadSize = asm.Byte
+	case 2:
+		loadSize = asm.Half
+	case 4:
+		loadSize = asm.Word
+	default:
+		loadSize = asm.DWord
+	}
+	insns := asm.Instructions{asm.LoadMem(dst, base, offset, loadSize)}
+	if signed && size < 8 {
+		shift := int32((8 - size) * 8)
+		insns = append(insns, asm.LSh.Imm(dst, shift), asm.ArSh.Imm(dst, shift))
+	}
+	return insns
+}
+
 func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
 	if len(filters) == 0 {
 		return nil
@@ -608,30 +667,7 @@ func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
 
 	for _, f := range filters {
 		offset := int16(f.ParamIndex * 8)
-
-		var loadSize asm.Size
-		switch f.ParamSize {
-		case 1:
-			loadSize = asm.Byte
-		case 2:
-			loadSize = asm.Half
-		case 4:
-			loadSize = asm.Word
-		default:
-			loadSize = asm.DWord
-		}
-		insns = append(insns, asm.LoadMem(asm.R3, asm.R2, offset, loadSize))
-
-		// Byte/Half/Word loads zero-extend into R3. For signed parameters we must
-		// sign-extend to 64-bit so that JSLT/JSGT comparisons work correctly
-		// (e.g. int8 -1 is loaded as 0xFF and must become 0xFFFFFFFFFFFFFFFF).
-		if f.Signed && f.ParamSize < 8 {
-			shift := int32((8 - f.ParamSize) * 8) // bits to shift
-			insns = append(insns,
-				asm.LSh.Imm(asm.R3, shift),
-				asm.ArSh.Imm(asm.R3, shift),
-			)
-		}
+		insns = append(insns, emitArgLoad(asm.R3, asm.R2, offset, f.ParamSize, f.Signed)...)
 
 		// Select unsigned or signed jump ops based on parameter signedness.
 		jLT, jGT := asm.JLT, asm.JGT


### PR DESCRIPTION
## 概要

`--arg-filter "imsi=..."` が当たらないとき、「対象関数の引数に実際どんな値が乗っているか」を見る診断モード `--arg-echo` を追加する。パケットキャプチャはせず、`--func` で狙った関数の整数引数(= `--list-params` が挙げるもの)を専用 ringbuf に流して表示する。

## 使い方

```bash
sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --list-params
#   imsi  [8 bytes, unsigned, arg index 1]
#   teid  [4 bytes, unsigned, arg index 2]

sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --arg-echo -c 1
#   pgwu_capture_point_ul: imsi=901040010000005 (0x3337db9b97685) teid=12345 (0x3039)
```

- `--func` 必須。10 進 + 16 進併記。
- `--arg-filter` 併用でマッチした呼び出しだけ表示(値の当たり付け→絞り込み)。
- 連続重複は `(xN)` に畳む。`-c N` で N 件表示後に終了、無指定は Ctrl-C。
- リーダは capture path と同じ in-tree `fastrb`(mmap + epoll)。

## 実装

- `internal/program/argecho.go`: `LoadArgEcho` が echo 専用の fentry/fexit プローブを単一 RingBuf 上に構築。`buildArgEchoInsns` が args を u64 として emit。
- **共有化(/simplify)**: attach ボイラープレート(`validateTracingTarget` / `tracingLabel` / `attachTracingProbe`)と引数ロード+符号拡張(`emitArgLoad`)を `loadProbe` / `buildArgFilter` から括り出し、capture 経路と共有。
- `Probe` に `EchoRing` / `EchoParams`(capture 経路では nil)。

## テスト

`internal/program/argecho_test.go`: root e2e。int 引数を取るサブ関数を持つ XDP をロード→echo attach→`BPF_PROG_TEST_RUN` で発火→emit された値(`0x1122334455667788`)を fastrb で読み戻して検証。

`make test` / `go vet` / `golangci-lint`(0 issues)green。arg-filter 実トラフィックテスト(emitArgLoad 経由)も PASS 確認。`/simplify`(4観点並列)適用済み。docs/ja/dsl-usage.md に節追加。

## 備考

出力の per-CPU マージ改善は別 PR(#53)。本 PR は診断機能のみ。
