### PR TITLE
feat(filter): pinned-map match sets (--set / @NAME + set subcommand)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ sudo xdp-ninja -i eth0 --func process_packet | tcpdump -n -r -
 # (e.g. UL + DL capture points living in separate per-direction programs)
 sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
   --func pgwu_capture_point_ul --func pgwu_capture_point_dl -w all.pcap
+
+# Match against a runtime-updatable set (pinned BPF hash map): the map
+# key IS the value to match; entries added/removed while capturing take
+# effect immediately, no re-attach. Manage entries by field name via
+# `xdp-ninja set` (schema comes from the map's BTF).
+sudo xdp-ninja set create /sys/fs/bpf/subs --key "imsi:u64"
+sudo xdp-ninja set add /sys/fs/bpf/subs imsi=901040010000005
+sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul \
+  --set "subs=/sys/fs/bpf/subs" --arg-filter "@subs" -w subs.pcap
 ```
 
 ### Filter syntax

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/internal/output"
 	"github.com/takehaya/xdp-ninja/internal/program"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
 )
 
 // Set via -ldflags "-X main.version=... -X main.commit=... -X main.date=... -X main.builtBy=..."
@@ -69,7 +70,11 @@ var flags = []cli.Flag{
 	},
 	&cli.StringSliceFlag{
 		Name:  "arg-filter",
-		Usage: "filter by function argument value (requires --func); format: param=value, param>=val, param<=val, param=min..max",
+		Usage: "filter by function argument value (requires --func); format: param=value, param>=val, param<=val, param=min..max, or @NAME to match against a --set pinned-map set",
+	},
+	&cli.StringSliceFlag{
+		Name:  "set",
+		Usage: "define a named match set backed by a pinned BPF hash map: NAME=/sys/fs/bpf/path[,key(field=arg:param,...)]; reference it with --arg-filter @NAME. Entries are managed at runtime via `xdp-ninja set` (no re-attach needed)",
 	},
 	&cli.BoolFlag{
 		Name:  "list-params",
@@ -256,7 +261,7 @@ Examples:
   xdp-ninja -i eth0 -w out.pcap`,
 		Flags:                 flags,
 		Action:                run,
-		Commands:              []*cli.Command{convertCommand},
+		Commands:              []*cli.Command{convertCommand, setCommand},
 		EnableShellCompletion: true,
 	}
 
@@ -471,35 +476,72 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	// --arg-filter: validate and resolve per target — the same param name
-	// can sit at a different arg index (or width) in different funcs, so
-	// each attach pair gets filters bound to its own BTF param layout.
-	var argFilters [][]filter.ArgFilter
-	if argFilterExprs := cmd.StringSlice("arg-filter"); len(argFilterExprs) > 0 {
-		argFilters = make([][]filter.ArgFilter, len(targets))
+	// --set: open the named pinned-map sets. The CLI owns the map handles;
+	// they must stay open until the tracing programs are loaded (the
+	// kernel then holds its own reference).
+	var sets []*setmap.Set
+	defer func() {
+		for _, s := range sets {
+			s.Def.Close()
+		}
+	}()
+	for _, spec := range cmd.StringSlice("set") {
+		ref, err := setmap.ParseSetSpec(spec)
+		if err != nil {
+			return err
+		}
+		s, err := setmap.OpenSet(ref)
+		if err != nil {
+			return err
+		}
+		sets = append(sets, s)
+		logVerbose(cmd, "set %q: %s (key %d B, %d field(s))", s.Name, s.Path, s.Def.KeySize, len(s.Def.Fields))
+	}
+
+	// --arg-filter: split "@NAME" set references from plain expressions,
+	// then validate and resolve both per target — the same param name can
+	// sit at a different arg index (or width) in different funcs, so each
+	// attach pair gets filters bound to its own BTF param layout.
+	setRefs, plainExprs := filter.SplitFilterExprs(cmd.StringSlice("arg-filter"))
+	var filters []filter.TargetFilters
+	if len(plainExprs) > 0 || len(setRefs) > 0 {
+		filters = make([]filter.TargetFilters, len(targets))
 		for i, t := range targets {
-			fs, err := filter.ParseAndValidateFilters(argFilterExprs, t.Params)
-			if err != nil {
-				return fmt.Errorf("func %s (id=%d): %w", t.FuncName, t.ProgID, err)
+			if len(plainExprs) > 0 {
+				fs, err := filter.ParseAndValidateFilters(plainExprs, t.Params)
+				if err != nil {
+					return fmt.Errorf("func %s (id=%d): %w", t.FuncName, t.ProgID, err)
+				}
+				filters[i].Args = fs
+				for _, f := range fs {
+					logVerbose(cmd, "arg filter on %s: %s", t.FuncName, f.String())
+				}
 			}
-			argFilters[i] = fs
-			for _, f := range fs {
-				logVerbose(cmd, "arg filter on %s: %s", t.FuncName, f.String())
+			if len(setRefs) > 0 {
+				sf, err := filter.ResolveSetFilters(sets, setRefs, t.Params)
+				if err != nil {
+					return fmt.Errorf("func %s (id=%d): %w", t.FuncName, t.ProgID, err)
+				}
+				filters[i].Sets = sf
 			}
 		}
 	}
 
 	// --arg-echo: emit the function's integer args instead of capturing
 	// packets. Single-target diagnostic — with multiple attach pairs the
-	// interleaved output would be ambiguous, so require exactly one.
+	// interleaved output would be ambiguous, so require exactly one; set
+	// references are not supported on this path in v1.
 	if cmd.Bool("arg-echo") {
 		if len(targets) != 1 {
 			return fmt.Errorf("--arg-echo supports exactly one (program, func) target; %d resolved", len(targets))
 		}
+		if len(setRefs) > 0 {
+			return fmt.Errorf("--arg-echo does not support set references (@%s); use plain --arg-filter expressions", setRefs[0])
+		}
 		t := targets[0]
 		var af []filter.ArgFilter
-		if argFilters != nil {
-			af = argFilters[0]
+		if filters != nil {
+			af = filters[0].Args
 		}
 		probe, err := program.LoadArgEcho(t.Program, t.FuncName, af, t.Params, isFexit)
 		if err != nil {
@@ -520,9 +562,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 	var probe *program.Probe
 	if isFexit {
-		probe, err = program.LoadMultiExit(targets, filterExpr, argFilters, useDSL)
+		probe, err = program.LoadMultiExit(targets, filterExpr, filters, useDSL)
 	} else {
-		probe, err = program.LoadMultiEntry(targets, filterExpr, argFilters, useDSL)
+		probe, err = program.LoadMultiEntry(targets, filterExpr, filters, useDSL)
 	}
 	if err != nil {
 		return err
@@ -1133,6 +1175,9 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	}
 	if len(cmd.StringSlice("arg-filter")) > 0 {
 		return fmt.Errorf("--arg-filter is only valid with --mode entry/exit (no tracing args in xdp-native)")
+	}
+	if len(cmd.StringSlice("set")) > 0 {
+		return fmt.Errorf("--set is only valid with --mode entry/exit (set matching keys off tracing args)")
 	}
 	if cmd.Bool("list-funcs") || cmd.Bool("list-progs") || cmd.Bool("list-params") {
 		return fmt.Errorf("--list-* flags are only valid with --mode entry/exit")

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -485,11 +485,20 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			s.Def.Close()
 		}
 	}()
+	if len(cmd.StringSlice("set")) > 0 && cmd.Bool("arg-echo") {
+		// Reject before opening any pinned map (which can fail).
+		return fmt.Errorf("--set is not supported with --arg-echo")
+	}
+	seenSet := map[string]bool{}
 	for _, spec := range cmd.StringSlice("set") {
 		ref, err := setmap.ParseSetSpec(spec)
 		if err != nil {
 			return err
 		}
+		if seenSet[ref.Name] {
+			return fmt.Errorf("--set %q: set name %q defined more than once", spec, ref.Name)
+		}
+		seenSet[ref.Name] = true
 		s, err := setmap.OpenSet(ref)
 		if err != nil {
 			return err

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 
 	"github.com/urfave/cli/v3"
@@ -54,8 +55,8 @@ var setCreateCmd = &cli.Command{
 			return err
 		}
 		maxEntries := cmd.Int("max-entries")
-		if maxEntries <= 0 {
-			return fmt.Errorf("--max-entries must be positive, got %d", maxEntries)
+		if maxEntries <= 0 || maxEntries > math.MaxUint32 {
+			return fmt.Errorf("--max-entries must be in 1..%d, got %d", math.MaxUint32, maxEntries)
 		}
 		if err := setmap.Create(path, cmd.String("key"), cmd.String("value"), uint32(maxEntries)); err != nil {
 			return err

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -1,0 +1,153 @@
+// `xdp-ninja set` subcommands: manage pinned-map match sets by field
+// name. BTF carries the key schema, so nobody hand-assembles zero-padded
+// native-endian hex the way `bpftool map update key hex ...` requires.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+)
+
+var setCommand = &cli.Command{
+	Name:  "set",
+	Usage: "manage pinned-map match sets (see --set / --arg-filter @NAME)",
+	Description: `A match set is a pinned BPF hash map whose KEY is the value (or
+composite of values) to match and whose value is a small tag. Capture
+references it with --set NAME=/path + --arg-filter @NAME; entries added
+or deleted here take effect immediately, without re-attaching.
+
+Examples:
+  xdp-ninja set create /sys/fs/bpf/flows --key "imsi:u64,teid:u32"
+  xdp-ninja set add    /sys/fs/bpf/flows imsi=901040010000005 teid=0x3039 tag=1
+  xdp-ninja set del    /sys/fs/bpf/flows imsi=901040010000005 teid=0x3039
+  xdp-ninja set list   /sys/fs/bpf/flows
+  xdp-ninja set schema /sys/fs/bpf/flows`,
+	Commands: []*cli.Command{setCreateCmd, setAddCmd, setDelCmd, setListCmd, setSchemaCmd},
+}
+
+var setCreateCmd = &cli.Command{
+	Name:      "create",
+	Usage:     "create + pin a BTF-carrying hash set map",
+	ArgsUsage: "<pin-path>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name: "key", Required: true,
+			Usage: "key schema, e.g. \"imsi:u64,teid:u32\" (types: u8/u16/u32/u64; fields are laid out with natural alignment)",
+		},
+		&cli.StringFlag{
+			Name: "value", Value: "tag:u32",
+			Usage: "value schema (default a u32 tag)",
+		},
+		&cli.IntFlag{
+			Name: "max-entries", Value: 1024,
+			Usage: "map capacity",
+		},
+	},
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		path, err := setPathArg(cmd)
+		if err != nil {
+			return err
+		}
+		if err := setmap.Create(path, cmd.String("key"), cmd.String("value"), uint32(cmd.Int("max-entries"))); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "created %s (key: %s, value: %s, max_entries: %d)\n",
+			path, cmd.String("key"), cmd.String("value"), cmd.Int("max-entries"))
+		return nil
+	},
+}
+
+var setAddCmd = &cli.Command{
+	Name:      "add",
+	Usage:     "insert or update one entry (full key required)",
+	ArgsUsage: "<pin-path> field=value ... [tag=N]",
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		def, fields, tag, err := setOpenWithFields(cmd)
+		if err != nil {
+			return err
+		}
+		defer def.Close()
+		return def.Add(fields, tag)
+	},
+}
+
+var setDelCmd = &cli.Command{
+	Name:      "del",
+	Usage:     "delete one entry (full key required)",
+	ArgsUsage: "<pin-path> field=value ...",
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		def, fields, _, err := setOpenWithFields(cmd)
+		if err != nil {
+			return err
+		}
+		defer def.Close()
+		return def.Delete(fields)
+	},
+}
+
+var setListCmd = &cli.Command{
+	Name:      "list",
+	Usage:     "print all entries as field=value lines",
+	ArgsUsage: "<pin-path>",
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		def, err := setOpen(cmd)
+		if err != nil {
+			return err
+		}
+		defer def.Close()
+		return def.List(os.Stdout)
+	},
+}
+
+var setSchemaCmd = &cli.Command{
+	Name:      "schema",
+	Usage:     "print the key layout resolved from the map's BTF",
+	ArgsUsage: "<pin-path>",
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		def, err := setOpen(cmd)
+		if err != nil {
+			return err
+		}
+		defer def.Close()
+		def.Schema(os.Stdout)
+		return nil
+	},
+}
+
+func setPathArg(cmd *cli.Command) (string, error) {
+	if cmd.Args().Len() < 1 {
+		return "", fmt.Errorf("missing pinned map path (e.g. /sys/fs/bpf/flows)")
+	}
+	return cmd.Args().First(), nil
+}
+
+func setOpen(cmd *cli.Command) (*setmap.Definition, error) {
+	path, err := setPathArg(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return setmap.Open(path)
+}
+
+// setOpenWithFields opens the map and parses the trailing field=value
+// args (with the optional tag=N split off).
+func setOpenWithFields(cmd *cli.Command) (*setmap.Definition, map[string]uint64, uint64, error) {
+	def, err := setOpen(cmd)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	fields, tag, hasTag, err := setmap.ParseFieldValues(cmd.Args().Tail())
+	if err != nil {
+		def.Close()
+		return nil, nil, 0, err
+	}
+	if !hasTag {
+		tag = 1 // presence marker
+	}
+	return def, fields, tag, nil
+}

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -53,7 +53,11 @@ var setCreateCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if err := setmap.Create(path, cmd.String("key"), cmd.String("value"), uint32(cmd.Int("max-entries"))); err != nil {
+		maxEntries := cmd.Int("max-entries")
+		if maxEntries <= 0 {
+			return fmt.Errorf("--max-entries must be positive, got %d", maxEntries)
+		}
+		if err := setmap.Create(path, cmd.String("key"), cmd.String("value"), uint32(maxEntries)); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "created %s (key: %s, value: %s, max_entries: %d)\n",

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -441,6 +441,37 @@ sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
 - `--arg-filter` は関数ごとに BTF を引いて検証・解決されます。同じ param 名が関数によって別の引数位置にあっても正しく効きます。指定した param を持たない関数が混ざるとエラーになります。
 - XDP と tc のターゲット混在は不可 (別々に起動してください)。`--arg-echo` は単一 (プログラム, 関数) のみ。
 
+## 集合マッチ (`--set` / `--arg-filter @NAME`)
+
+`--arg-filter "imsi=X"` は値を命令列に焼き込むため、値を変えるたびに re-attach が要ります。**pinned BPF hash map を「集合」として参照**すると、購読者リスト(IMSI 群など)をパケットごとの O(1) lookup で照合でき、**エントリの追加・削除はキャプチャ中でも即時反映**されます (re-attach 不要)。
+
+map の**キーが照合する値そのもの** (スカラ or struct 複合キー)、value は小さな tag です。複合キーのフィールド間は AND (1 lookup)、OR はエントリを複数入れて表現します (集合=直和)。部分キーは不可です。
+
+```bash
+# 1) 集合を作る (BTF 付き hash map を pin)
+sudo xdp-ninja set create /sys/fs/bpf/flows --key "imsi:u64,teid:u32" --max-entries 1024
+
+# 2) エントリ投入 (フィールド名で指定。幅・パディングはツールが保証)
+sudo xdp-ninja set add /sys/fs/bpf/flows imsi=901040010000005 teid=0x3039 tag=1
+
+# 3) キャプチャ (--set で名前を付け、@NAME で参照)
+sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul \
+  --set "flows=/sys/fs/bpf/flows" --arg-filter "@flows" -w out.pcap
+
+# 4) キャプチャ中でも出し入れできる
+sudo xdp-ninja set add /sys/fs/bpf/flows imsi=901040010000777 teid=100
+sudo xdp-ninja set del /sys/fs/bpf/flows imsi=901040010000005 teid=0x3039
+sudo xdp-ninja set list /sys/fs/bpf/flows
+sudo xdp-ninja set schema /sys/fs/bpf/flows
+```
+
+- **キーの対応付け**: 既定はキーの BTF フィールド名と fentry 引数名の同名一致。名前が違うときは `--set "flows=/sys/fs/bpf/flows,key(imsi=arg:subscriber,teid=arg:teid)"` と明示します (`()` は bash メタ文字なのでクオート必須)。
+- `@NAME` は他の `--arg-filter` と AND 合成。`--set` は複数定義できます。
+- 引数がキーのフィールドより広い場合 (u64 引数 → u32 フィールド) は切り詰めになるためエラーです。
+- 外部で作った pinned map も、hash 型で BTF キー (整数 or 整数のみの struct、各 1/2/4/8B、キー全体 64B 以下) を持っていれば参照できます。BTF 無しの map は `set create` で作り直してください。
+- 外部から直接書く場合 (bpftool 等) は**パディングのゼロ埋めが必須**です (hash はキー全バイトをハッシュするため、パディングが非ゼロだと永遠に一致しません)。`xdp-ninja set add` はこれを自動で保証します。
+- スキーマ (キー幅・オフセット) は `set schema` で確認できます。`bpftool map dump pinned <path>` もフィールド名付きで整形表示されます (合成 BTF の効能)。
+
 ## 関数引数の値を覗く (`--arg-echo`)
 
 `--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、「そもそも引数にどんな値が乗っているか」を確認するのに使います (例: IMSI が 10 進なのか TBCD なのか)。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。

--- a/internal/filter/setfilter.go
+++ b/internal/filter/setfilter.go
@@ -19,12 +19,13 @@ import (
 // SetKeyField binds one key-struct member to a fentry arg of one target
 // function.
 type SetKeyField struct {
-	FieldName string // BTF member name in the key struct
-	FieldOff  uint32 // byte offset within the key
-	FieldSize uint32 // 1/2/4/8
-	ParamName string
-	ParamIdx  int // per-target arg index
-	ParamSize uint32
+	FieldName   string // BTF member name in the key struct
+	FieldOff    uint32 // byte offset within the key
+	FieldSize   uint32 // 1/2/4/8
+	ParamName   string
+	ParamIdx    int // per-target arg index
+	ParamSize   uint32
+	ParamSigned bool // sign-extend a narrow signed arg into the key field
 }
 
 // SetFilter is one "@NAME" reference resolved against one target's
@@ -110,7 +111,7 @@ func ResolveSetFilters(sets []*setmap.Set, refs []string, params []attach.FuncPa
 			}
 			sf.Fields = append(sf.Fields, SetKeyField{
 				FieldName: f.Name, FieldOff: f.Off, FieldSize: f.Size,
-				ParamName: paramName, ParamIdx: p.Index, ParamSize: p.Size,
+				ParamName: paramName, ParamIdx: p.Index, ParamSize: p.Size, ParamSigned: p.Signed,
 			})
 		}
 		out = append(out, sf)

--- a/internal/filter/setfilter.go
+++ b/internal/filter/setfilter.go
@@ -1,0 +1,127 @@
+// Set filters: `--arg-filter "@NAME"` references a named pinned-map set
+// (see internal/setmap) and passes when the composite key built from the
+// target function's arguments exists in the map. Resolution is per attach
+// target because the same param name can sit at a different arg index in
+// different functions — the same reason plain arg-filters resolve per
+// target.
+package filter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+)
+
+// SetKeyField binds one key-struct member to a fentry arg of one target
+// function.
+type SetKeyField struct {
+	FieldName string // BTF member name in the key struct
+	FieldOff  uint32 // byte offset within the key
+	FieldSize uint32 // 1/2/4/8
+	ParamName string
+	ParamIdx  int // per-target arg index
+	ParamSize uint32
+}
+
+// SetFilter is one "@NAME" reference resolved against one target's
+// params. Map is borrowed from the setmap.Set (the CLI owns its
+// lifetime); it must stay open until the tracing program is loaded.
+type SetFilter struct {
+	SetName string
+	Map     *ebpf.Map
+	KeySize uint32
+	Fields  []SetKeyField
+}
+
+// TargetFilters is everything --arg-filter produced for one attach
+// target: plain scalar compares plus set lookups, all ANDed.
+type TargetFilters struct {
+	Args []ArgFilter
+	Sets []SetFilter
+}
+
+// Empty reports whether the target has no filters at all.
+func (tf TargetFilters) Empty() bool {
+	return len(tf.Args) == 0 && len(tf.Sets) == 0
+}
+
+// SplitFilterExprs partitions --arg-filter values into set references
+// ("@name") and plain filter expressions.
+func SplitFilterExprs(exprs []string) (refs, plain []string) {
+	for _, e := range exprs {
+		if name, ok := strings.CutPrefix(e, "@"); ok {
+			refs = append(refs, name)
+		} else {
+			plain = append(plain, e)
+		}
+	}
+	return refs, plain
+}
+
+// ResolveSetFilters binds each referenced set's key fields to the
+// target's function params. Every key field must resolve (full-key rule):
+// through the set's explicit key(...) mapping when given, else implicitly
+// by field name.
+func ResolveSetFilters(sets []*setmap.Set, refs []string, params []attach.FuncParamInfo) ([]SetFilter, error) {
+	byName := map[string]*setmap.Set{}
+	for _, s := range sets {
+		byName[s.Name] = s
+	}
+	paramByName := map[string]attach.FuncParamInfo{}
+	for _, p := range params {
+		paramByName[p.Name] = p
+	}
+
+	var out []SetFilter
+	for _, ref := range refs {
+		s, ok := byName[ref]
+		if !ok {
+			return nil, fmt.Errorf("@%s: no such set (define it with --set %q)", ref, ref+"=/sys/fs/bpf/...")
+		}
+
+		// source per key field: explicit mapping wins, else field name.
+		// (OpenSet has already reconciled a scalar key's synthetic name
+		// with the mapping's field name, so field lookups are uniform.)
+		srcFor := map[string]string{}
+		for _, m := range s.Mapping {
+			if _, ok := s.Def.Field(m.Field); !ok {
+				return nil, fmt.Errorf("@%s: key(...) names field %q but the map key has: %s", ref, m.Field, keyFieldList(s.Def))
+			}
+			srcFor[m.Field] = m.Source
+		}
+
+		sf := SetFilter{SetName: s.Name, Map: s.Def.Map, KeySize: s.Def.KeySize}
+		for _, f := range s.Def.Fields {
+			src, ok := srcFor[f.Name]
+			if !ok {
+				src = "arg:" + f.Name // implicit match by name
+			}
+			paramName := strings.TrimPrefix(src, "arg:")
+			p, ok := paramByName[paramName]
+			if !ok {
+				return nil, fmt.Errorf("@%s: key field %s needs arg %q, which the target function does not have (see --list-params); map it with key(%s=arg:<param>)", ref, f.Name, paramName, f.Name)
+			}
+			if p.Size > f.Size {
+				return nil, fmt.Errorf("@%s: arg %s (u%d) is wider than key field %s (u%d) — truncation is not supported", ref, paramName, p.Size*8, f.Name, f.Size*8)
+			}
+			sf.Fields = append(sf.Fields, SetKeyField{
+				FieldName: f.Name, FieldOff: f.Off, FieldSize: f.Size,
+				ParamName: paramName, ParamIdx: p.Index, ParamSize: p.Size,
+			})
+		}
+		out = append(out, sf)
+	}
+	return out, nil
+}
+
+func keyFieldList(d *setmap.Definition) string {
+	names := make([]string, len(d.Fields))
+	for i, f := range d.Fields {
+		names[i] = f.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/filter/setfilter_test.go
+++ b/internal/filter/setfilter_test.go
@@ -1,0 +1,117 @@
+package filter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+)
+
+func flowSet(mapping []setmap.MapEntry) *setmap.Set {
+	return &setmap.Set{
+		SpecRef: setmap.SpecRef{Name: "flows", Mapping: mapping},
+		Def: &setmap.Definition{
+			KeySize: 16,
+			Fields: []setmap.KeyField{
+				{Name: "imsi", Off: 0, Size: 8},
+				{Name: "teid", Off: 8, Size: 4},
+			},
+		},
+	}
+}
+
+var ulParams = []attach.FuncParamInfo{
+	{Name: "imsi", Index: 1, Size: 8},
+	{Name: "teid", Index: 2, Size: 4},
+}
+
+func TestSplitFilterExprs(t *testing.T) {
+	refs, plain := SplitFilterExprs([]string{"imsi=5", "@subs", "teid>=7", "@cells"})
+	if len(refs) != 2 || refs[0] != "subs" || refs[1] != "cells" {
+		t.Errorf("refs = %v", refs)
+	}
+	if len(plain) != 2 || plain[0] != "imsi=5" {
+		t.Errorf("plain = %v", plain)
+	}
+}
+
+func TestResolveSetFiltersImplicit(t *testing.T) {
+	sf, err := ResolveSetFilters([]*setmap.Set{flowSet(nil)}, []string{"flows"}, ulParams)
+	if err != nil {
+		t.Fatalf("ResolveSetFilters: %v", err)
+	}
+	if len(sf) != 1 || len(sf[0].Fields) != 2 {
+		t.Fatalf("resolved = %+v", sf)
+	}
+	f := sf[0].Fields[0]
+	if f.FieldName != "imsi" || f.ParamIdx != 1 || f.FieldOff != 0 || f.FieldSize != 8 {
+		t.Errorf("imsi field = %+v", f)
+	}
+	f = sf[0].Fields[1]
+	if f.FieldName != "teid" || f.ParamIdx != 2 || f.FieldOff != 8 || f.FieldSize != 4 {
+		t.Errorf("teid field = %+v", f)
+	}
+}
+
+func TestResolveSetFiltersExplicitMapping(t *testing.T) {
+	// key field imsi sourced from a differently-named arg.
+	set := flowSet([]setmap.MapEntry{{Field: "imsi", Source: "arg:subscriber"}})
+	params := []attach.FuncParamInfo{
+		{Name: "subscriber", Index: 1, Size: 8},
+		{Name: "teid", Index: 2, Size: 4},
+	}
+	sf, err := ResolveSetFilters([]*setmap.Set{set}, []string{"flows"}, params)
+	if err != nil {
+		t.Fatalf("ResolveSetFilters: %v", err)
+	}
+	if sf[0].Fields[0].ParamName != "subscriber" || sf[0].Fields[0].ParamIdx != 1 {
+		t.Errorf("explicit mapping field = %+v", sf[0].Fields[0])
+	}
+}
+
+func TestResolveSetFiltersErrors(t *testing.T) {
+	// unknown set name
+	if _, err := ResolveSetFilters(nil, []string{"nope"}, ulParams); err == nil || !strings.Contains(err.Error(), "no such set") {
+		t.Errorf("unknown set err = %v", err)
+	}
+	// missing param → mentions the field and the fix
+	params := []attach.FuncParamInfo{{Name: "imsi", Index: 1, Size: 8}} // no teid
+	if _, err := ResolveSetFilters([]*setmap.Set{flowSet(nil)}, []string{"flows"}, params); err == nil || !strings.Contains(err.Error(), "teid") {
+		t.Errorf("missing param err = %v", err)
+	}
+	// arg wider than field → truncation rejected
+	wide := []attach.FuncParamInfo{
+		{Name: "imsi", Index: 1, Size: 8},
+		{Name: "teid", Index: 2, Size: 8}, // u64 arg into u32 field
+	}
+	if _, err := ResolveSetFilters([]*setmap.Set{flowSet(nil)}, []string{"flows"}, wide); err == nil || !strings.Contains(err.Error(), "truncation") {
+		t.Errorf("truncation err = %v", err)
+	}
+	// mapping names a field the key doesn't have
+	bad := flowSet([]setmap.MapEntry{{Field: "bogus", Source: "arg:imsi"}})
+	if _, err := ResolveSetFilters([]*setmap.Set{bad}, []string{"flows"}, ulParams); err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("bad mapping err = %v", err)
+	}
+}
+
+func TestResolveSetFiltersScalarPositional(t *testing.T) {
+	// scalar key with a non-matching BTF name binds positionally via a
+	// single-entry mapping. OpenSet reconciles a scalar key's synthetic
+	// name with the mapping's field name; represent that post-open state.
+	set := &setmap.Set{
+		SpecRef: setmap.SpecRef{Name: "subs", Mapping: []setmap.MapEntry{{Field: "imsi", Source: "arg:imsi"}}},
+		Def: &setmap.Definition{
+			KeySize:  8,
+			Fields:   []setmap.KeyField{{Name: "imsi", Off: 0, Size: 8}},
+			IsScalar: true,
+		},
+	}
+	sf, err := ResolveSetFilters([]*setmap.Set{set}, []string{"subs"}, ulParams)
+	if err != nil {
+		t.Fatalf("ResolveSetFilters scalar: %v", err)
+	}
+	if sf[0].Fields[0].ParamName != "imsi" {
+		t.Errorf("scalar positional field = %+v", sf[0].Fields[0])
+	}
+}

--- a/internal/program/dump.go
+++ b/internal/program/dump.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
 
@@ -106,7 +107,7 @@ func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, 
 		shape = "XDP-native program"
 	} else {
 		var err error
-		insns, err = buildTracingInsns(out, nil, 0, 0, isFexit, ebpf.XDP)
+		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP)
 		if err != nil {
 			return err
 		}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -100,7 +100,7 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 		return nil, err
 	}
 	targets := []attach.Target{{Program: targetProg, FuncName: funcName, Type: progType}}
-	return loadMulti(targets, filterExpr, [][]filter.ArgFilter{argFilters}, isFexit, useDSL)
+	return loadMulti(targets, filterExpr, []filter.TargetFilters{{Args: argFilters}}, isFexit, useDSL)
 }
 
 // LoadMultiEntry attaches one fentry per (program, func) target, all
@@ -108,28 +108,29 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 // dispatcher's per-direction capture points (UL + DL v4 + DL v6) are
 // captured in one run and merge into one time-ordered pcap.
 //
-// argFilters is parallel to targets (nil, or one slice per target): the
+// filters is parallel to targets (nil, or one entry per target): the
 // same param name can sit at a different arg index in different funcs, so
-// filters must be resolved against each target's own BTF params.
-func LoadMultiEntry(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, useDSL bool) (*Probe, error) {
-	return loadMulti(targets, filterExpr, argFilters, false, useDSL)
+// arg filters and set-key bindings must be resolved against each target's
+// own BTF params.
+func LoadMultiEntry(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool) (*Probe, error) {
+	return loadMulti(targets, filterExpr, filters, false, useDSL)
 }
 
 // LoadMultiExit is LoadMultiEntry for fexit (sees the return action).
-func LoadMultiExit(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, useDSL bool) (*Probe, error) {
-	return loadMulti(targets, filterExpr, argFilters, true, useDSL)
+func LoadMultiExit(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool) (*Probe, error) {
+	return loadMulti(targets, filterExpr, filters, true, useDSL)
 }
 
 // loadMulti builds the shared capture infrastructure once (filter compile,
 // sharded ringbuf, scratch map — all of which depend only on the program
 // type, not the individual target) and then attaches one tracing program
 // per (target prog, func) pair against it.
-func loadMulti(targets []attach.Target, filterExpr string, argFilters [][]filter.ArgFilter, isFexit, useDSL bool) (*Probe, error) {
+func loadMulti(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, isFexit, useDSL bool) (*Probe, error) {
 	if len(targets) == 0 {
 		return nil, fmt.Errorf("no attach targets")
 	}
-	if argFilters != nil && len(argFilters) != len(targets) {
-		return nil, fmt.Errorf("argFilters length %d does not match %d targets", len(argFilters), len(targets))
+	if filters != nil && len(filters) != len(targets) {
+		return nil, fmt.Errorf("filters length %d does not match %d targets", len(filters), len(targets))
 	}
 	progType := targets[0].Type
 	for _, t := range targets[1:] {
@@ -185,11 +186,11 @@ func loadMulti(targets []attach.Target, filterExpr string, argFilters [][]filter
 	// only on progType and the shared maps, but arg-filter offsets are
 	// resolved against each target func's own BTF param layout.
 	for i, t := range targets {
-		var af []filter.ArgFilter
-		if argFilters != nil {
-			af = argFilters[i]
+		var tf filter.TargetFilters
+		if filters != nil {
+			tf = filters[i]
 		}
-		insns, err := buildTracingInsns(filterOut, af, outerMap.FD(), scratchFD, isFexit, progType)
+		insns, err := buildTracingInsns(filterOut, tf, outerMap.FD(), scratchFD, isFexit, progType)
 		if err != nil {
 			_ = probe.Close()
 			return nil, err
@@ -336,6 +337,9 @@ func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType)
 //   -16: map lookup の key
 //   -24: scratch buffer ポインタ (フィルタ時のみ)
 //   -48: tracing args ポインタの退避
+//   -57..-120: set filter のキーバッファ (emitSetFilters; runFilter の
+//              前で死ぬ。kunai は KunaiStackTop=-56 以深を所有するが
+//              それは runFilter 内のみ live — phase ordering で共存)
 //
 // bpf_xdp_output を使うことで:
 //   - パケットデータはカーネルが xdp_buff から直接コピー (bpf_probe_read_kernel 不要)
@@ -441,14 +445,15 @@ const (
 	metadataSize = 16
 )
 
-func buildTracingInsns(filterOut codegen.Output, argFilters []filter.ArgFilter, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType) (asm.Instructions, error) {
+func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType) (asm.Instructions, error) {
 	var insns asm.Instructions
 	prelude, err := loadPacketPointers(progType)
 	if err != nil {
 		return nil, err
 	}
 	insns = append(insns, prelude...)
-	insns = append(insns, buildArgFilter(argFilters)...)
+	insns = append(insns, buildArgFilter(tf.Args)...)
+	insns = append(insns, emitSetFilters(tf.Sets)...)
 	insns = append(insns, runFilter(filterOut.Main, scratchFD, filterScanLen(filterOut))...)
 	insns = append(insns, captureWithRingbuf(eventsFD, isFexit, filterOut.Capture.MaxCapLen)...)
 	insns = append(insns, asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"), asm.Return())
@@ -701,23 +706,25 @@ func captureWithRingbuf(eventsFD int, isFexit bool, maxCapLen int) asm.Instructi
 // arg-filter gate and the arg-echo emitter so the sign-extend invariant
 // lives in one place.
 func emitArgLoad(dst, base asm.Register, offset int16, size uint32, signed bool) asm.Instructions {
-	var loadSize asm.Size
-	switch size {
-	case 1:
-		loadSize = asm.Byte
-	case 2:
-		loadSize = asm.Half
-	case 4:
-		loadSize = asm.Word
-	default:
-		loadSize = asm.DWord
-	}
-	insns := asm.Instructions{asm.LoadMem(dst, base, offset, loadSize)}
+	insns := asm.Instructions{asm.LoadMem(dst, base, offset, asmSizeFor(size))}
 	if signed && size < 8 {
 		shift := int32((8 - size) * 8)
 		insns = append(insns, asm.LSh.Imm(dst, shift), asm.ArSh.Imm(dst, shift))
 	}
 	return insns
+}
+
+// asmSizeFor maps a 1/2/4/8-byte width to the matching load/store size.
+func asmSizeFor(n uint32) asm.Size {
+	switch n {
+	case 1:
+		return asm.Byte
+	case 2:
+		return asm.Half
+	case 4:
+		return asm.Word
+	}
+	return asm.DWord
 }
 
 func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
@@ -753,6 +760,70 @@ func buildArgFilter(filters []filter.ArgFilter) asm.Instructions {
 	}
 
 	return insns
+}
+
+// setKeyBase is the stack offset of the set-filter key buffer:
+// fp-120..fp-57, sized for setmap.MaxKeySize (64 B). It is written and
+// consumed strictly before runFilter jumps into the packet filter, whose
+// kunai codegen owns everything at/below KunaiStackTop (-56) — temporal
+// reuse, not a partition (see the stack layout comment above).
+const setKeyBase = -120
+
+// emitSetFilters emits one pinned-map membership check per set filter:
+// zero the key buffer (hash maps hash every key byte including padding,
+// and the verifier requires the full key range initialized), build each
+// key field from the target function's args, then bpf_map_lookup_elem —
+// a NULL result jumps to "exit" (skip capture), so multiple sets and
+// plain arg-filters AND together naturally.
+func emitSetFilters(sets []filter.SetFilter) asm.Instructions {
+	var insns asm.Instructions
+	for _, s := range sets {
+		// Only zero the key buffer when the fields leave padding gaps: hash
+		// maps hash every key byte, and the verifier requires the full key
+		// range initialized. Gapless keys (every scalar key, and structs
+		// that tile [0,KeySize)) have every byte overwritten by the field
+		// stores below, so the zeroing is pure per-packet waste there.
+		if keyHasGaps(s) {
+			// No 64-bit store-immediate in the BPF ISA — zero via a register.
+			insns = append(insns, asm.Mov.Imm(asm.R3, 0))
+			for off := 0; off < int(s.KeySize); off += 8 {
+				insns = append(insns, asm.StoreMem(asm.R10, int16(setKeyBase+off), asm.R3, asm.DWord))
+			}
+		}
+
+		// R2 = tracing args ptr (reload per set: lookup clobbers R0-R5, and
+		// no callee-saved register is free — R6-R9 hold the capture prelude).
+		insns = append(insns, asm.LoadMem(asm.R2, asm.R10, -48, asm.DWord))
+		for _, f := range s.Fields {
+			// Load at param width (zero-extends; ParamSize <= FieldSize is
+			// enforced at resolve time), store at field width into the buffer.
+			insns = append(insns, emitArgLoad(asm.R3, asm.R2, int16(f.ParamIdx*8), f.ParamSize, false)...)
+			insns = append(insns, asm.StoreMem(asm.R10, int16(setKeyBase+int(f.FieldOff)), asm.R3, asmSizeFor(f.FieldSize)))
+		}
+
+		insns = append(insns,
+			asm.LoadMapPtr(asm.R1, s.Map.FD()),
+			asm.Mov.Reg(asm.R2, asm.R10),
+			asm.Add.Imm(asm.R2, setKeyBase),
+			asm.FnMapLookupElem.Call(),
+			asm.JEq.Imm(asm.R0, 0, "exit"),
+		)
+	}
+	return insns
+}
+
+// keyHasGaps reports whether the set's key has any byte not covered by a
+// field (padding), which must be zeroed for a correct hash lookup. Fields
+// are laid out in ascending offset order by resolution.
+func keyHasGaps(s filter.SetFilter) bool {
+	var covered uint32
+	for _, f := range s.Fields {
+		if f.FieldOff != covered {
+			return true // hole before this field
+		}
+		covered += f.FieldSize
+	}
+	return covered != s.KeySize // trailing padding
 }
 
 // appendCmpJump appends a conditional jump-to-exit comparing R3 against value.

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -795,9 +795,11 @@ func emitSetFilters(sets []filter.SetFilter) asm.Instructions {
 		// no callee-saved register is free — R6-R9 hold the capture prelude).
 		insns = append(insns, asm.LoadMem(asm.R2, asm.R10, -48, asm.DWord))
 		for _, f := range s.Fields {
-			// Load at param width (zero-extends; ParamSize <= FieldSize is
-			// enforced at resolve time), store at field width into the buffer.
-			insns = append(insns, emitArgLoad(asm.R3, asm.R2, int16(f.ParamIdx*8), f.ParamSize, false)...)
+			// Load at param width, sign-extending signed params so a
+			// narrow negative arg fills the wider key field the same way a
+			// signed value written into the map would (ParamSize <=
+			// FieldSize is enforced at resolve time); store at field width.
+			insns = append(insns, emitArgLoad(asm.R3, asm.R2, int16(f.ParamIdx*8), f.ParamSize, f.ParamSigned)...)
 			insns = append(insns, asm.StoreMem(asm.R10, int16(setKeyBase+int(f.FieldOff)), asm.R3, asmSizeFor(f.FieldSize)))
 		}
 

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 
+	"github.com/takehaya/xdp-ninja/internal/filter"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
 
@@ -75,7 +76,7 @@ func TestBuildTracingInsns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// FD==0 は実際のmapではないが、命令生成のテストには十分
-			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, nil, 0, 0, tt.isFexit, ebpf.XDP)
+			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, filter.TargetFilters{}, 0, 0, tt.isFexit, ebpf.XDP)
 			if err != nil {
 				t.Fatalf("buildTracingInsns: %v", err)
 			}
@@ -93,8 +94,8 @@ func TestBuildTracingInsns(t *testing.T) {
 }
 
 func TestBuildTracingInsnsLabels(t *testing.T) {
-	filter := dummyFilter()
-	insns, err := buildTracingInsns(codegen.Output{Main: filter}, nil, 0, 0, false, ebpf.XDP)
+	filterInsns := dummyFilter()
+	insns, err := buildTracingInsns(codegen.Output{Main: filterInsns}, filter.TargetFilters{}, 0, 0, false, ebpf.XDP)
 	if err != nil {
 		t.Fatalf("buildTracingInsns: %v", err)
 	}

--- a/internal/program/setfilter_test.go
+++ b/internal/program/setfilter_test.go
@@ -1,0 +1,190 @@
+package program
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/filter"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// setTargetSrc derives the capture-point args from packet bytes so each
+// BPF_PROG_TEST_RUN can steer (imsi, teid) — packet[0:8] is imsi and
+// packet[8:12] is teid, both native-endian.
+const setTargetSrc = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline))
+int set_capture_pt(struct xdp_md *ctx, unsigned long long imsi, unsigned int teid) {
+    if (!ctx)
+        return 0;
+    return (int)(imsi + teid) & 3;
+}
+
+SEC("xdp")
+int xdp_set_target(struct xdp_md *ctx) {
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    if (data + 12 > data_end)
+        return 1;
+    unsigned long long imsi = *(unsigned long long *)data;
+    unsigned int teid = *(unsigned int *)(data + 8);
+    return set_capture_pt(ctx, imsi, teid);
+}
+char _license[] SEC("license") = "GPL";
+`
+
+// runWithKey test-runs the target with a packet whose leading bytes carry
+// (imsi, teid). Packet byte 0 = imsi's low byte, which drainMarkers reads
+// back as the per-run marker.
+func runWithKey(t *testing.T, prog *ebpf.Program, imsi uint64, teid uint32) {
+	t.Helper()
+	in := make([]byte, 64)
+	for i := range 8 {
+		in[i] = byte(imsi >> (8 * i))
+	}
+	for i := range 4 {
+		in[8+i] = byte(teid >> (8 * i))
+	}
+	if _, err := prog.Run(&ebpf.RunOptions{Data: in}); err != nil {
+		t.Fatalf("test-run: %v", err)
+	}
+}
+
+// TestBpfSetFilterLookupAndRuntimeUpdate is the end-to-end for pinned-map
+// set matching: create+pin a composite-key set (with struct padding), add
+// an entry, attach a probe gated on "@flows", and verify (a) only calls
+// whose (imsi, teid) is in the set are captured, (b) entries added and
+// deleted at runtime take effect without re-attaching.
+func TestBpfSetFilterLookupAndRuntimeUpdate(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_settest_%d", os.Getpid())
+	if err := setmap.Create(pin, "imsi:u64,teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	def, err := setmap.Open(pin)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(def.Close)
+	if len(def.Fields) != 2 || def.KeySize != 16 {
+		t.Fatalf("schema = %+v (key %d B), want imsi/teid in 16 B", def.Fields, def.KeySize)
+	}
+
+	const inImsi, inTeid = uint64(0x1111222233334444), uint32(0x3039)
+	if err := def.Add(map[string]uint64{"imsi": inImsi, "teid": uint64(inTeid)}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prog := loadXDPByName(t, setTargetSrc, "xdp_set_target")
+	params, err := attach.GetFuncParams(prog, "set_capture_pt")
+	if err != nil {
+		t.Fatalf("GetFuncParams: %v", err)
+	}
+
+	set := &setmap.Set{SpecRef: setmap.SpecRef{Name: "flows", Path: pin}, Def: def}
+	sf, err := filter.ResolveSetFilters([]*setmap.Set{set}, []string{"flows"}, params)
+	if err != nil {
+		t.Fatalf("ResolveSetFilters: %v", err)
+	}
+
+	targets := []attach.Target{{Program: prog, FuncName: "set_capture_pt", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true)
+	if err != nil {
+		t.Fatalf("LoadMultiEntry with set filter: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	// (a) membership gates capture: 0x44 is in the set, 0x55 is not.
+	runWithKey(t, prog, inImsi, inTeid)             // marker 0x44 — hit
+	runWithKey(t, prog, 0x9999888877776655, inTeid) // marker 0x55 — miss (imsi)
+	runWithKey(t, prog, inImsi, 0xdead)             // marker 0x44, wrong teid — miss
+	markers := drainMarkers(t, probe, 1)
+	if markers[0x44] != 1 {
+		t.Fatalf("markers = %v, want exactly one 0x44 event (wrong-teid run must miss)", markers)
+	}
+	if markers[0x55] != 0 {
+		t.Fatalf("markers = %v: non-member imsi was captured", markers)
+	}
+
+	// (b) runtime add: no re-attach, next call is captured.
+	const newImsi = uint64(0x00000000000000aa)
+	if err := def.Add(map[string]uint64{"imsi": newImsi, "teid": uint64(inTeid)}, 2); err != nil {
+		t.Fatalf("runtime Add: %v", err)
+	}
+	runWithKey(t, prog, newImsi, inTeid)
+	markers = drainMarkers(t, probe, 1)
+	if markers[0xaa] != 1 {
+		t.Fatalf("markers after runtime add = %v, want one 0xaa event", markers)
+	}
+
+	// (c) runtime delete: the same key stops matching.
+	if err := def.Delete(map[string]uint64{"imsi": newImsi, "teid": uint64(inTeid)}); err != nil {
+		t.Fatalf("runtime Delete: %v", err)
+	}
+	runWithKey(t, prog, newImsi, inTeid)
+	markers = drainMarkers(t, probe, 0)
+	if markers[0xaa] != 0 {
+		t.Fatalf("markers after runtime delete = %v, want no 0xaa event", markers)
+	}
+}
+
+// TestBpfSetFilterScalarKey covers the scalar (bare u64) key path,
+// including the typedef-carried field name from `set create`.
+func TestBpfSetFilterScalarKey(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_setscalar_%d", os.Getpid())
+	if err := setmap.Create(pin, "imsi:u64", "", 16); err != nil {
+		t.Skipf("creating pinned set map: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	def, err := setmap.Open(pin)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(def.Close)
+	if !def.IsScalar || def.Fields[0].Name != "imsi" {
+		t.Fatalf("scalar schema = %+v (IsScalar=%v), want typedef name imsi", def.Fields, def.IsScalar)
+	}
+
+	const member = uint64(0x00000000000000bb)
+	if err := def.Add(map[string]uint64{"imsi": member}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prog := loadXDPByName(t, setTargetSrc, "xdp_set_target")
+	params, err := attach.GetFuncParams(prog, "set_capture_pt")
+	if err != nil {
+		t.Fatalf("GetFuncParams: %v", err)
+	}
+	set := &setmap.Set{SpecRef: setmap.SpecRef{Name: "subs", Path: pin}, Def: def}
+	sf, err := filter.ResolveSetFilters([]*setmap.Set{set}, []string{"subs"}, params)
+	if err != nil {
+		t.Fatalf("ResolveSetFilters: %v", err)
+	}
+
+	targets := []attach.Target{{Program: prog, FuncName: "set_capture_pt", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true)
+	if err != nil {
+		t.Fatalf("LoadMultiEntry: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	runWithKey(t, prog, member, 1)             // hit (teid irrelevant)
+	runWithKey(t, prog, 0x00000000000000cc, 1) // miss
+	markers := drainMarkers(t, probe, 1)
+	if markers[0xbb] != 1 || markers[0xcc] != 0 {
+		t.Fatalf("markers = %v, want one 0xbb and no 0xcc", markers)
+	}
+}

--- a/internal/program/setfilter_test.go
+++ b/internal/program/setfilter_test.go
@@ -1,6 +1,7 @@
 package program
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"testing"
@@ -46,12 +47,9 @@ char _license[] SEC("license") = "GPL";
 func runWithKey(t *testing.T, prog *ebpf.Program, imsi uint64, teid uint32) {
 	t.Helper()
 	in := make([]byte, 64)
-	for i := range 8 {
-		in[i] = byte(imsi >> (8 * i))
-	}
-	for i := range 4 {
-		in[8+i] = byte(teid >> (8 * i))
-	}
+	// Native-endian, matching how the target reads *(u64*)data / *(u32*).
+	binary.NativeEndian.PutUint64(in[0:8], imsi)
+	binary.NativeEndian.PutUint32(in[8:12], teid)
 	if _, err := prog.Run(&ebpf.RunOptions{Data: in}); err != nil {
 		t.Fatalf("test-run: %v", err)
 	}

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -119,6 +119,13 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 	if keySize > MaxKeySize {
 		return fmt.Errorf("key size %d exceeds the %d-byte limit", keySize, MaxKeySize)
 	}
+	// "tag" is reserved for the value assignment in `set add`, so a key
+	// field of that name could never be addressed on the CLI.
+	for _, f := range keyFields {
+		if f.Name == reservedTagName {
+			return fmt.Errorf("key field name %q is reserved (used for the value in `set add`)", f.Name)
+		}
+	}
 
 	if valueSchema == "" {
 		valueSchema = "tag:u32"
@@ -145,6 +152,10 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 	return nil
 }
 
+// reservedTagName is the field=value key that `set add`/`del` treat as
+// the entry value (tag) rather than a key field.
+const reservedTagName = "tag"
+
 // ParseFieldValues parses `field=value` CLI args (decimal or 0x hex) and
 // splits off the reserved `tag=` value assignment.
 func ParseFieldValues(args []string) (fields map[string]uint64, tag uint64, hasTag bool, err error) {
@@ -158,7 +169,7 @@ func ParseFieldValues(args []string) (fields map[string]uint64, tag uint64, hasT
 		if perr != nil {
 			return nil, 0, false, fmt.Errorf("argument %q: %w", a, perr)
 		}
-		if name == "tag" {
+		if name == reservedTagName {
 			tag, hasTag = v, true
 			continue
 		}
@@ -186,7 +197,7 @@ func parseUint(s string) (uint64, error) {
 // Padding is zeroed — hash maps hash all key_size bytes, so a non-zero
 // pad byte would make lookups silently miss.
 func (d *Definition) BuildKey(values map[string]uint64) ([]byte, error) {
-	key := make([]byte, d.KeySize)
+	key := make([]byte, int(d.KeySize))
 	used := map[string]bool{}
 	for _, f := range d.Fields {
 		v, ok := values[f.Name]
@@ -240,7 +251,7 @@ func (d *Definition) Add(values map[string]uint64, tag uint64) error {
 	if valSize < 8 && tag >= 1<<(8*valSize) {
 		return fmt.Errorf("tag %d does not fit the map's %d-byte value", tag, valSize)
 	}
-	val := make([]byte, valSize)
+	val := make([]byte, int(valSize))
 	n := min(len(val), 8)
 	putUint(val[:n], tag)
 	return d.Map.Put(key, val)
@@ -257,8 +268,8 @@ func (d *Definition) Delete(values map[string]uint64) error {
 
 // List writes all entries as `field=value ... tag=N` lines.
 func (d *Definition) List(w io.Writer) error {
-	key := make([]byte, d.KeySize)
-	val := make([]byte, d.Map.ValueSize())
+	key := make([]byte, int(d.KeySize))
+	val := make([]byte, int(d.Map.ValueSize()))
 	iter := d.Map.Iterate()
 	for iter.Next(&key, &val) {
 		var parts []string

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -135,6 +135,11 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 		return fmt.Errorf("--value: %w", err)
 	}
 	valFields, valSize := layout(valSpecs)
+	// The value is a single integer tag (add/list round-trip it as one
+	// number); a multi-field or odd-width value has no tag semantics.
+	if len(valFields) != 1 || !validFieldSize(valSize) {
+		return fmt.Errorf("--value must be a single u8/u16/u32/u64 tag field, got %q", valueSchema)
+	}
 
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Name: "xdpninja_set", Type: ebpf.Hash,
@@ -240,6 +245,18 @@ func putUint(buf []byte, v uint64) {
 	}
 }
 
+// tagWidth returns the value byte width, which must be a single 1/2/4/8-byte
+// integer for the tag to round-trip through putUint/getUint. `set create`
+// enforces this; the guard also covers externally-created maps with an
+// odd or multi-field value.
+func (d *Definition) tagWidth() (uint32, error) {
+	w := d.Map.ValueSize()
+	if !validFieldSize(w) {
+		return 0, fmt.Errorf("map value is %d bytes; tag add/list needs a single u8/u16/u32/u64 value", w)
+	}
+	return w, nil
+}
+
 // Add inserts (or updates) one entry. The value is the tag zero-extended
 // to the map's value size (default tag 1 = plain presence).
 func (d *Definition) Add(values map[string]uint64, tag uint64) error {
@@ -247,13 +264,15 @@ func (d *Definition) Add(values map[string]uint64, tag uint64) error {
 	if err != nil {
 		return err
 	}
-	valSize := d.Map.ValueSize()
-	if valSize < 8 && tag >= 1<<(8*valSize) {
-		return fmt.Errorf("tag %d does not fit the map's %d-byte value", tag, valSize)
+	w, err := d.tagWidth()
+	if err != nil {
+		return err
 	}
-	val := make([]byte, int(valSize))
-	n := min(len(val), 8)
-	putUint(val[:n], tag)
+	if w < 8 && tag >= 1<<(8*w) {
+		return fmt.Errorf("tag %d does not fit the map's %d-byte value", tag, w)
+	}
+	val := make([]byte, int(w))
+	putUint(val, tag)
 	return d.Map.Put(key, val)
 }
 
@@ -267,18 +286,21 @@ func (d *Definition) Delete(values map[string]uint64) error {
 }
 
 // List writes all entries as `field=value ... tag=N` lines.
-func (d *Definition) List(w io.Writer) error {
+func (d *Definition) List(out io.Writer) error {
+	tagW, err := d.tagWidth()
+	if err != nil {
+		return err
+	}
 	key := make([]byte, int(d.KeySize))
-	val := make([]byte, int(d.Map.ValueSize()))
+	val := make([]byte, int(tagW))
 	iter := d.Map.Iterate()
 	for iter.Next(&key, &val) {
 		var parts []string
 		for _, f := range d.Fields {
 			parts = append(parts, fmt.Sprintf("%s=%d", f.Name, getUint(key[f.Off:f.Off+f.Size])))
 		}
-		n := min(len(val), 8)
-		parts = append(parts, fmt.Sprintf("tag=%d", getUint(val[:n])))
-		_, _ = fmt.Fprintln(w, strings.Join(parts, " "))
+		parts = append(parts, fmt.Sprintf("tag=%d", getUint(val)))
+		_, _ = fmt.Fprintln(out, strings.Join(parts, " "))
 	}
 	return iter.Err()
 }

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -1,0 +1,297 @@
+// Management operations behind `xdp-ninja set ...`: create a pinned set
+// map with synthesized BTF, and add/delete/list entries by field name so
+// nobody has to hand-assemble zero-padded little-endian hex like bpftool
+// requires (the exact error class behind the IMSI-encoding saga).
+package setmap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+)
+
+// FieldSpec is one `name:type` element of a --key/--value schema string.
+type FieldSpec struct {
+	Name string
+	Size uint32
+}
+
+// ParseSchema parses "imsi:u64,teid:u32" into field specs.
+func ParseSchema(s string) ([]FieldSpec, error) {
+	var out []FieldSpec
+	for ent := range strings.SplitSeq(s, ",") {
+		ent = strings.TrimSpace(ent)
+		if ent == "" {
+			continue
+		}
+		name, typ, ok := strings.Cut(ent, ":")
+		if !ok || name == "" {
+			return nil, fmt.Errorf("schema entry %q: want name:type (e.g. imsi:u64)", ent)
+		}
+		size, err := typeSize(typ)
+		if err != nil {
+			return nil, fmt.Errorf("schema entry %q: %w", ent, err)
+		}
+		out = append(out, FieldSpec{Name: name, Size: size})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("empty schema")
+	}
+	return out, nil
+}
+
+func typeSize(t string) (uint32, error) {
+	switch t {
+	case "u8":
+		return 1, nil
+	case "u16":
+		return 2, nil
+	case "u32":
+		return 4, nil
+	case "u64":
+		return 8, nil
+	}
+	return 0, fmt.Errorf("unsupported type %q (u8/u16/u32/u64)", t)
+}
+
+// layout assigns naturally-aligned offsets and returns the padded total
+// size, mirroring C struct layout so BTF offsets match what a C writer of
+// the same struct would produce.
+func layout(fields []FieldSpec) ([]KeyField, uint32) {
+	var out []KeyField
+	var cur, maxAlign uint32
+	maxAlign = 1
+	for _, f := range fields {
+		align := f.Size
+		if align > maxAlign {
+			maxAlign = align
+		}
+		cur = (cur + align - 1) &^ (align - 1)
+		out = append(out, KeyField{Name: f.Name, Off: cur, Size: f.Size})
+		cur += f.Size
+	}
+	total := (cur + maxAlign - 1) &^ (maxAlign - 1)
+	return out, total
+}
+
+// intType builds a BTF unsigned integer of the given byte width.
+func intType(size uint32) *btf.Int {
+	return &btf.Int{Name: fmt.Sprintf("__u%d", size*8), Size: size, Encoding: btf.Unsigned}
+}
+
+// synthesizeStruct builds the BTF struct for a schema.
+func synthesizeStruct(name string, fields []KeyField, size uint32) *btf.Struct {
+	st := &btf.Struct{Name: name, Size: size}
+	for _, f := range fields {
+		st.Members = append(st.Members, btf.Member{
+			Name:   f.Name,
+			Type:   intType(f.Size),
+			Offset: btf.Bits(f.Off * 8),
+		})
+	}
+	return st
+}
+
+// synthesizeType builds the BTF for a key or value schema: a single scalar
+// keeps its field name reachable via a typedef (so implicit name matching
+// works); anything else becomes a struct named structName.
+func synthesizeType(structName string, fields []KeyField, size uint32) btf.Type {
+	if len(fields) == 1 && fields[0].Off == 0 && fields[0].Size == size {
+		return &btf.Typedef{Name: fields[0].Name, Type: intType(size)}
+	}
+	return synthesizeStruct(structName, fields, size)
+}
+
+// Create builds a BTF-carrying HASH set map and pins it at path. The key
+// schema comes from keySchema ("imsi:u64,teid:u32"); the value defaults
+// to a __u32 tag when valueSchema is empty.
+func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
+	keySpecs, err := ParseSchema(keySchema)
+	if err != nil {
+		return fmt.Errorf("--key: %w", err)
+	}
+	keyFields, keySize := layout(keySpecs)
+	if keySize > MaxKeySize {
+		return fmt.Errorf("key size %d exceeds the %d-byte limit", keySize, MaxKeySize)
+	}
+
+	if valueSchema == "" {
+		valueSchema = "tag:u32"
+	}
+	valSpecs, err := ParseSchema(valueSchema)
+	if err != nil {
+		return fmt.Errorf("--value: %w", err)
+	}
+	valFields, valSize := layout(valSpecs)
+
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name: "xdpninja_set", Type: ebpf.Hash,
+		KeySize: keySize, ValueSize: valSize, MaxEntries: maxEntries,
+		Key:   synthesizeType("xdpninja_set_key", keyFields, keySize),
+		Value: synthesizeType("xdpninja_set_val", valFields, valSize),
+	})
+	if err != nil {
+		return fmt.Errorf("creating map: %w", err)
+	}
+	defer func() { _ = m.Close() }()
+	if err := m.Pin(path); err != nil {
+		return fmt.Errorf("pinning at %s: %w", path, err)
+	}
+	return nil
+}
+
+// ParseFieldValues parses `field=value` CLI args (decimal or 0x hex) and
+// splits off the reserved `tag=` value assignment.
+func ParseFieldValues(args []string) (fields map[string]uint64, tag uint64, hasTag bool, err error) {
+	fields = map[string]uint64{}
+	for _, a := range args {
+		name, vs, ok := strings.Cut(a, "=")
+		if !ok || name == "" || vs == "" {
+			return nil, 0, false, fmt.Errorf("argument %q: want field=value", a)
+		}
+		v, perr := parseUint(vs)
+		if perr != nil {
+			return nil, 0, false, fmt.Errorf("argument %q: %w", a, perr)
+		}
+		if name == "tag" {
+			tag, hasTag = v, true
+			continue
+		}
+		if _, dup := fields[name]; dup {
+			return nil, 0, false, fmt.Errorf("field %q given twice", name)
+		}
+		fields[name] = v
+	}
+	return fields, tag, hasTag, nil
+}
+
+// parseUint is a deliberate copy of filter.parseValue (hex/dec): filter
+// imports setmap, so setmap can't import filter without a cycle. Keep in
+// sync; setmap has no need for the signed/negative branch.
+func parseUint(s string) (uint64, error) {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return strconv.ParseUint(s[2:], 16, 64)
+	}
+	return strconv.ParseUint(s, 10, 64)
+}
+
+// BuildKey assembles the zero-padded key bytes for the definition from
+// named field values. Every key field must be present (full-key rule) and
+// every provided name must be a key field; values must fit their field.
+// Padding is zeroed — hash maps hash all key_size bytes, so a non-zero
+// pad byte would make lookups silently miss.
+func (d *Definition) BuildKey(values map[string]uint64) ([]byte, error) {
+	key := make([]byte, d.KeySize)
+	used := map[string]bool{}
+	for _, f := range d.Fields {
+		v, ok := values[f.Name]
+		if !ok {
+			return nil, fmt.Errorf("missing key field %s (u%d at offset %d) — partial keys are not supported", f.Name, f.Size*8, f.Off)
+		}
+		if f.Size < 8 && v >= 1<<(8*f.Size) {
+			return nil, fmt.Errorf("value %d does not fit key field %s (u%d)", v, f.Name, f.Size*8)
+		}
+		putUint(key[f.Off:f.Off+f.Size], v)
+		used[f.Name] = true
+	}
+	for name := range values {
+		if !used[name] {
+			return nil, fmt.Errorf("unknown key field %q (key has: %s)", name, d.fieldNames())
+		}
+	}
+	return key, nil
+}
+
+func (d *Definition) fieldNames() string {
+	names := make([]string, len(d.Fields))
+	for i, f := range d.Fields {
+		names[i] = fmt.Sprintf("%s:u%d", f.Name, f.Size*8)
+	}
+	return strings.Join(names, ", ")
+}
+
+// putUint writes v into buf in native endianness at the field's width.
+func putUint(buf []byte, v uint64) {
+	switch len(buf) {
+	case 1:
+		buf[0] = byte(v)
+	case 2:
+		binary.NativeEndian.PutUint16(buf, uint16(v))
+	case 4:
+		binary.NativeEndian.PutUint32(buf, uint32(v))
+	case 8:
+		binary.NativeEndian.PutUint64(buf, v)
+	}
+}
+
+// Add inserts (or updates) one entry. The value is the tag zero-extended
+// to the map's value size (default tag 1 = plain presence).
+func (d *Definition) Add(values map[string]uint64, tag uint64) error {
+	key, err := d.BuildKey(values)
+	if err != nil {
+		return err
+	}
+	valSize := d.Map.ValueSize()
+	if valSize < 8 && tag >= 1<<(8*valSize) {
+		return fmt.Errorf("tag %d does not fit the map's %d-byte value", tag, valSize)
+	}
+	val := make([]byte, valSize)
+	n := min(len(val), 8)
+	putUint(val[:n], tag)
+	return d.Map.Put(key, val)
+}
+
+// Delete removes one entry.
+func (d *Definition) Delete(values map[string]uint64) error {
+	key, err := d.BuildKey(values)
+	if err != nil {
+		return err
+	}
+	return d.Map.Delete(key)
+}
+
+// List writes all entries as `field=value ... tag=N` lines.
+func (d *Definition) List(w io.Writer) error {
+	key := make([]byte, d.KeySize)
+	val := make([]byte, d.Map.ValueSize())
+	iter := d.Map.Iterate()
+	for iter.Next(&key, &val) {
+		var parts []string
+		for _, f := range d.Fields {
+			parts = append(parts, fmt.Sprintf("%s=%d", f.Name, getUint(key[f.Off:f.Off+f.Size])))
+		}
+		n := min(len(val), 8)
+		parts = append(parts, fmt.Sprintf("tag=%d", getUint(val[:n])))
+		_, _ = fmt.Fprintln(w, strings.Join(parts, " "))
+	}
+	return iter.Err()
+}
+
+func getUint(buf []byte) uint64 {
+	switch len(buf) {
+	case 1:
+		return uint64(buf[0])
+	case 2:
+		return uint64(binary.NativeEndian.Uint16(buf))
+	case 4:
+		return uint64(binary.NativeEndian.Uint32(buf))
+	case 8:
+		return binary.NativeEndian.Uint64(buf)
+	}
+	return 0
+}
+
+// Schema writes the key layout, one field per line.
+func (d *Definition) Schema(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "hash map: key %d B, value %d B, max_entries %d\n",
+		d.KeySize, d.Map.ValueSize(), d.Map.MaxEntries())
+	for _, f := range d.Fields {
+		_, _ = fmt.Fprintf(w, "  %-20s u%-3d offset %d\n", f.Name, f.Size*8, f.Off)
+	}
+	_, _ = fmt.Fprintf(w, "note: entries must zero all padding bytes (hash covers the full key)\n")
+}

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -24,16 +24,22 @@ type FieldSpec struct {
 // ParseSchema parses "imsi:u64,teid:u32" into field specs.
 func ParseSchema(s string) ([]FieldSpec, error) {
 	var out []FieldSpec
+	seen := map[string]bool{}
 	for ent := range strings.SplitSeq(s, ",") {
 		ent = strings.TrimSpace(ent)
 		if ent == "" {
 			continue
 		}
 		name, typ, ok := strings.Cut(ent, ":")
+		name = strings.TrimSpace(name)
 		if !ok || name == "" {
 			return nil, fmt.Errorf("schema entry %q: want name:type (e.g. imsi:u64)", ent)
 		}
-		size, err := typeSize(typ)
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate field name %q in schema", name)
+		}
+		seen[name] = true
+		size, err := typeSize(strings.TrimSpace(typ))
 		if err != nil {
 			return nil, fmt.Errorf("schema entry %q: %w", ent, err)
 		}

--- a/internal/setmap/setmap.go
+++ b/internal/setmap/setmap.go
@@ -108,6 +108,16 @@ func ParseSetSpec(s string) (SpecRef, error) {
 			continue
 		}
 		field, source, hasSource := strings.Cut(ent, "=")
+		field = strings.TrimSpace(field)
+		source = strings.TrimSpace(source)
+		if field == "" {
+			return ref, fmt.Errorf("--set %q: empty key field name in %q", s, ent)
+		}
+		for _, prev := range ref.Mapping {
+			if prev.Field == field {
+				return ref, fmt.Errorf("--set %q: key field %q mapped twice", s, field)
+			}
+		}
 		if !hasSource {
 			source = "arg:" + field // shorthand: key(imsi) = key(imsi=arg:imsi)
 		}
@@ -133,7 +143,7 @@ func OpenSet(ref SpecRef) (*Set, error) {
 	if err != nil {
 		return nil, fmt.Errorf("set %q: %w", ref.Name, err)
 	}
-	if def.IsScalar && len(ref.Mapping) == 1 {
+	if def.IsScalar && def.Fields[0].Name == scalarUnnamed && len(ref.Mapping) == 1 {
 		def.Fields[0].Name = ref.Mapping[0].Field
 	}
 	return &Set{SpecRef: ref, Def: def}, nil
@@ -188,7 +198,17 @@ func describe(m *ebpf.Map) (*Definition, error) {
 			if !validFieldSize(it.Size) {
 				return nil, fmt.Errorf("key field %s: size %d is not 1/2/4/8", mem.Name, it.Size)
 			}
-			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: mem.Offset.Bytes(), Size: it.Size})
+			off := mem.Offset.Bytes()
+			// emitSetFilters stores each field with a naturally-aligned,
+			// in-bounds store; reject layouts (e.g. __attribute__((packed)))
+			// that would otherwise produce a misaligned or OOB stack write.
+			if off%it.Size != 0 {
+				return nil, fmt.Errorf("key field %s: offset %d is not aligned to its %d-byte width (packed keys are not supported)", mem.Name, off, it.Size)
+			}
+			if off+it.Size > def.KeySize {
+				return nil, fmt.Errorf("key field %s: extends past the %d-byte key", mem.Name, def.KeySize)
+			}
+			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: off, Size: it.Size})
 		}
 		if len(def.Fields) == 0 {
 			return nil, fmt.Errorf("key struct %s has no fields", t.Name)
@@ -199,14 +219,18 @@ func describe(m *ebpf.Map) (*Definition, error) {
 	return def, nil
 }
 
+// scalarUnnamed is the placeholder name for a bare-integer key with no
+// typedef; OpenSet may rename it from the --set key(...) mapping.
+const scalarUnnamed = "key"
+
 // scalarKeyName picks a match name for a bare-integer key: the typedef
 // name when the key is declared through one (typedef __u64 imsi_t), else
-// the generic "key" (which then requires an explicit key(...) mapping).
+// scalarUnnamed (which then requires an explicit key(...) mapping).
 func scalarKeyName(t btf.Type) string {
 	if td, ok := t.(*btf.Typedef); ok {
 		return td.Name
 	}
-	return "key"
+	return scalarUnnamed
 }
 
 func validFieldSize(n uint32) bool {

--- a/internal/setmap/setmap.go
+++ b/internal/setmap/setmap.go
@@ -1,0 +1,290 @@
+// Package setmap resolves pinned BPF HASH maps used as match sets: the
+// map key IS the value (or composite of values) to match, the map value
+// is a small tag (unused by lookup — presence means match). Filters
+// reference a set by name (`--arg-filter "@subs"`) and the set's key
+// schema comes from the map's own BTF, so entries can be added and
+// removed at runtime without re-attaching the probe.
+//
+// Semantics: fields of a composite key AND together (one lookup); OR is
+// expressed by inserting more entries (the set is the union). Partial
+// keys are rejected — every key field must be bound to a source.
+package setmap
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/btf"
+	"golang.org/x/sys/unix"
+)
+
+// MaxKeySize caps the composite key width: the BPF-side key buffer lives
+// in a fixed 64-byte stack window (see program.emitSetFilters).
+const MaxKeySize = 64
+
+// KeyField is one member of the set's key schema, resolved from the
+// map's BTF key type.
+type KeyField struct {
+	Name string
+	Off  uint32 // byte offset within the key
+	Size uint32 // 1, 2, 4 or 8
+}
+
+// Definition is an opened set map plus its resolved key schema.
+type Definition struct {
+	Map      *ebpf.Map
+	KeySize  uint32
+	Fields   []KeyField
+	IsScalar bool // key is a bare integer (single pseudo-field)
+}
+
+// Close releases the map handle. The pin (and the map, while pinned or
+// referenced by a program) survives.
+func (d *Definition) Close() {
+	if d.Map != nil {
+		_ = d.Map.Close()
+	}
+}
+
+// Field returns the key field with the given name.
+func (d *Definition) Field(name string) (KeyField, bool) {
+	for _, f := range d.Fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return KeyField{}, false
+}
+
+// Set is a named set: the parsed spec (name, path, field->source mapping,
+// promoted) plus the opened map definition.
+type Set struct {
+	SpecRef
+	Def *Definition
+}
+
+// MapEntry binds one key field to a source ("arg:<param>" in v1).
+type MapEntry struct {
+	Field  string
+	Source string
+}
+
+// SpecRef is a parsed --set specification, before the map is opened.
+type SpecRef struct {
+	Name    string
+	Path    string
+	Mapping []MapEntry
+}
+
+// ParseSetSpec parses `NAME=/pinned/path[,key(f1=arg:p1,f2,...)]`.
+// The shorthand `key(imsi)` means `key(imsi=arg:imsi)`.
+func ParseSetSpec(s string) (SpecRef, error) {
+	var ref SpecRef
+	name, rest, ok := strings.Cut(s, "=")
+	if !ok || name == "" {
+		return ref, fmt.Errorf("--set %q: want NAME=/pinned/path[,key(...)]", s)
+	}
+	ref.Name = name
+
+	path, keySpec, hasKey := strings.Cut(rest, ",")
+	if path == "" {
+		return ref, fmt.Errorf("--set %q: empty pinned map path", s)
+	}
+	ref.Path = path
+	if !hasKey {
+		return ref, nil
+	}
+
+	inner, ok := strings.CutPrefix(keySpec, "key(")
+	if !ok || !strings.HasSuffix(inner, ")") {
+		return ref, fmt.Errorf("--set %q: expected key(field=source,...) after the path, got %q", s, keySpec)
+	}
+	inner = strings.TrimSuffix(inner, ")")
+	for ent := range strings.SplitSeq(inner, ",") {
+		ent = strings.TrimSpace(ent)
+		if ent == "" {
+			continue
+		}
+		field, source, hasSource := strings.Cut(ent, "=")
+		if !hasSource {
+			source = "arg:" + field // shorthand: key(imsi) = key(imsi=arg:imsi)
+		}
+		if !strings.HasPrefix(source, "arg:") || len(source) <= len("arg:") {
+			return ref, fmt.Errorf("--set %q: source %q must be arg:<param> (pkt: sources are not supported yet)", s, source)
+		}
+		ref.Mapping = append(ref.Mapping, MapEntry{Field: field, Source: source})
+	}
+	if len(ref.Mapping) == 0 {
+		return ref, fmt.Errorf("--set %q: empty key(...) mapping", s)
+	}
+	return ref, nil
+}
+
+// OpenSet opens the pinned map behind a parsed spec and resolves its key
+// schema. Callers own the returned Set's map handle (Set.Def.Close).
+//
+// For a scalar key whose BTF name is synthetic ("key") the mapping's field
+// name is adopted as the canonical scalar field name, so both consumers of
+// the schema — filter resolution and `set add`/`del` — see one name.
+func OpenSet(ref SpecRef) (*Set, error) {
+	def, err := Open(ref.Path)
+	if err != nil {
+		return nil, fmt.Errorf("set %q: %w", ref.Name, err)
+	}
+	if def.IsScalar && len(ref.Mapping) == 1 {
+		def.Fields[0].Name = ref.Mapping[0].Field
+	}
+	return &Set{SpecRef: ref, Def: def}, nil
+}
+
+// Open loads a pinned map and resolves its key schema from the map's BTF.
+func Open(path string) (*Definition, error) {
+	m, err := ebpf.LoadPinnedMap(path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("opening pinned map %s: %w", path, err)
+	}
+	def, err := describe(m)
+	if err != nil {
+		_ = m.Close()
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return def, nil
+}
+
+// describe validates the map and extracts the key schema from its BTF.
+func describe(m *ebpf.Map) (*Definition, error) {
+	if m.Type() != ebpf.Hash {
+		return nil, fmt.Errorf("map type %s is not supported (need hash: the key is the match value)", m.Type())
+	}
+	if m.KeySize() > MaxKeySize {
+		return nil, fmt.Errorf("key size %d exceeds the %d-byte limit", m.KeySize(), MaxKeySize)
+	}
+
+	keyType, err := mapKeyBTF(m)
+	if err != nil {
+		return nil, err
+	}
+
+	def := &Definition{Map: m, KeySize: m.KeySize()}
+	switch t := btf.UnderlyingType(keyType).(type) {
+	case *btf.Int:
+		if !validFieldSize(t.Size) {
+			return nil, fmt.Errorf("scalar key size %d is not 1/2/4/8", t.Size)
+		}
+		name := scalarKeyName(keyType)
+		def.Fields = []KeyField{{Name: name, Off: 0, Size: t.Size}}
+		def.IsScalar = true
+	case *btf.Struct:
+		for _, mem := range t.Members {
+			if mem.BitfieldSize != 0 {
+				return nil, fmt.Errorf("key field %s: bitfields are not supported", mem.Name)
+			}
+			it, ok := btf.UnderlyingType(mem.Type).(*btf.Int)
+			if !ok {
+				return nil, fmt.Errorf("key field %s: only integer fields are supported (got %s)", mem.Name, mem.Type)
+			}
+			if !validFieldSize(it.Size) {
+				return nil, fmt.Errorf("key field %s: size %d is not 1/2/4/8", mem.Name, it.Size)
+			}
+			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: mem.Offset.Bytes(), Size: it.Size})
+		}
+		if len(def.Fields) == 0 {
+			return nil, fmt.Errorf("key struct %s has no fields", t.Name)
+		}
+	default:
+		return nil, fmt.Errorf("key BTF type %s is not a struct or integer", keyType)
+	}
+	return def, nil
+}
+
+// scalarKeyName picks a match name for a bare-integer key: the typedef
+// name when the key is declared through one (typedef __u64 imsi_t), else
+// the generic "key" (which then requires an explicit key(...) mapping).
+func scalarKeyName(t btf.Type) string {
+	if td, ok := t.(*btf.Typedef); ok {
+		return td.Name
+	}
+	return "key"
+}
+
+func validFieldSize(n uint32) bool {
+	return n == 1 || n == 2 || n == 4 || n == 8
+}
+
+// mapKeyBTF returns the map's BTF key type. cilium/ebpf exposes the map's
+// BTF handle but not btf_key_type_id (it lives in the internal sys
+// package), so read struct bpf_map_info via a raw BPF_OBJ_GET_INFO_BY_FD
+// and look the type up in the handle's spec.
+func mapKeyBTF(m *ebpf.Map) (btf.Type, error) {
+	keyTypeID, err := mapKeyBTFTypeID(m.FD())
+	if err != nil {
+		return nil, err
+	}
+	if keyTypeID == 0 {
+		return nil, fmt.Errorf("map has no key BTF; create it with `xdp-ninja set create` (or load it with BTF key/value types)")
+	}
+
+	h, err := m.Handle()
+	if err != nil {
+		return nil, fmt.Errorf("map BTF handle: %w", err)
+	}
+	defer func() { _ = h.Close() }()
+	spec, err := h.Spec(nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading map BTF: %w", err)
+	}
+	t, err := spec.TypeByID(btf.TypeID(keyTypeID))
+	if err != nil {
+		return nil, fmt.Errorf("resolving key type id %d: %w", keyTypeID, err)
+	}
+	return t, nil
+}
+
+// bpfMapInfo mirrors the leading fields of UAPI struct bpf_map_info up to
+// and including the BTF ids (see include/uapi/linux/bpf.h). The layout is
+// kernel ABI and append-only.
+type bpfMapInfo struct {
+	MapType               uint32 // 0
+	ID                    uint32 // 4
+	KeySize               uint32 // 8
+	ValueSize             uint32 // 12
+	MaxEntries            uint32 // 16
+	MapFlags              uint32 // 20
+	Name                  [16]byte
+	Ifindex               uint32 // 40
+	BTFVmlinuxValueTypeID uint32 // 44
+	NetnsDev              uint64 // 48
+	NetnsIno              uint64 // 56
+	BTFID                 uint32 // 64
+	BTFKeyTypeID          uint32 // 68
+	BTFValueTypeID        uint32 // 72
+	BTFVmlinuxID          uint32 // 76
+	MapExtra              uint64 // 80
+}
+
+// bpfObjGetInfoByFDAttr mirrors the info union member of union bpf_attr.
+type bpfObjGetInfoByFDAttr struct {
+	BpfFD   uint32
+	InfoLen uint32
+	Info    uint64 // pointer
+}
+
+const bpfObjGetInfoByFD = 15 // BPF_OBJ_GET_INFO_BY_FD
+
+// mapKeyBTFTypeID reads btf_key_type_id from bpf_map_info.
+func mapKeyBTFTypeID(fd int) (uint32, error) {
+	var info bpfMapInfo
+	attr := bpfObjGetInfoByFDAttr{
+		BpfFD:   uint32(fd),
+		InfoLen: uint32(unsafe.Sizeof(info)),
+		Info:    uint64(uintptr(unsafe.Pointer(&info))),
+	}
+	_, _, errno := unix.Syscall(unix.SYS_BPF, bpfObjGetInfoByFD,
+		uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	if errno != 0 {
+		return 0, fmt.Errorf("BPF_OBJ_GET_INFO_BY_FD: %w", errno)
+	}
+	return info.BTFKeyTypeID, nil
+}

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -134,3 +134,29 @@ func TestParseFieldValues(t *testing.T) {
 		t.Errorf("dup err = %v", err)
 	}
 }
+
+func TestParseSetSpecTrimAndDup(t *testing.T) {
+	// whitespace-polluted field/source get trimmed
+	ref, err := ParseSetSpec("s=/p,key( imsi = arg:imsi )")
+	if err != nil {
+		t.Fatalf("ParseSetSpec trim: %v", err)
+	}
+	if ref.Mapping[0].Field != "imsi" || ref.Mapping[0].Source != "arg:imsi" {
+		t.Errorf("trimmed mapping = %+v", ref.Mapping[0])
+	}
+	// duplicate field mapping is rejected
+	if _, err := ParseSetSpec("s=/p,key(imsi=arg:a,imsi=arg:b)"); err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Errorf("dup field err = %v", err)
+	}
+	// empty field name
+	if _, err := ParseSetSpec("s=/p,key(=arg:imsi)"); err == nil || !strings.Contains(err.Error(), "empty key field") {
+		t.Errorf("empty field err = %v", err)
+	}
+}
+
+func TestCreateRejectsReservedAndBadMaxEntries(t *testing.T) {
+	// A "tag" key field can never be addressed by `set add`.
+	if err := Create("/sys/fs/bpf/unused", "tag:u32", "", 8); err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Errorf("reserved-key err = %v", err)
+	}
+}

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -160,3 +160,9 @@ func TestCreateRejectsReservedKeyField(t *testing.T) {
 		t.Errorf("reserved-key err = %v", err)
 	}
 }
+
+func TestCreateRejectsMultiFieldValue(t *testing.T) {
+	if err := Create("/sys/fs/bpf/unused", "imsi:u64", "a:u8,b:u16", 8); err == nil || !strings.Contains(err.Error(), "single") {
+		t.Errorf("multi-field value err = %v, want 'single ... tag'", err)
+	}
+}

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -166,3 +166,9 @@ func TestCreateRejectsMultiFieldValue(t *testing.T) {
 		t.Errorf("multi-field value err = %v, want 'single ... tag'", err)
 	}
 }
+
+func TestParseSchemaRejectsDuplicateField(t *testing.T) {
+	if _, err := ParseSchema("imsi:u64,imsi:u32"); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("dup field err = %v, want 'duplicate'", err)
+	}
+}

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -154,7 +154,7 @@ func TestParseSetSpecTrimAndDup(t *testing.T) {
 	}
 }
 
-func TestCreateRejectsReservedAndBadMaxEntries(t *testing.T) {
+func TestCreateRejectsReservedKeyField(t *testing.T) {
 	// A "tag" key field can never be addressed by `set add`.
 	if err := Create("/sys/fs/bpf/unused", "tag:u32", "", 8); err == nil || !strings.Contains(err.Error(), "reserved") {
 		t.Errorf("reserved-key err = %v", err)

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -1,0 +1,136 @@
+package setmap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSetSpec(t *testing.T) {
+	tests := []struct {
+		in      string
+		name    string
+		path    string
+		mapping []MapEntry
+		wantErr string
+	}{
+		{in: "subs=/sys/fs/bpf/subs", name: "subs", path: "/sys/fs/bpf/subs"},
+		{
+			in:   "flows=/sys/fs/bpf/flows,key(imsi=arg:imsi,teid=arg:teid)",
+			name: "flows", path: "/sys/fs/bpf/flows",
+			mapping: []MapEntry{{Field: "imsi", Source: "arg:imsi"}, {Field: "teid", Source: "arg:teid"}},
+		},
+		{
+			// shorthand: key(imsi) = key(imsi=arg:imsi)
+			in: "s=/p,key(imsi)", name: "s", path: "/p",
+			mapping: []MapEntry{{Field: "imsi", Source: "arg:imsi"}},
+		},
+		{in: "=/p", wantErr: "want NAME="},
+		{in: "s=", wantErr: "empty pinned map path"},
+		{in: "s=/p,keys(imsi)", wantErr: "expected key("},
+		{in: "s=/p,key()", wantErr: "empty key"},
+		{in: "s=/p,key(f=pkt:ipv4.src)", wantErr: "must be arg:"},
+	}
+	for _, tt := range tests {
+		ref, err := ParseSetSpec(tt.in)
+		if tt.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ParseSetSpec(%q) err = %v, want containing %q", tt.in, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseSetSpec(%q): %v", tt.in, err)
+			continue
+		}
+		if ref.Name != tt.name || ref.Path != tt.path {
+			t.Errorf("ParseSetSpec(%q) = %+v", tt.in, ref)
+		}
+		if len(ref.Mapping) != len(tt.mapping) {
+			t.Errorf("ParseSetSpec(%q) mapping = %+v, want %+v", tt.in, ref.Mapping, tt.mapping)
+			continue
+		}
+		for i := range tt.mapping {
+			if ref.Mapping[i] != tt.mapping[i] {
+				t.Errorf("ParseSetSpec(%q) mapping[%d] = %+v, want %+v", tt.in, i, ref.Mapping[i], tt.mapping[i])
+			}
+		}
+	}
+}
+
+func TestLayoutNaturalAlignment(t *testing.T) {
+	specs, err := ParseSchema("imsi:u64,teid:u32")
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	fields, size := layout(specs)
+	if size != 16 {
+		t.Errorf("size = %d, want 16 (u64+u32 padded to 8-alignment)", size)
+	}
+	if fields[0].Off != 0 || fields[1].Off != 8 {
+		t.Errorf("offsets = %d,%d, want 0,8", fields[0].Off, fields[1].Off)
+	}
+
+	// u16 then u64: u64 must align to 8, total padded to 16.
+	specs2, _ := ParseSchema("a:u16,b:u64")
+	f2, size2 := layout(specs2)
+	if f2[1].Off != 8 || size2 != 16 {
+		t.Errorf("a:u16,b:u64 → b@%d size %d, want b@8 size 16", f2[1].Off, size2)
+	}
+}
+
+func TestBuildKeyPaddingAndErrors(t *testing.T) {
+	def := &Definition{
+		KeySize: 16,
+		Fields: []KeyField{
+			{Name: "imsi", Off: 0, Size: 8},
+			{Name: "teid", Off: 8, Size: 4},
+		},
+	}
+
+	key, err := def.BuildKey(map[string]uint64{"imsi": 0x0102030405060708, "teid": 0x3039})
+	if err != nil {
+		t.Fatalf("BuildKey: %v", err)
+	}
+	if len(key) != 16 {
+		t.Fatalf("key len = %d, want 16", len(key))
+	}
+	// padding bytes (12..15) must be zero — hash covers the full key.
+	for i := 12; i < 16; i++ {
+		if key[i] != 0 {
+			t.Errorf("padding byte %d = %#x, want 0", i, key[i])
+		}
+	}
+
+	// partial key → error naming the missing field
+	if _, err := def.BuildKey(map[string]uint64{"imsi": 1}); err == nil || !strings.Contains(err.Error(), "teid") {
+		t.Errorf("partial key err = %v, want mention of teid", err)
+	}
+	// unknown field
+	if _, err := def.BuildKey(map[string]uint64{"imsi": 1, "teid": 2, "bogus": 3}); err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("unknown field err = %v, want mention of bogus", err)
+	}
+	// value too wide for field
+	if _, err := def.BuildKey(map[string]uint64{"imsi": 1, "teid": 1 << 40}); err == nil || !strings.Contains(err.Error(), "does not fit") {
+		t.Errorf("overflow err = %v, want 'does not fit'", err)
+	}
+}
+
+func TestParseFieldValues(t *testing.T) {
+	fields, tag, hasTag, err := ParseFieldValues([]string{"imsi=901040010000005", "teid=0x3039", "tag=7"})
+	if err != nil {
+		t.Fatalf("ParseFieldValues: %v", err)
+	}
+	if fields["imsi"] != 901040010000005 || fields["teid"] != 0x3039 {
+		t.Errorf("fields = %v", fields)
+	}
+	if !hasTag || tag != 7 {
+		t.Errorf("tag = %d hasTag=%v, want 7 true", tag, hasTag)
+	}
+
+	if _, _, _, err := ParseFieldValues([]string{"imsi"}); err == nil {
+		t.Error("expected error for missing =value")
+	}
+	if _, _, _, err := ParseFieldValues([]string{"a=1", "a=2"}); err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Errorf("dup err = %v", err)
+	}
+}

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -258,6 +258,11 @@ const dslReject = "dsl_reject"
 //   - host: any subset of [-1, KunaiStackTop+1]; xdp-ninja uses -48
 //     for the saved tracing args pointer.
 //
+// The host may additionally use slots at or below this line *strictly
+// before* jumping into the filter (temporal reuse): xdp-ninja's set
+// filters build their map-lookup key at -57..-120, which is dead by the
+// time the filter body (the owner of this region at runtime) executes.
+//
 // The TestZeroCapsIsHostAgnostic regression check asserts that a
 // zero-Capabilities filter never touches any slot above this line.
 const KunaiStackTop = int16(-56)


### PR DESCRIPTION
## 概要

スカラ `--arg-filter "imsi=X"` は値を命令列に焼き込むため、購読者リストのマッチには (1) 値ごとに命令が伸びて verifier が爆発、(2) 値変更のたび re-attach、という問題があります。**値集合を pinned BPF HASH map に外出し** (キー = 照合する値そのもの) すると、データパスはパケットごとに **O(1) lookup 1回**で済み、**エントリの追加・削除がキャプチャ中でも即時反映** (re-attach 不要) されます。選択的 pcap 取得サービスの最小核です。

```bash
xdp-ninja set create /sys/fs/bpf/flows --key "imsi:u64,teid:u32"
xdp-ninja set add    /sys/fs/bpf/flows imsi=901040010000005 teid=0x3039
xdp-ninja -p 1661 --func pgwu_capture_point_ul \
  --set "flows=/sys/fs/bpf/flows" --arg-filter "@flows" -w out.pcap
# ↑ 実行中に set add/del すると即座に反映
```

## 設計

- **`internal/setmap`**: `--set NAME=/path[,key(f=arg:p,...)]` パース、pinned map open、キースキーマを **map の BTF から取得** (`btf_key_type_id` を raw `BPF_OBJ_GET_INFO_BY_FD` で。cilium/ebpf が公開していないため)。`set create/add/del/list/schema` ops は BTF を合成し、**フィールド名でエントリ管理** (bpftool のような zero-padded native-endian hex を手組みしなくてよい — IMSI エンコード騒動の footgun)。
- **`--arg-filter "@NAME"`**: 対象関数の引数から複合キーをスタック上 (`fp-57..-120`、パケットフィルタ実行前に死ぬ = kunai 領域の temporal reuse) に構築 → lookup、NULL なら skip。他の arg-filter や別 set と AND。複合キーのフィールド間は AND、OR はエントリ複数 (集合=直和)、完全キーのみ。
- **`filter.TargetFilters`** がターゲットごとの `[][]ArgFilter` を置換し、スカラ比較と set lookup を一体化。arg-filter はターゲットごとに解決 (param 位置が関数で異なるため)。
- 複合キーはパディングのゼロ埋めが必須 (hash は全バイト対象) だが、`emitSetFilters` は **gapless/scalar キーではゼロ埋めを省略** (per-packet の無駄を削減)。
- v1 のソースは `arg:` のみ (pkt:/DSL 述語は後段)。`--arg-echo` / `--mode xdp` は set 併用不可。

## テスト

- **unit**: spec/schema パース、キー構築のパディング・オーバーフローエラー、resolve (幅チェック・引数欠落・スカラ位置指定)。
- **root e2e** (`internal/program/setfilter_test.go`): パディング付き複合キー set を create+pin → `@flows` gate の probe を attach → `BPF_PROG_TEST_RUN` で (a) メンバのみ capture、(b) **実行中の add/del が re-attach 無しで反映**、を検証。スカラキー set も別途。
- **CLI 実機スモーク**: create/add/list/del/schema 往復、`bpftool map dump` の BTF 整形表示 interop、エラーパス。

`/simplify` (4観点並列) 適用済み: `asmSizeFor`/`intType`/`synthesizeType` helper 化、`Set` に `SpecRef` 埋め込み、スカラ名正規化を `OpenSet` に集約 (filter/管理の2消費者で一貫)、gapless キーのゼロ埋め skip、parseUint の forced-copy 注記。stack 契約は codegen.go の `KunaiStackTop` docblock に相互記載。

## スコープ外 (後段)
- DSL 述語 `@NAME` (pkt: ソース、kunai Capabilities 注入)
- value tag → metadata → pcap-ng interface 分離 / オフライン split
- 外部 mapid 直参照 (bearer map 等)、LPM_TRIE (IP prefix)
