### PR TITLE
ci(release): check out the release tag for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,16 @@ jobs:
       contents: write
       packages: write
     steps:
+      # Check out the exact tag release-please just created, not the branch
+      # HEAD. Both point at the same commit, but pinning the ref makes
+      # goreleaser's `git describe` deterministic: otherwise it can race the
+      # just-pushed tag and resolve the previous release as "current",
+      # failing with "git tag vX.Y.Z was not made against commit ...".
       - uses: actions/checkout@v5
         with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
           fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## 問題

Release workflow は1つの run で `release-please`(タグ作成)→ `goreleaser`(バイナリビルド)を回すが、goreleaser の checkout が **main への push commit (`github.sha`)** を取得するため、release-please が直前ジョブで作った新タグを `git describe` が拾えず、**1つ前のリリースを current と誤認**して落ちることがある:

```
using tags  previous=v0.13.0 current=v0.13.1
⨯ release failed: git tag v0.13.1 was not made against commit <HEAD>
```

間欠的で、v0.14.0 で発火(アセット添付されず、手動再実行も同事象で失敗)。v0.16.0 はタイミングで回避できたが根治していない。

## 修正

goreleaser ジョブの checkout を **release-please が出力する `tag_name` に固定**する。タグと branch HEAD は同一 commit を指すが、タグを直接 checkout することで `git describe` が決定的になり、レースが消える。`fetch-depth: 0` + `fetch-tags: true` で changelog 用の履歴とタグも確保。

```yaml
- uses: actions/checkout@v5
  with:
    ref: ${{ needs.release-please.outputs.tag_name }}
    fetch-depth: 0
    fetch-tags: true
```

`tag_name` は release-please ジョブが既に output 済み。releases_created=true のときのみ goreleaser が走るので ref は常に存在する。

## 検証

この workflow は push-to-main でのみ走るため本 PR の CI では実行されない(YAML 妥当性 + yamllint は pass)。次のリリースで実地検証される。既存リリース (v0.16.0 まで) はアセット添付済みで影響なし。
