### PR TITLE
feat(attach): attach multiple (program, func) pairs in one run

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ sudo xdp-ninja -i eth0 --list-funcs
 
 # Attach to a specific __noinline subfunction (entry/exit only)
 sudo xdp-ninja -i eth0 --func process_packet | tcpdump -n -r -
+
+# Attach several (program, func) pairs in one run: -p and --func are
+# repeatable, and each func attaches in every listed program whose BTF
+# has it. All attach points share one ringbuf and merge into one pcap.
+# (e.g. UL + DL capture points living in separate per-direction programs)
+sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
+  --func pgwu_capture_point_ul --func pgwu_capture_point_dl -w all.pcap
 ```
 
 ### Filter syntax

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -411,7 +411,11 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	// --list-funcs: print available BTF functions per target and exit
 	if cmd.Bool("list-funcs") {
 		for _, info := range infos {
-			funcs, err := attach.ListFuncs(info.Program)
+			spec, err := info.BTFSpecCached()
+			if err != nil {
+				return fmt.Errorf("program (id=%d): %w", info.ProgID, err)
+			}
+			funcs, err := attach.ListFuncsFromSpec(spec)
 			if err != nil {
 				return err
 			}

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -39,9 +39,9 @@ var flags = []cli.Flag{
 		Name: "interface", Aliases: []string{"i"},
 		Usage: "network interface to capture on",
 	},
-	&cli.IntFlag{
+	&cli.IntSliceFlag{
 		Name: "prog-id", Aliases: []string{"p"},
-		Usage: "BPF program ID to attach to (use instead of -i for multi-prog setups)",
+		Usage: "BPF program ID to attach to (use instead of -i for multi-prog setups); repeatable to attach several programs in one run",
 	},
 	&cli.StringFlag{
 		Name: "write", Aliases: []string{"w"},
@@ -55,9 +55,9 @@ var flags = []cli.Flag{
 		Name: "count", Aliases: []string{"c"},
 		Usage: "exit after capturing N packets (0 = unlimited)",
 	},
-	&cli.StringFlag{
+	&cli.StringSliceFlag{
 		Name:  "func",
-		Usage: "attach to a specific __noinline subfunction (by BTF name) instead of the entry function",
+		Usage: "attach to a specific __noinline subfunction (by BTF name) instead of the entry function; repeatable, and each func attaches in every target program whose BTF has it",
 	},
 	&cli.BoolFlag{
 		Name:  "list-funcs",
@@ -370,126 +370,142 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return runXDPNative(cmd)
 	}
 
-	info, err := findTarget(cmd, isTC)
+	infos, err := findTargets(cmd, isTC)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = info.Program.Close() }()
+	defer func() {
+		for _, in := range infos {
+			_ = in.Program.Close()
+		}
+	}()
 
 	// --list-progs: show reachable programs (tail calls +
 	// CPUMAP/DEVMAP/DEVMAP_HASH redirect targets, followed
-	// transitively), then exit
+	// transitively) for each target, then exit
 	if cmd.Bool("list-progs") {
-		fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
+		for _, info := range infos {
+			fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
 
-		progs, err := attach.WalkReachablePrograms(info.Program, info.ProgID)
-		if err != nil {
-			return err
-		}
-		byParent := map[uint32][]attach.ReachableProgram{}
-		for _, p := range progs {
-			byParent[p.ParentID] = append(byParent[p.ParentID], p)
-		}
-		var printTree func(parent uint32, indent string)
-		printTree = func(parent uint32, indent string) {
-			for _, c := range byParent[parent] {
-				fmt.Fprintf(os.Stderr, "%sid=%-6d %s (%s[%s])\n",
-					indent, c.ProgID, c.ProgName, c.Via, formatKeyRanges(c.Keys))
-				printTree(c.ProgID, indent+"  ")
-			}
-		}
-		printTree(info.ProgID, "  ")
-		return nil
-	}
-
-	// --list-funcs: print available BTF functions and exit
-	if cmd.Bool("list-funcs") {
-		funcs, err := attach.ListFuncs(info.Program)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stderr, "BTF functions in program (id=%d):\n", info.ProgID)
-		for _, f := range funcs {
-			fmt.Fprintf(os.Stderr, "  %-40s [%s]\n", f.Name, f.Linkage)
-		}
-		return nil
-	}
-
-	// --func: override target function name.
-	// Open BTF once and share across validation and parameter extraction.
-	funcName := cmd.String("func")
-	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0 || cmd.Bool("arg-echo")
-	var params []attach.FuncParamInfo
-	if funcName != "" {
-		spec, err := attach.BTFSpec(info.Program)
-		if err != nil {
-			return fmt.Errorf("program (id=%d): %w", info.ProgID, err)
-		}
-		if err := attach.ValidateSubfuncFromSpec(spec, info.ProgID, funcName); err != nil {
-			return err
-		}
-		logVerbose(cmd, "overriding entry function with --func %q", funcName)
-		info.FuncName = funcName
-
-		if needParams {
-			params, err = attach.GetFuncParamsFromSpec(spec, funcName)
+			progs, err := attach.WalkReachablePrograms(info.Program, info.ProgID)
 			if err != nil {
 				return err
 			}
-		}
-	} else if needParams {
-		if cmd.Bool("list-params") {
-			return fmt.Errorf("--list-params requires --func")
-		}
-		if cmd.Bool("arg-echo") {
-			return fmt.Errorf("--arg-echo requires --func")
-		}
-		return fmt.Errorf("--arg-filter requires --func")
-	}
-
-	// --list-params: show filterable parameters, then exit
-	if cmd.Bool("list-params") {
-		fmt.Fprintf(os.Stderr, "Filterable parameters for %s (id=%d):\n", funcName, info.ProgID)
-		if len(params) == 0 {
-			fmt.Fprintf(os.Stderr, "  (none - only integer parameters after the first argument are supported)\n")
-		}
-		for _, p := range params {
-			signStr := "unsigned"
-			if p.Signed {
-				signStr = "signed"
+			byParent := map[uint32][]attach.ReachableProgram{}
+			for _, p := range progs {
+				byParent[p.ParentID] = append(byParent[p.ParentID], p)
 			}
-			fmt.Fprintf(os.Stderr, "  %-20s [%d bytes, %s, arg index %d]\n", p.Name, p.Size, signStr, p.Index)
+			var printTree func(parent uint32, indent string)
+			printTree = func(parent uint32, indent string) {
+				for _, c := range byParent[parent] {
+					fmt.Fprintf(os.Stderr, "%sid=%-6d %s (%s[%s])\n",
+						indent, c.ProgID, c.ProgName, c.Via, formatKeyRanges(c.Keys))
+					printTree(c.ProgID, indent+"  ")
+				}
+			}
+			printTree(info.ProgID, "  ")
 		}
 		return nil
 	}
 
-	// --arg-filter: parse and validate argument filters
-	var argFilters []filter.ArgFilter
-	if argFilterExprs := cmd.StringSlice("arg-filter"); len(argFilterExprs) > 0 {
-		var err error
-		argFilters, err = filter.ParseAndValidateFilters(argFilterExprs, params)
-		if err != nil {
-			return err
+	// --list-funcs: print available BTF functions per target and exit
+	if cmd.Bool("list-funcs") {
+		for _, info := range infos {
+			funcs, err := attach.ListFuncs(info.Program)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "BTF functions in program (id=%d):\n", info.ProgID)
+			for _, f := range funcs {
+				fmt.Fprintf(os.Stderr, "  %-40s [%s]\n", f.Name, f.Linkage)
+			}
 		}
-		for _, f := range argFilters {
-			logVerbose(cmd, "arg filter: %s", f.String())
+		return nil
+	}
+
+	// Resolve the concrete (program, func) attach pairs: each --func
+	// attaches in every target program whose BTF carries it (noinline
+	// subfuncs get one copy per calling program); without --func each
+	// program contributes its entry function.
+	funcNames := cmd.StringSlice("func")
+	needParams := cmd.Bool("list-params") || len(cmd.StringSlice("arg-filter")) > 0 || cmd.Bool("arg-echo")
+	if len(funcNames) == 0 && needParams {
+		switch {
+		case cmd.Bool("list-params"):
+			return fmt.Errorf("--list-params requires --func")
+		case cmd.Bool("arg-echo"):
+			return fmt.Errorf("--arg-echo requires --func")
+		default:
+			return fmt.Errorf("--arg-filter requires --func")
+		}
+	}
+	targets, err := attach.ResolveTargets(infos, funcNames)
+	if err != nil {
+		return err
+	}
+	for _, t := range targets {
+		logVerbose(cmd, "attach target: prog id=%d func=%q", t.ProgID, t.FuncName)
+	}
+
+	// --list-params: show filterable parameters per attach pair, then exit.
+	// Params were resolved once from each program's cached BTF during
+	// ResolveTargets.
+	if cmd.Bool("list-params") {
+		for _, t := range targets {
+			fmt.Fprintf(os.Stderr, "Filterable parameters for %s (id=%d):\n", t.FuncName, t.ProgID)
+			if len(t.Params) == 0 {
+				fmt.Fprintf(os.Stderr, "  (none - only integer parameters after the first argument are supported)\n")
+			}
+			for _, p := range t.Params {
+				signStr := "unsigned"
+				if p.Signed {
+					signStr = "signed"
+				}
+				fmt.Fprintf(os.Stderr, "  %-20s [%d bytes, %s, arg index %d]\n", p.Name, p.Size, signStr, p.Index)
+			}
+		}
+		return nil
+	}
+
+	// --arg-filter: validate and resolve per target — the same param name
+	// can sit at a different arg index (or width) in different funcs, so
+	// each attach pair gets filters bound to its own BTF param layout.
+	var argFilters [][]filter.ArgFilter
+	if argFilterExprs := cmd.StringSlice("arg-filter"); len(argFilterExprs) > 0 {
+		argFilters = make([][]filter.ArgFilter, len(targets))
+		for i, t := range targets {
+			fs, err := filter.ParseAndValidateFilters(argFilterExprs, t.Params)
+			if err != nil {
+				return fmt.Errorf("func %s (id=%d): %w", t.FuncName, t.ProgID, err)
+			}
+			argFilters[i] = fs
+			for _, f := range fs {
+				logVerbose(cmd, "arg filter on %s: %s", t.FuncName, f.String())
+			}
 		}
 	}
 
 	// --arg-echo: emit the function's integer args instead of capturing
-	// packets. Reuses the parsed argFilters as a gate and the resolved
-	// integer params as the echo set.
+	// packets. Single-target diagnostic — with multiple attach pairs the
+	// interleaved output would be ambiguous, so require exactly one.
 	if cmd.Bool("arg-echo") {
-		probe, err := program.LoadArgEcho(info.Program, info.FuncName, argFilters, params, isFexit)
+		if len(targets) != 1 {
+			return fmt.Errorf("--arg-echo supports exactly one (program, func) target; %d resolved", len(targets))
+		}
+		t := targets[0]
+		var af []filter.ArgFilter
+		if argFilters != nil {
+			af = argFilters[0]
+		}
+		probe, err := program.LoadArgEcho(t.Program, t.FuncName, af, t.Params, isFexit)
 		if err != nil {
 			return err
 		}
 		printProbeWarnings(probe)
-		return runArgEchoLoop(cmd, probe, info.FuncName)
+		return runArgEchoLoop(cmd, probe, t.FuncName)
 	}
 
 	filterExpr := strings.Join(cmd.Args().Slice(), " ")
-	logVerbose(cmd, "found XDP program %q (id=%d)", info.FuncName, info.ProgID)
 	if filterExpr != "" {
 		logVerbose(cmd, "filter: %s", filterExpr)
 	}
@@ -498,15 +514,29 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	probe, err := loadProbe(isFexit, info, filterExpr, argFilters, useDSL)
+	var probe *program.Probe
+	if isFexit {
+		probe, err = program.LoadMultiExit(targets, filterExpr, argFilters, useDSL)
+	} else {
+		probe, err = program.LoadMultiEntry(targets, filterExpr, argFilters, useDSL)
+	}
 	if err != nil {
 		return err
 	}
 	printProbeWarnings(probe)
 
-	label := fmt.Sprintf("prog %q id=%d", info.FuncName, info.ProgID)
-	if info.IfaceName != "" {
-		label = fmt.Sprintf("%s on %s", label, info.IfaceName)
+	var label string
+	if len(targets) == 1 {
+		label = fmt.Sprintf("prog %q id=%d", targets[0].FuncName, targets[0].ProgID)
+		if infos[0].IfaceName != "" {
+			label = fmt.Sprintf("%s on %s", label, infos[0].IfaceName)
+		}
+	} else {
+		names := make([]string, len(targets))
+		for i, t := range targets {
+			names[i] = fmt.Sprintf("%s@%d", t.FuncName, t.ProgID)
+		}
+		label = fmt.Sprintf("%d attach points: %s", len(targets), strings.Join(names, ", "))
 	}
 	return runCaptureLoop(cmd, probe, isFexit, fmt.Sprintf("%s, mode=%s", label, mode))
 }
@@ -1091,10 +1121,10 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	if cmd.String("interface") == "" {
 		return fmt.Errorf("--mode xdp requires -i <interface>")
 	}
-	if cmd.Int("prog-id") != 0 {
+	if len(cmd.IntSlice("prog-id")) > 0 {
 		return fmt.Errorf("--mode xdp does not accept -p (the program is xdp-ninja itself, not an existing one)")
 	}
-	if cmd.String("func") != "" {
+	if len(cmd.StringSlice("func")) > 0 {
 		return fmt.Errorf("--func is only valid with --mode entry/exit (no BTF subfunction concept in xdp-native)")
 	}
 	if len(cmd.StringSlice("arg-filter")) > 0 {
@@ -1106,37 +1136,57 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	return nil
 }
 
-func findTarget(cmd *cli.Command, isTC bool) (*attach.ProgInfo, error) {
+// findTargets resolves `-p` (repeatable) or `-i` (single) into the target
+// programs. Multiple programs come only from repeated -p; an interface
+// still resolves to the single XDP program attached to it.
+func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	ifaceName := cmd.String("interface")
-	progID := cmd.Int("prog-id")
+	progIDs := cmd.IntSlice("prog-id")
 
-	if ifaceName != "" && progID != 0 {
+	if ifaceName != "" && len(progIDs) > 0 {
 		return nil, fmt.Errorf("specify either -i or -p, not both")
 	}
-	if ifaceName == "" && progID == 0 {
+	if ifaceName == "" && len(progIDs) == 0 {
 		return nil, fmt.Errorf("specify -i <interface> or -p <prog-id>")
 	}
 
-	if isTC {
-		// tc clsact targets are addressed by program ID — no
-		// interface-based clsact qdisc walk wired up yet.
-		if ifaceName != "" {
+	if ifaceName != "" {
+		if isTC {
+			// tc clsact targets are addressed by program ID — no
+			// interface-based clsact qdisc walk wired up yet.
 			return nil, fmt.Errorf("--mode tc-* requires -p <prog-id>; interface-based tc target lookup is not implemented")
 		}
-		return attach.FindBPFProgramByID(uint32(progID))
+		info, err := attach.FindXDPProgram(ifaceName)
+		if err != nil {
+			return nil, err
+		}
+		return []*attach.ProgInfo{info}, nil
 	}
 
-	if progID != 0 {
-		return attach.FindXDPProgramByID(uint32(progID))
+	var infos []*attach.ProgInfo
+	seen := map[uint32]bool{}
+	for _, id := range progIDs {
+		pid := uint32(id)
+		if seen[pid] {
+			continue
+		}
+		seen[pid] = true
+		var info *attach.ProgInfo
+		var err error
+		if isTC {
+			info, err = attach.FindBPFProgramByID(pid)
+		} else {
+			info, err = attach.FindXDPProgramByID(pid)
+		}
+		if err != nil {
+			for _, prev := range infos {
+				_ = prev.Program.Close()
+			}
+			return nil, err
+		}
+		infos = append(infos, info)
 	}
-	return attach.FindXDPProgram(ifaceName)
-}
-
-func loadProbe(isFexit bool, info *attach.ProgInfo, filterExpr string, argFilters []filter.ArgFilter, useDSL bool) (*program.Probe, error) {
-	if isFexit {
-		return program.LoadExit(info.Program, info.FuncName, filterExpr, argFilters, useDSL)
-	}
-	return program.LoadEntry(info.Program, info.FuncName, filterExpr, argFilters, useDSL)
+	return infos, nil
 }
 
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -1166,6 +1166,9 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	var infos []*attach.ProgInfo
 	seen := map[uint32]bool{}
 	for _, id := range progIDs {
+		if id <= 0 {
+			return nil, fmt.Errorf("invalid prog-id %d: must be a positive BPF program ID", id)
+		}
 		pid := uint32(id)
 		if seen[pid] {
 			continue

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -420,6 +420,27 @@ mergecap -w merged.pcap path.pcap.cpu*
 
 注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます (raw-dump は自動マージの対象外)。
 
+## 複数の (プログラム, 関数) に同時アタッチする
+
+`-p` と `--func` はどちらも繰り返し指定できます。各 `--func` は、指定した全プログラムのうち **BTF にその関数を持つものすべて**にアタッチされます (無いプログラムはスキップ。どのプログラムにも無い関数名はエラー)。`--func` を省略した場合は各プログラムの entry 関数が対象です。
+
+多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムへ散り、さらに noinline サブ関数は呼び出し元プログラムごとに実体を持ちます (例: `pgwu_capture_point_dl` が v4/v6 ハンドラ両方に入る)。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で張れます。
+
+```bash
+# --list-progs で dispatcher から末端の prog ID を洗い出し
+sudo xdp-ninja -i ens2f0 --list-progs
+
+# UL + DL (v4/v6 両実体) を1回でアタッチ。--func pgwu_capture_point_dl は
+# 1610/1611 の両方に、_ul は 1614 だけにマッチする
+sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
+  --func pgwu_capture_point_ul --func pgwu_capture_point_dl \
+  --arg-filter "imsi=901040010000005" -w all.pcap
+```
+
+- 全アタッチポイントが **1本の共有 ringbuf** に emit するので、出力は通常どおり 1 つの pcap に時刻順で入ります (`-w` なら終了時マージ、stdout なら直列化ストリーム)。
+- `--arg-filter` は関数ごとに BTF を引いて検証・解決されます。同じ param 名が関数によって別の引数位置にあっても正しく効きます。指定した param を持たない関数が混ざるとエラーになります。
+- XDP と tc のターゲット混在は不可 (別々に起動してください)。`--arg-echo` は単一 (プログラム, 関数) のみ。
+
 ## 関数引数の値を覗く (`--arg-echo`)
 
 `--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、「そもそも引数にどんな値が乗っているか」を確認するのに使います (例: IMSI が 10 進なのか TBCD なのか)。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -22,6 +22,26 @@ type ProgInfo struct {
 	FuncName  string // BTF-resolved entry function name
 	IfaceName string
 	Type      ebpf.ProgramType
+
+	// Spec is the program's parsed BTF, cached by the Find* constructors
+	// (parsing is the expensive part of BTFSpec) so downstream lookups —
+	// target resolution, param extraction — don't re-parse per call.
+	// May be nil for hand-built ProgInfos; use BTFSpecCached.
+	Spec *btf.Spec
+}
+
+// BTFSpecCached returns the cached BTF spec, opening and caching it on
+// first use for ProgInfos constructed without one.
+func (p *ProgInfo) BTFSpecCached() (*btf.Spec, error) {
+	if p.Spec != nil {
+		return p.Spec, nil
+	}
+	spec, err := BTFSpec(p.Program)
+	if err != nil {
+		return nil, err
+	}
+	p.Spec = spec
+	return spec, nil
 }
 
 // FindXDPProgramByID gets an XDP program by its BPF program ID. The
@@ -62,7 +82,7 @@ func FindBPFProgramByID(progID uint32) (*ProgInfo, error) {
 		return nil, fmt.Errorf("program (id=%d) type %s is not supported (need XDP, SchedCLS, or SchedACT)", progID, progType)
 	}
 
-	funcName, err := resolveEntryFunc(prog, progID)
+	funcName, spec, err := resolveEntryFunc(prog, progID)
 	if err != nil {
 		_ = prog.Close()
 		return nil, err
@@ -73,6 +93,7 @@ func FindBPFProgramByID(progID uint32) (*ProgInfo, error) {
 		Program:  prog,
 		FuncName: funcName,
 		Type:     progType,
+		Spec:     spec,
 	}, nil
 }
 
@@ -143,7 +164,7 @@ func FindXDPProgram(ifaceName string) (*ProgInfo, error) {
 		return nil, fmt.Errorf("getting XDP program (id=%d): %w", xdp.ProgId, err)
 	}
 
-	funcName, err := resolveEntryFunc(prog, xdp.ProgId)
+	funcName, spec, err := resolveEntryFunc(prog, xdp.ProgId)
 	if err != nil {
 		_ = prog.Close()
 		return nil, err
@@ -155,6 +176,7 @@ func FindXDPProgram(ifaceName string) (*ProgInfo, error) {
 		FuncName:  funcName,
 		IfaceName: ifaceName,
 		Type:      ebpf.XDP,
+		Spec:      spec,
 	}, nil
 }
 
@@ -567,22 +589,22 @@ func ListFuncsFromSpec(spec *btf.Spec) ([]FuncInfo, error) {
 //     and a btf.Func starts with that prefix — but only if exactly one matches
 //  3. Single Func: BTF has exactly one Func entry
 //  4. Error: ambiguous or no match
-func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
+func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, *btf.Spec, error) {
 	info, err := prog.Info()
 	if err != nil {
-		return "", fmt.Errorf("program id=%d: getting info: %w", progID, err)
+		return "", nil, fmt.Errorf("program id=%d: getting info: %w", progID, err)
 	}
 	progName := info.Name
 
 	spec, err := BTFSpec(prog)
 	if err != nil {
-		return "", fmt.Errorf("program %q (id=%d): %w", progName, progID, err)
+		return "", nil, fmt.Errorf("program %q (id=%d): %w", progName, progID, err)
 	}
 
 	// 1. Exact match
 	var fn *btf.Func
 	if err := spec.TypeByName(progName, &fn); err == nil {
-		return fn.Name, nil
+		return fn.Name, spec, nil
 	}
 
 	// Collect all Func entries
@@ -597,7 +619,7 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 	}
 
 	if len(funcs) == 0 {
-		return "", fmt.Errorf("program %q (id=%d): no btf.Func found in BTF", progName, progID)
+		return "", nil, fmt.Errorf("program %q (id=%d): no btf.Func found in BTF", progName, progID)
 	}
 
 	// 2. Prefix match (prog name may be truncated to 15 chars by kernel)
@@ -609,10 +631,10 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 			}
 		}
 		if len(matches) == 1 {
-			return matches[0], nil
+			return matches[0], spec, nil
 		}
 		if len(matches) > 1 {
-			return "", fmt.Errorf(
+			return "", nil, fmt.Errorf(
 				"program %q (id=%d): ambiguous BTF function name (truncated prog name matches %d funcs: %v)",
 				progName, progID, len(matches), matches,
 			)
@@ -621,11 +643,11 @@ func resolveEntryFunc(prog *ebpf.Program, progID uint32) (string, error) {
 
 	// 3. Single Func
 	if len(funcs) == 1 {
-		return funcs[0], nil
+		return funcs[0], spec, nil
 	}
 
 	// 4. Ambiguous
-	return "", fmt.Errorf(
+	return "", nil, fmt.Errorf(
 		"program %q (id=%d): cannot resolve entry function from BTF (%d candidates: %v)",
 		progName, progID, len(funcs), funcs,
 	)

--- a/internal/attach/targets.go
+++ b/internal/attach/targets.go
@@ -1,0 +1,132 @@
+// Multi-target resolution for `-p` (repeatable) × `--func` (repeatable):
+// expand program × function into the concrete (program, BTF func) pairs a
+// fentry/fexit probe can attach to. Multi-stage dispatchers (cpu_dispatch →
+// CPUMAP → per-direction handlers) put capture points in separate programs,
+// and noinline subfunctions get one copy per calling program (e.g. a
+// `pgwu_capture_point_dl` in both the v4 and the v6 handler), so covering
+// UL+DL takes several attaches in one run.
+package attach
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+)
+
+// Target is one (program, function) pair to attach a tracing probe to.
+// Params carries the func's filterable integer parameters, resolved once
+// from the program's cached BTF so downstream arg-filter / list-params /
+// arg-echo consumers don't re-parse BTF per use.
+type Target struct {
+	Program  *ebpf.Program
+	ProgID   uint32
+	FuncName string
+	Type     ebpf.ProgramType
+	Params   []FuncParamInfo
+}
+
+// CloseTargets closes the programs of all targets. Each program handle is
+// opened once per -p / -i even when several funcs target it, so dedup by
+// pointer before closing.
+func CloseTargets(targets []Target) {
+	seen := map[*ebpf.Program]bool{}
+	for _, t := range targets {
+		if t.Program != nil && !seen[t.Program] {
+			seen[t.Program] = true
+			_ = t.Program.Close()
+		}
+	}
+}
+
+// ResolveTargets expands the given programs × funcNames into attachable
+// (program, func) pairs.
+//
+// For each program: if funcNames is empty, its BTF-resolved entry function
+// (already on ProgInfo) is the single target. Otherwise each requested func
+// that exists in the program's BTF becomes a target; funcs missing from a
+// program are skipped (multi-program setups rarely have every func in every
+// program), but a func found in no program at all is an error listing the
+// functions that do exist. Duplicate (progID, func) pairs collapse.
+//
+// The returned targets borrow the ProgInfo program handles; free them with
+// CloseTargets. Program-type validation (uniform, supported) is owned by
+// program.loadMulti, the single enforcement point every attach path passes
+// through.
+func ResolveTargets(infos []*ProgInfo, funcNames []string) ([]Target, error) {
+	var targets []Target
+	seenPair := map[string]bool{}
+	funcFound := map[string]bool{}
+
+	addTarget := func(info *ProgInfo, fn string, params []FuncParamInfo) {
+		key := fmt.Sprintf("%d/%s", info.ProgID, fn)
+		if seenPair[key] {
+			return
+		}
+		seenPair[key] = true
+		targets = append(targets, Target{
+			Program: info.Program, ProgID: info.ProgID, FuncName: fn,
+			Type: info.Type, Params: params,
+		})
+	}
+
+	for _, info := range infos {
+		if len(funcNames) == 0 {
+			// Entry functions never take filterable args (their only
+			// param is the ctx pointer), so no params to resolve.
+			addTarget(info, info.FuncName, nil)
+			continue
+		}
+		spec, err := info.BTFSpecCached()
+		if err != nil {
+			return nil, fmt.Errorf("program (id=%d): %w", info.ProgID, err)
+		}
+		for _, fn := range funcNames {
+			var f *btf.Func
+			if err := spec.TypeByName(fn, &f); err != nil {
+				continue // this program doesn't carry fn — fine in multi setups
+			}
+			funcFound[fn] = true
+			params, err := GetFuncParamsFromSpec(spec, fn)
+			if err != nil {
+				return nil, fmt.Errorf("program (id=%d) func %s: %w", info.ProgID, fn, err)
+			}
+			addTarget(info, fn, params)
+		}
+	}
+
+	for _, fn := range funcNames {
+		if !funcFound[fn] {
+			return nil, fmt.Errorf("function %q not found in any target program's BTF; available functions: %v",
+				fn, availableFuncs(infos))
+		}
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no attachable (program, function) pairs resolved")
+	}
+	return targets, nil
+}
+
+// availableFuncs collects the BTF function names across all target
+// programs, for the not-found error message.
+func availableFuncs(infos []*ProgInfo) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, info := range infos {
+		spec, err := info.BTFSpecCached()
+		if err != nil {
+			continue
+		}
+		funcs, err := ListFuncsFromSpec(spec)
+		if err != nil {
+			continue
+		}
+		for _, f := range funcs {
+			if !seen[f.Name] {
+				seen[f.Name] = true
+				names = append(names, f.Name)
+			}
+		}
+	}
+	return names
+}

--- a/internal/program/multiattach_test.go
+++ b/internal/program/multiattach_test.go
@@ -1,0 +1,223 @@
+package program
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/capture/fastrb"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// multiXDPSource builds a distinct XDP program whose entry function is
+// entryName. The body must be non-trivial so clang keeps it.
+func multiXDPSource(entryName string) string {
+	return fmt.Sprintf(`
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+SEC("xdp")
+int %s(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+char _license[] SEC("license") = "GPL";
+`, entryName)
+}
+
+// multiNoinlineSource builds an XDP program with entryName calling a
+// __noinline subfunction named capture_pt — the same subfunction name in
+// several programs, like a shared DL capture point compiled into both the
+// v4 and v6 handlers.
+func multiNoinlineSource(entryName string) string {
+	return fmt.Sprintf(`
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int capture_pt(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 1 > data_end)
+        return 1;
+    return 2;
+}
+
+SEC("xdp")
+int %s(struct xdp_md *ctx) { return capture_pt(ctx); }
+char _license[] SEC("license") = "GPL";
+`, entryName)
+}
+
+// loadXDPByName compiles src and loads the program named entryName.
+func loadXDPByName(t *testing.T, src, entryName string) *ebpf.Program {
+	t.Helper()
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, src))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		t.Fatalf("loading collection: %v", err)
+	}
+	prog := coll.Programs[entryName]
+	if prog == nil {
+		coll.Close()
+		t.Fatalf("program %s not in collection", entryName)
+	}
+	// Detach the program from the collection lifetime.
+	prog2 := prog
+	delete(coll.Programs, entryName)
+	coll.Close()
+	t.Cleanup(func() { _ = prog2.Close() })
+	return prog2
+}
+
+// progInfoFor wraps a loaded program as attach.ProgInfo for ResolveTargets.
+func progInfoFor(t *testing.T, prog *ebpf.Program, funcName string) *attach.ProgInfo {
+	t.Helper()
+	info, err := prog.Info()
+	if err != nil {
+		t.Fatalf("prog info: %v", err)
+	}
+	id, ok := info.ID()
+	if !ok {
+		t.Fatal("program has no ID")
+	}
+	return &attach.ProgInfo{Program: prog, ProgID: uint32(id), FuncName: funcName, Type: ebpf.XDP}
+}
+
+// drainMarkers reads every shard of the probe's ringbuf and collects the
+// first payload byte (the per-source marker) of each captured record.
+func drainMarkers(t *testing.T, probe *Probe) map[byte]int {
+	t.Helper()
+	markers := map[byte]int{}
+	innerSize := int(shardRingbufSize(RingbufSize, runtime.NumCPU()))
+	for i, m := range probe.InnerMaps {
+		rd, err := fastrb.New(m.FD(), innerSize)
+		if err != nil {
+			t.Fatalf("fastrb on shard %d: %v", i, err)
+		}
+		rd.ReadBatch(func(rec []byte) {
+			if len(rec) > metadataSize { // metadata + at least 1 payload byte
+				markers[rec[metadataSize]]++
+			}
+		})
+		_ = rd.Close()
+	}
+	return markers
+}
+
+// runWithMarker test-runs an XDP program with a packet whose first byte is
+// the given marker, firing any attached fentry probes.
+func runWithMarker(t *testing.T, prog *ebpf.Program, marker byte) {
+	t.Helper()
+	in := make([]byte, 64)
+	in[0] = marker
+	if _, err := prog.Run(&ebpf.RunOptions{Data: in}); err != nil {
+		t.Fatalf("test-run: %v", err)
+	}
+}
+
+// TestBpfMultiAttachEntryPrograms covers case (A): one probe attached to
+// the entry functions of two independent XDP programs, both emitting into
+// the shared ringbuf.
+func TestBpfMultiAttachEntryPrograms(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	progA := loadXDPByName(t, multiXDPSource("xdp_multi_a"), "xdp_multi_a")
+	progB := loadXDPByName(t, multiXDPSource("xdp_multi_b"), "xdp_multi_b")
+
+	infos := []*attach.ProgInfo{
+		progInfoFor(t, progA, "xdp_multi_a"),
+		progInfoFor(t, progB, "xdp_multi_b"),
+	}
+	// No --func: each program contributes its entry function.
+	targets, err := attach.ResolveTargets(infos, nil)
+	if err != nil {
+		t.Fatalf("ResolveTargets: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("resolved %d targets, want 2: %+v", len(targets), targets)
+	}
+
+	probe, err := LoadMultiEntry(targets, "", nil, true)
+	if err != nil {
+		t.Fatalf("LoadMultiEntry: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+	if probe.AttachCount() != 2 {
+		t.Fatalf("AttachCount = %d, want 2", probe.AttachCount())
+	}
+
+	runWithMarker(t, progA, 0xAA)
+	runWithMarker(t, progB, 0xBB)
+
+	markers := drainMarkers(t, probe)
+	if markers[0xAA] == 0 || markers[0xBB] == 0 {
+		t.Fatalf("expected events from both programs in the shared ringbuf, got markers %v", markers)
+	}
+}
+
+// TestBpfMultiAttachNoinlineAcrossPrograms covers case (B): one --func
+// name (a __noinline subfunction) that exists in two programs — like a
+// shared DL capture point in both the v4 and the v6 handler — resolves to
+// two attach pairs and both fire into the shared ringbuf.
+func TestBpfMultiAttachNoinlineAcrossPrograms(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	progV4 := loadXDPByName(t, multiNoinlineSource("xdp_v4_handler"), "xdp_v4_handler")
+	progV6 := loadXDPByName(t, multiNoinlineSource("xdp_v6_handler"), "xdp_v6_handler")
+
+	infos := []*attach.ProgInfo{
+		progInfoFor(t, progV4, "xdp_v4_handler"),
+		progInfoFor(t, progV6, "xdp_v6_handler"),
+	}
+	targets, err := attach.ResolveTargets(infos, []string{"capture_pt"})
+	if err != nil {
+		t.Fatalf("ResolveTargets: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("resolved %d targets, want 2 (capture_pt in both programs): %+v", len(targets), targets)
+	}
+	for _, tg := range targets {
+		if tg.FuncName != "capture_pt" {
+			t.Fatalf("target func = %q, want capture_pt", tg.FuncName)
+		}
+	}
+
+	probe, err := LoadMultiEntry(targets, "", nil, true)
+	if err != nil {
+		t.Fatalf("LoadMultiEntry: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+	if probe.AttachCount() != 2 {
+		t.Fatalf("AttachCount = %d, want 2", probe.AttachCount())
+	}
+
+	runWithMarker(t, progV4, 0x44)
+	runWithMarker(t, progV6, 0x66)
+
+	markers := drainMarkers(t, probe)
+	if markers[0x44] == 0 || markers[0x66] == 0 {
+		t.Fatalf("expected events from both noinline copies in the shared ringbuf, got markers %v", markers)
+	}
+}
+
+// TestResolveTargetsFuncMissingEverywhere verifies a func found in no
+// target program is an error rather than a silent no-attach.
+func TestResolveTargetsFuncMissingEverywhere(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	prog := loadXDPByName(t, multiXDPSource("xdp_multi_solo"), "xdp_multi_solo")
+	infos := []*attach.ProgInfo{progInfoFor(t, prog, "xdp_multi_solo")}
+	if _, err := attach.ResolveTargets(infos, []string{"no_such_func"}); err == nil {
+		t.Fatal("expected error for func missing from every program, got nil")
+	}
+}

--- a/internal/program/multiattach_test.go
+++ b/internal/program/multiattach_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/cilium/ebpf"
 
@@ -95,23 +96,41 @@ func progInfoFor(t *testing.T, prog *ebpf.Program, funcName string) *attach.Prog
 
 // drainMarkers reads every shard of the probe's ringbuf and collects the
 // first payload byte (the per-source marker) of each captured record.
-func drainMarkers(t *testing.T, probe *Probe) map[byte]int {
+// Records from a synchronous BPF_PROG_TEST_RUN are committed before Run
+// returns, but retry briefly anyway so a slow/contended CI runner can't
+// flake the drain; wantMarkers is the number of distinct markers expected.
+func drainMarkers(t *testing.T, probe *Probe, wantMarkers int) map[byte]int {
 	t.Helper()
 	markers := map[byte]int{}
 	innerSize := int(shardRingbufSize(RingbufSize, runtime.NumCPU()))
+	readers := make([]*fastrb.Reader, len(probe.InnerMaps))
 	for i, m := range probe.InnerMaps {
 		rd, err := fastrb.New(m.FD(), innerSize)
 		if err != nil {
 			t.Fatalf("fastrb on shard %d: %v", i, err)
 		}
-		rd.ReadBatch(func(rec []byte) {
-			if len(rec) > metadataSize { // metadata + at least 1 payload byte
-				markers[rec[metadataSize]]++
-			}
-		})
-		_ = rd.Close()
+		readers[i] = rd
 	}
-	return markers
+	defer func() {
+		for _, rd := range readers {
+			_ = rd.Close()
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		for _, rd := range readers {
+			rd.ReadBatch(func(rec []byte) {
+				if len(rec) > metadataSize { // metadata + at least 1 payload byte
+					markers[rec[metadataSize]]++
+				}
+			})
+		}
+		if len(markers) >= wantMarkers || time.Now().After(deadline) {
+			return markers
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 // runWithMarker test-runs an XDP program with a packet whose first byte is
@@ -159,7 +178,7 @@ func TestBpfMultiAttachEntryPrograms(t *testing.T) {
 	runWithMarker(t, progA, 0xAA)
 	runWithMarker(t, progB, 0xBB)
 
-	markers := drainMarkers(t, probe)
+	markers := drainMarkers(t, probe, 2)
 	if markers[0xAA] == 0 || markers[0xBB] == 0 {
 		t.Fatalf("expected events from both programs in the shared ringbuf, got markers %v", markers)
 	}
@@ -204,7 +223,7 @@ func TestBpfMultiAttachNoinlineAcrossPrograms(t *testing.T) {
 	runWithMarker(t, progV4, 0x44)
 	runWithMarker(t, progV6, 0x66)
 
-	markers := drainMarkers(t, probe)
+	markers := drainMarkers(t, probe, 2)
 	if markers[0x44] == 0 || markers[0x66] == 0 {
 		t.Fatalf("expected events from both noinline copies in the shared ringbuf, got markers %v", markers)
 	}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -22,7 +22,9 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-// Probe は fentry または fexit の1つのトレーシングポイント。
+// Probe は fentry/fexit のトレーシングポイント群。単一ターゲットなら
+// progs/links は1要素、multi-attach (複数の (prog, func) ペア) では
+// 各ペアに1本ずつ載り、全プローブが同じ sharded ringbuf に emit する。
 type Probe struct {
 	EventsMap *ebpf.Map
 	InnerMaps []*ebpf.Map // non-nil only in per-CPU sharded mode
@@ -35,29 +37,38 @@ type Probe struct {
 	EchoRing   *ebpf.Map
 	EchoParams []attach.FuncParamInfo
 
-	maps []*ebpf.Map
-	prog *ebpf.Program
-	link link.Link
+	maps  []*ebpf.Map
+	progs []*ebpf.Program // one per attached (target prog, func) pair
+	links []link.Link     // parallel to progs
 }
 
-// Program returns the underlying tracing program. Exposed so that
+// Program returns the first underlying tracing program. Exposed so that
 // benchmarks (E2 / B2) can call Program.Test() to measure the per-
 // packet runtime cost of the filter via BPF_PROG_TEST_RUN. Not
 // intended for general callers — production code should manipulate
 // the probe through Close() / EventsMap.
 func (p *Probe) Program() *ebpf.Program {
-	return p.prog
+	if len(p.progs) == 0 {
+		return nil
+	}
+	return p.progs[0]
+}
+
+// AttachCount reports how many (target prog, func) pairs this probe is
+// attached to.
+func (p *Probe) AttachCount() int {
+	return len(p.links)
 }
 
 func (p *Probe) Close() error {
 	var errs []error
-	if p.link != nil {
-		if err := p.link.Close(); err != nil {
+	for _, l := range p.links {
+		if err := l.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if p.prog != nil {
-		if err := p.prog.Close(); err != nil {
+	for _, pr := range p.progs {
+		if err := pr.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -71,6 +82,8 @@ func (p *Probe) Close() error {
 
 // LoadEntry は fentry (前段) probe を作成してアタッチする。
 // useDSL=true のとき filterExpr は xdp-ninja DSL として解釈される。
+// 単一ターゲット用の互換ラッパ (bare *ebpf.Program から Target を合成
+// して loadMulti に委譲)。本番 CLI 経路は LoadMultiEntry/Exit を使う。
 func LoadEntry(targetProg *ebpf.Program, funcName string, filterExpr string, argFilters []filter.ArgFilter, useDSL bool) (*Probe, error) {
 	return loadProbe(targetProg, funcName, filterExpr, argFilters, false, useDSL)
 }
@@ -85,6 +98,47 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 	progType, err := validateTracingTarget(targetProg)
 	if err != nil {
 		return nil, err
+	}
+	targets := []attach.Target{{Program: targetProg, FuncName: funcName, Type: progType}}
+	return loadMulti(targets, filterExpr, [][]filter.ArgFilter{argFilters}, isFexit, useDSL)
+}
+
+// LoadMultiEntry attaches one fentry per (program, func) target, all
+// emitting into a single shared sharded ringbuf, so a multi-stage
+// dispatcher's per-direction capture points (UL + DL v4 + DL v6) are
+// captured in one run and merge into one time-ordered pcap.
+//
+// argFilters is parallel to targets (nil, or one slice per target): the
+// same param name can sit at a different arg index in different funcs, so
+// filters must be resolved against each target's own BTF params.
+func LoadMultiEntry(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, useDSL bool) (*Probe, error) {
+	return loadMulti(targets, filterExpr, argFilters, false, useDSL)
+}
+
+// LoadMultiExit is LoadMultiEntry for fexit (sees the return action).
+func LoadMultiExit(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, useDSL bool) (*Probe, error) {
+	return loadMulti(targets, filterExpr, argFilters, true, useDSL)
+}
+
+// loadMulti builds the shared capture infrastructure once (filter compile,
+// sharded ringbuf, scratch map — all of which depend only on the program
+// type, not the individual target) and then attaches one tracing program
+// per (target prog, func) pair against it.
+func loadMulti(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, isFexit, useDSL bool) (*Probe, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no attach targets")
+	}
+	if argFilters != nil && len(argFilters) != len(targets) {
+		return nil, fmt.Errorf("argFilters length %d does not match %d targets", len(argFilters), len(targets))
+	}
+	progType := targets[0].Type
+	for _, t := range targets[1:] {
+		if t.Type != progType {
+			return nil, fmt.Errorf("mixed target program types (%s and %s)", progType, t.Type)
+		}
+	}
+	if progType != ebpf.XDP && progType != ebpf.SchedCLS && progType != ebpf.SchedACT {
+		return nil, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", progType)
 	}
 
 	filterOut, err := compileFilter(filterExpr, useDSL, isFexit, progType)
@@ -127,13 +181,22 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 		scratchFD = scratchMap.FD()
 	}
 
-	insns, err := buildTracingInsns(filterOut, argFilters, outerMap.FD(), scratchFD, isFexit, progType)
-	if err != nil {
-		_ = probe.Close()
-		return nil, err
-	}
-	if err := attachTracingProbe(probe, targetProg, fmt.Sprintf("xdp_ninja_%s", label), funcName, attachType, insns); err != nil {
-		return nil, err
+	// Instructions are built per target: the packet-filter part depends
+	// only on progType and the shared maps, but arg-filter offsets are
+	// resolved against each target func's own BTF param layout.
+	for i, t := range targets {
+		var af []filter.ArgFilter
+		if argFilters != nil {
+			af = argFilters[i]
+		}
+		insns, err := buildTracingInsns(filterOut, af, outerMap.FD(), scratchFD, isFexit, progType)
+		if err != nil {
+			_ = probe.Close()
+			return nil, err
+		}
+		if err := attachTracingProbe(probe, t.Program, fmt.Sprintf("xdp_ninja_%s", label), t.FuncName, attachType, insns); err != nil {
+			return nil, err
+		}
 	}
 	return probe, nil
 }
@@ -162,9 +225,10 @@ func tracingLabel(isFexit bool) (string, ebpf.AttachType) {
 }
 
 // attachTracingProbe loads insns as a Tracing program named `name`,
-// attaches it to funcName on targetProg, and records prog+link on probe.
-// On failure it closes probe (unwinding any maps already registered).
-// Shared by loadProbe (capture) and LoadArgEcho (diagnostic).
+// attaches it to funcName on targetProg, and appends prog+link to probe.
+// Callable multiple times to build up a multi-attach probe; on failure it
+// closes probe (unwinding maps and any attaches already made).
+// Shared by loadMulti (capture) and LoadArgEcho (diagnostic).
 func attachTracingProbe(probe *Probe, targetProg *ebpf.Program, name, funcName string, attachType ebpf.AttachType, insns asm.Instructions) error {
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Name: name, Type: ebpf.Tracing, AttachType: attachType,
@@ -173,16 +237,16 @@ func attachTracingProbe(probe *Probe, targetProg *ebpf.Program, name, funcName s
 	})
 	if err != nil {
 		_ = probe.Close()
-		return fmt.Errorf("loading %s program: %w", name, err)
+		return fmt.Errorf("loading %s (%s) program: %w", name, funcName, err)
 	}
-	probe.prog = prog
+	probe.progs = append(probe.progs, prog)
 
 	l, err := link.AttachTracing(link.TracingOptions{Program: prog, AttachType: attachType})
 	if err != nil {
 		_ = probe.Close()
-		return fmt.Errorf("attaching %s: %w", name, err)
+		return fmt.Errorf("attaching %s to %s: %w", name, funcName, err)
 	}
-	probe.link = l
+	probe.links = append(probe.links, l)
 	return nil
 }
 

--- a/internal/program/program_xdp.go
+++ b/internal/program/program_xdp.go
@@ -97,7 +97,7 @@ func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool)
 		_ = probe.Close()
 		return nil, fmt.Errorf("loading XDP program: %w", err)
 	}
-	probe.prog = prog
+	probe.progs = append(probe.progs, prog)
 
 	l, err := link.AttachXDP(link.XDPOptions{
 		Program:   prog,
@@ -107,7 +107,7 @@ func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool)
 		_ = probe.Close()
 		return nil, fmt.Errorf("attaching XDP: %w", err)
 	}
-	probe.link = l
+	probe.links = append(probe.links, l)
 
 	return probe, nil
 }


### PR DESCRIPTION
## 概要

`-p` と `--func` を繰り返し指定可能にし、解決した全 (プログラム, 関数) ペアへ **1回の起動で同時に fentry/fexit を張る**。

多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムに散り、noinline サブ関数は呼び出し元プログラムごとに実体を持つ (例: `pgwu_capture_point_dl` が v4/v6 ハンドラ両方に入る)。UL + DL v4 + DL v6 の全網羅は従来3回起動 + 手動 mergecap が必要だった。

```bash
sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
  --func pgwu_capture_point_ul --func pgwu_capture_point_dl \
  --arg-filter "imsi=901040010000005" -w all.pcap
# capturing (3 attach points: ...)... → all.pcap 1本に時刻順で全方向
```

## 設計

- **`attach.ResolveTargets`**: プログラム × 関数を attach ペアに展開。各 `--func` は BTF にその関数を持つ全プログラムにマッチ (一部に無いのは skip、どこにも無いのは available 関数一覧付きでエラー)。`(progID, func)` で dedup。
- **BTF parse は1回/プログラム**: `Find*` が parse 済み spec を `ProgInfo.Spec` にキャッシュし、ResolveTargets が params (`Target.Params`) を1回で解決。従来は list-params/arg-filter/arg-echo の各経路で最大4回 re-parse していた。
- **`program.LoadMultiEntry/Exit`**: 共有インフラ (filter compile・sharded ringbuf・scratch map) を1回だけ構築し、ペアごとに tracing プログラムを attach。**全 attach point が同一 ringbuf に emit** するので、既存 reader と終了時 shard マージがそのまま効き、出力は1つの時刻順 pcap。
- **arg-filter はターゲットごとに解決**: 同じ param 名でも関数によって引数位置が違い得るため、各ペアの BTF param layout に束縛して命令列を個別生成。
- `Probe` を `progs[]/links[]` に一般化。`LoadEntry/LoadExit` は単一ターゲット互換ラッパとして維持 (テスト/ベンチ用)。
- `--list-progs/--list-funcs/--list-params` は全ターゲットを列挙。`--arg-echo` は出力が混ざるため単一ターゲット限定。XDP/tc の混在は不可。

## テスト (root で全 PASS)

- **(A) `TestBpfMultiAttachEntryPrograms`** — 独立した2つの XDP プログラムの entry 関数に1プローブで attach。各々 `BPF_PROG_TEST_RUN` で発火させ、共有 ringbuf から両方のイベント (ペイロードマーカで区別) を読み戻し。
- **(B) `TestBpfMultiAttachNoinlineAcrossPrograms`** — 同名 noinline `capture_pt` を持つ2プログラム (v4/v6 相当) に `--func` 1指定で2ペア解決・両方発火を確認。
- `TestResolveTargetsFuncMissingEverywhere` — どこにも無い関数名はエラー。
- 既存の単一ターゲット群 (`TestBpfEntryLoad`/`TestBpfArgEcho...` 等) 回帰なし。

**CLI 実機スモーク**: 2つの veth に別 XDP を張り `-p A -p B -c 6 -w multi.pcap` → 両ネットワークの ping (3+3) が1つのマージ済み pcap に時刻順で格納されることを確認。

`/simplify` (4観点並列) 適用済み: BTF parse 一元化、ResolveTargets のエラー強化 + CLI special-case 削除、型チェックの enforcement point 一元化 (loadMulti)。

## スコープ外 (後続)

- `--func-any` (ロード済み全プログラム自動走査)
- capture point 別の pcap-ng interface タグ付け (マージ後に UL/DL を Wireshark 上で区別)
- `--arg-echo` の multi 対応
