### PR TITLE
feat(kunai): DSL packet-field set matching (layer[field in @NAME])

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ sudo xdp-ninja set create /sys/fs/bpf/subs --key "imsi:u64"
 sudo xdp-ninja set add /sys/fs/bpf/subs imsi=901040010000005
 sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul \
   --set "subs=/sys/fs/bpf/subs" --arg-filter "@subs" -w subs.pcap
+
+# Key the set off a PACKET field instead of a function arg — for values
+# that live in the packet (GTP TEID, SRv6 SID). Works on fentry and xdp.
+sudo xdp-ninja set create /sys/fs/bpf/teids --key "teid:u32"
+sudo xdp-ninja set add /sys/fs/bpf/teids teid=0x3039
+sudo xdp-ninja -p 1661 --set "teids=/sys/fs/bpf/teids" \
+  'eth/ipv4/udp/gtp[teid in @teids]' -w teids.pcap
 ```
 
 ### Filter syntax

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -489,22 +489,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		// Reject before opening any pinned map (which can fail).
 		return fmt.Errorf("--set is not supported with --arg-echo")
 	}
-	seenSet := map[string]bool{}
-	for _, spec := range cmd.StringSlice("set") {
-		ref, err := setmap.ParseSetSpec(spec)
-		if err != nil {
-			return err
-		}
-		if seenSet[ref.Name] {
-			return fmt.Errorf("--set %q: set name %q defined more than once", spec, ref.Name)
-		}
-		seenSet[ref.Name] = true
-		s, err := setmap.OpenSet(ref)
-		if err != nil {
-			return err
-		}
-		sets = append(sets, s)
-		logVerbose(cmd, "set %q: %s (key %d B, %d field(s))", s.Name, s.Path, s.Def.KeySize, len(s.Def.Fields))
+	var setErr error
+	if sets, setErr = openDeclaredSets(cmd); setErr != nil {
+		return setErr
 	}
 
 	// --arg-filter: split "@NAME" set references from plain expressions,
@@ -571,9 +558,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 	var probe *program.Probe
 	if isFexit {
-		probe, err = program.LoadMultiExit(targets, filterExpr, filters, useDSL)
+		probe, err = program.LoadMultiExit(targets, filterExpr, filters, useDSL, sets)
 	} else {
-		probe, err = program.LoadMultiEntry(targets, filterExpr, filters, useDSL)
+		probe, err = program.LoadMultiEntry(targets, filterExpr, filters, useDSL, sets)
 	}
 	if err != nil {
 		return err
@@ -981,8 +968,8 @@ func captureLoopShardedRaw(cmd *cli.Command, inners []*ebpf.Map, label, basePath
 	// shardCounts[shardIdx].n++; only one shard goroutine ever
 	// writes its own slot, and the final reader runs after stop().
 	type paddedCounter struct {
-		n   int64
-		_   [56]byte
+		n int64
+		_ [56]byte
 	}
 	shardCounts := make([]paddedCounter, len(inners))
 	var captured atomic.Int64
@@ -1131,8 +1118,46 @@ func reportLatencySamples(outputPath string) {
 
 // runXDPNative handles --mode xdp: xdp-ninja is itself the XDP
 // program on the netdev (no fentry/fexit piggybacking).
+// openDeclaredSets parses and opens every --set spec, rejecting duplicate
+// names. The caller owns the returned handles (defer Def.Close) until the
+// program is loaded. On error it returns whatever opened so far so the
+// caller's deferred close still runs.
+func openDeclaredSets(cmd *cli.Command) ([]*setmap.Set, error) {
+	var sets []*setmap.Set
+	seen := map[string]bool{}
+	for _, spec := range cmd.StringSlice("set") {
+		ref, err := setmap.ParseSetSpec(spec)
+		if err != nil {
+			return sets, err
+		}
+		if seen[ref.Name] {
+			return sets, fmt.Errorf("--set %q: set name %q defined more than once", spec, ref.Name)
+		}
+		seen[ref.Name] = true
+		s, err := setmap.OpenSet(ref)
+		if err != nil {
+			return sets, err
+		}
+		sets = append(sets, s)
+		logVerbose(cmd, "set %q: %s (key %d B, %d field(s))", s.Name, s.Path, s.Def.KeySize, len(s.Def.Fields))
+	}
+	return sets, nil
+}
+
 func runXDPNative(cmd *cli.Command) error {
 	if err := validateXDPNativeFlags(cmd); err != nil {
+		return err
+	}
+
+	// DSL `layer[field in @NAME]` extracts packet fields into a host key
+	// buffer and looks the pinned set up after the filter; open the sets.
+	sets, err := openDeclaredSets(cmd)
+	defer func() {
+		for _, s := range sets {
+			s.Def.Close()
+		}
+	}()
+	if err != nil {
 		return err
 	}
 
@@ -1161,7 +1186,7 @@ func runXDPNative(cmd *cli.Command) error {
 
 	logVerbose(cmd, "attaching xdp-ninja as native XDP on %s (filter: %s)", ifaceName, filterExpr)
 
-	probe, err := program.LoadXDPNative(state, filterExpr, useDSL)
+	probe, err := program.LoadXDPNative(state, filterExpr, useDSL, sets)
 	if err != nil {
 		return err
 	}
@@ -1185,8 +1210,11 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	if len(cmd.StringSlice("arg-filter")) > 0 {
 		return fmt.Errorf("--arg-filter is only valid with --mode entry/exit (no tracing args in xdp-native)")
 	}
-	if len(cmd.StringSlice("set")) > 0 {
-		return fmt.Errorf("--set is only valid with --mode entry/exit (set matching keys off tracing args)")
+	if len(cmd.StringSlice("set")) > 0 && len(cmd.StringSlice("arg-filter")) > 0 {
+		// arg-filter is already rejected above; this guards the case where
+		// a future relaxation lets both through. DSL `@set` (packet-field
+		// extraction) is fine on xdp-native and handled in runXDPNative.
+		return fmt.Errorf("--set with --arg-filter needs tracing args (--mode entry/exit); use DSL `layer[field in @NAME]` on xdp-native")
 	}
 	if cmd.Bool("list-funcs") || cmd.Bool("list-progs") || cmd.Bool("list-params") {
 		return fmt.Errorf("--list-* flags are only valid with --mode entry/exit")
@@ -1249,7 +1277,6 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	}
 	return infos, nil
 }
-
 
 // formatKeyRanges renders a sorted key list compactly, collapsing runs of
 // consecutive keys: [0,1,2,3] -> "0-3", [0,1,3,4,5] -> "0-1,3-5".

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -74,7 +74,7 @@ var flags = []cli.Flag{
 	},
 	&cli.StringSliceFlag{
 		Name:  "set",
-		Usage: "define a named match set backed by a pinned BPF hash map: NAME=/sys/fs/bpf/path[,key(field=arg:param,...)]; reference it with --arg-filter @NAME. Entries are managed at runtime via `xdp-ninja set` (no re-attach needed)",
+		Usage: "define a named match set backed by a pinned BPF hash map: NAME=/sys/fs/bpf/path[,key(field=arg:param,...)]; reference it with --arg-filter @NAME (function arg) or the DSL predicate layer[field in @NAME] (packet field). Entries are managed at runtime via `xdp-ninja set` (no re-attach needed)",
 	},
 	&cli.BoolFlag{
 		Name:  "list-params",

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -1210,12 +1210,9 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	if len(cmd.StringSlice("arg-filter")) > 0 {
 		return fmt.Errorf("--arg-filter is only valid with --mode entry/exit (no tracing args in xdp-native)")
 	}
-	if len(cmd.StringSlice("set")) > 0 && len(cmd.StringSlice("arg-filter")) > 0 {
-		// arg-filter is already rejected above; this guards the case where
-		// a future relaxation lets both through. DSL `@set` (packet-field
-		// extraction) is fine on xdp-native and handled in runXDPNative.
-		return fmt.Errorf("--set with --arg-filter needs tracing args (--mode entry/exit); use DSL `layer[field in @NAME]` on xdp-native")
-	}
+	// --set is valid on xdp-native for DSL `layer[field in @NAME]` (packet
+	// extraction). arg-filter @NAME (which needs tracing args) is already
+	// rejected by the --arg-filter check above.
 	if cmd.Bool("list-funcs") || cmd.Bool("list-progs") || cmd.Bool("list-params") {
 		return fmt.Errorf("--list-* flags are only valid with --mode entry/exit")
 	}

--- a/docs/ja/dsl-grammar.md
+++ b/docs/ja/dsl-grammar.md
@@ -62,12 +62,14 @@ resolver / codegen が enforce する MVP 制約は次のとおりです。
 ```ebnf
 predicate      ::= '[' field-path op value ']'
                  | '[' field-path 'in' value-list ']'      (* F7: integer 値の OR-chain *)
+                 | '[' field-path 'in' '@' set-name ']'    (* pinned-map 集合照合 *)
                  | '[' field-path 'has' flag-name ']'      (* F6 bitwise & で superseded *)
 field-path     ::= field-name ('.' field-name)*            (* aux access: <aux>.<field> *)
 field-name     ::= [a-z] [a-z0-9_]*
 op             ::= '==' | '!=' | '<' | '<=' | '>' | '>='
 value          ::= integer | ipv4 | ipv4-cidr | ipv6 | ipv6-cidr | mac
 value-list     ::= '[' value (',' value)* ']'
+set-name       ::= [a-z] [a-z0-9_]*                        (* --set NAME= で宣言した集合 *)
 flag-name      ::= [A-Z] [A-Z0-9_]*
 integer        ::= '-'? ('0x' [0-9a-fA-F]+ | [0-9]+)        (* 値域: [-2^63, 2^64) *)
 ipv4           ::= INT '.' INT '.' INT '.' INT              (* 各 INT: 0..255、zero-prefix 拒否 *)
@@ -81,6 +83,7 @@ mac            ::= [0-9a-fA-F]{2} (':' [0-9a-fA-F]{2}){5}   (* colon 区切り 6
 |---|---|---|
 | `predicate` (cmp) | `predicate.go::parsePredicate` | `[dport==443]`, `[src!=fe80::1]`, `[opt.next_ext == 0]` |
 | `predicate` (in) | `predicate.go::parsePredicate` (`PredIn` branch) | `[dport in [80, 443]]` *(codegen reject)* |
+| `predicate` (in @set) | `predicate.go::parsePredicate` (`PredInSet` branch) | `gtp[teid in @teids]`、複合キーは `gtp[teid in @f, imsi in @f]` |
 | `predicate` (has) | `predicate.go::parsePredicate` (`PredHas` branch) | `[flags has SYN]` *(codegen reject)* |
 | `field-path` (1-part) | `predicate.go::parseFieldPath` | `dport` / `src` |
 | `field-path` (2-part = aux) | `predicate.go::parseFieldPath` | `opt.next_ext` (gtp の auxiliary header field) |

--- a/docs/ja/dsl-internals.md
+++ b/docs/ja/dsl-internals.md
@@ -586,17 +586,17 @@ eBPF の LDX は x86 上で little-endian で読みます。packet bytes は net
 
 ### 4.9 pinned-map 集合照合 (`layer[field in @NAME]`)
 
-パケットフィールドを pinned BPF hash map に集合照合する述語です。設計の要点は **kunai は map を一切知らない不変条件を保つ** ことです (codegen は `FnMapLookupElem` / `LoadMapPtr` を emit せず、`Output` に map 参照を持たない)。実現は 2 段構成です (host adapter 境界の典型例)。
+パケットフィールドを pinned BPF hash map に集合照合する述語です。設計の要点は、kunai が map を一切知らない不変条件を保つことにあります。codegen は `FnMapLookupElem` や `LoadMapPtr` を emit せず、`Output` にも map 参照を持ちません。実現は host adapter 境界の典型例となる 2 段構成です。
 
-- **kunai 側 (`predicate.go::emitInSetPredicate`)**: フィールドを境界チェック付きで load し、`HostTo(BE)` で数値 (host order) に正規化して、**host が指定した R10 スロットに store** します。map lookup は emit しません。set atom は verdict に影響させず (レイヤ到達失敗時のみ `dslReject`)、抽出したスロットは `Output.Extractions` (`{SetName, FieldName, StackOff, StoreSize}`) で host に返します。host はスロット offset を `codegen.SetSlotResolver` (`caps.Lang.SetSlots`、`ActionFetcher` と同型の注入面) で渡します。返すのは int16 offset と幅だけで、map/FD/BTF は渡りません。
-- **host 側 (`internal/program/setslots.go`)**: filter 実行後に、そのスロットのバイト列をキーに `FnMapLookupElem` を emit し、miss なら capture skip します (`emitPktSetLookups`)。事前に buffer を zero 埋めして pad を 0 に保ちます (`emitPktSetKeyZeroing`)。
+- kunai 側の `predicate.go::emitInSetPredicate` は、フィールドを境界チェック付きで load し、`HostTo(BE)` で host order の数値に正規化してから、host が指定した R10 スロットに store します。map lookup は emit しません。set atom は verdict に影響させず、レイヤ到達に失敗したときだけ `dslReject` へ飛びます。抽出したスロットは `{SetName, FieldName, StackOff, StoreSize}` を並べた `Output.Extractions` で host に返します。host はスロット offset を `codegen.SetSlotResolver` で渡します。これは `caps.Lang.SetSlots` に置く `ActionFetcher` と同型の注入面で、返すのは int16 offset と幅だけであり、map や FD や BTF は渡りません。
+- host 側の `internal/program/setslots.go` は、filter 実行後にそのスロットのバイト列をキーとして `FnMapLookupElem` を emit し、miss なら capture を skip します。この処理は `emitPktSetLookups` にあります。事前に `emitPktSetKeyZeroing` で buffer を zero 埋めし、pad を 0 に保ちます。
 
 制約は次のとおりです。
 
-- **エンディアン契約**: `set add` は host order (`setmap.BuildKey` の `binary.NativeEndian`)、パケットは network order。kunai の `HostTo(BE)` 正規化 + host の native store で両者を一致させます。ここがずれると全 miss します (差分テスト `TestBpfDSLSetMatchPacketField` が守ります)。
-- **スタック**: 抽出スロットは filter 実行中に書かれ filter 後に読まれるため、kunai 領域 `[-56, ...)` には置けません。host 領域 `[-40, -24)` (両 attach path で空きの 16B) を使うので、**合計キー幅は 16 バイトまで**、1 フィールド 8 バイトまでです。
-- **構文**: bracket predicate 専用 (`where` 句では不可)。bracket は layer の連言に必ず入るので、`@set` は構造的にトップレベル AND になり、v1 の「集合は AND」と一致します。複合キーは 1 つの角括弧にカンマ併記します。
-- iterator-stack (`any`/`all` の aux) 上のフィールドは resolver が拒否します (last-write-wins になるため)。
+- エンディアン契約があります。`set add` は `setmap.BuildKey` の `binary.NativeEndian` により host order で書き、パケットは network order です。kunai の `HostTo(BE)` 正規化と host の native store で両者を一致させます。ここがずれると全 miss するので、差分テストの `TestBpfDSLSetMatchPacketField` が守ります。
+- スタックに制約があります。抽出スロットは filter 実行中に書かれ filter 後に読まれるため、kunai 領域の `[-56, ...)` には置けません。両 attach path で空いている 16 バイトの host 領域 `[-40, -24)` を使うので、合計キー幅は 16 バイトまで、1 フィールドは 8 バイトまでです。
+- 構文は bracket predicate 専用で、`where` 句では使えません。bracket は layer の連言に必ず入るので、`@set` は構造的にトップレベルの AND になり、v1 の集合は AND という意味論と一致します。複合キーは 1 つの角括弧にカンマ併記します。
+- `any` や `all` の aux にあたる iterator-stack 上のフィールドは、last-write-wins になるため resolver が拒否します。
 
 ## 5. P4-16 互換性
 

--- a/docs/ja/dsl-internals.md
+++ b/docs/ja/dsl-internals.md
@@ -584,6 +584,20 @@ action atom (`action == NAME`) では、codegen は `caps.Lang.ActionFetcher.Emi
 
 eBPF の LDX は x86 上で little-endian で読みます。packet bytes は network order (BE) です。runtime BSwap を avoid するため、codegen 時に定数を byte-swap して LE 形式で immediate に埋めます。`==` / `!=` の単純比較が 1 命令で済みます。`<` や `>` 等の ordered 比較は意味的に LE にできないので、runtime BSwap を入れます。
 
+### 4.9 pinned-map 集合照合 (`layer[field in @NAME]`)
+
+パケットフィールドを pinned BPF hash map に集合照合する述語です。設計の要点は **kunai は map を一切知らない不変条件を保つ** ことです (codegen は `FnMapLookupElem` / `LoadMapPtr` を emit せず、`Output` に map 参照を持たない)。実現は 2 段構成です (host adapter 境界の典型例)。
+
+- **kunai 側 (`predicate.go::emitInSetPredicate`)**: フィールドを境界チェック付きで load し、`HostTo(BE)` で数値 (host order) に正規化して、**host が指定した R10 スロットに store** します。map lookup は emit しません。set atom は verdict に影響させず (レイヤ到達失敗時のみ `dslReject`)、抽出したスロットは `Output.Extractions` (`{SetName, FieldName, StackOff, StoreSize}`) で host に返します。host はスロット offset を `codegen.SetSlotResolver` (`caps.Lang.SetSlots`、`ActionFetcher` と同型の注入面) で渡します。返すのは int16 offset と幅だけで、map/FD/BTF は渡りません。
+- **host 側 (`internal/program/setslots.go`)**: filter 実行後に、そのスロットのバイト列をキーに `FnMapLookupElem` を emit し、miss なら capture skip します (`emitPktSetLookups`)。事前に buffer を zero 埋めして pad を 0 に保ちます (`emitPktSetKeyZeroing`)。
+
+制約は次のとおりです。
+
+- **エンディアン契約**: `set add` は host order (`setmap.BuildKey` の `binary.NativeEndian`)、パケットは network order。kunai の `HostTo(BE)` 正規化 + host の native store で両者を一致させます。ここがずれると全 miss します (差分テスト `TestBpfDSLSetMatchPacketField` が守ります)。
+- **スタック**: 抽出スロットは filter 実行中に書かれ filter 後に読まれるため、kunai 領域 `[-56, ...)` には置けません。host 領域 `[-40, -24)` (両 attach path で空きの 16B) を使うので、**合計キー幅は 16 バイトまで**、1 フィールド 8 バイトまでです。
+- **構文**: bracket predicate 専用 (`where` 句では不可)。bracket は layer の連言に必ず入るので、`@set` は構造的にトップレベル AND になり、v1 の「集合は AND」と一致します。複合キーは 1 つの角括弧にカンマ併記します。
+- iterator-stack (`any`/`all` の aux) 上のフィールドは resolver が拒否します (last-write-wins になるため)。
+
 ## 5. P4-16 互換性
 
 `pkg/kunai/vocab/p4lite/` は、xdp-ninja の vocab loader が `.p4` ファイルを読むための P4-16 の限定サブセットのパーサです。

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -472,6 +472,31 @@ sudo xdp-ninja set schema /sys/fs/bpf/flows
 - 外部から直接書く場合 (bpftool 等) は**パディングのゼロ埋めが必須**です (hash はキー全バイトをハッシュするため、パディングが非ゼロだと永遠に一致しません)。`xdp-ninja set add` はこれを自動で保証します。
 - スキーマ (キー幅・オフセット) は `set schema` で確認できます。`bpftool map dump pinned <path>` もフィールド名付きで整形表示されます (合成 BTF の効能)。
 
+### パケットフィールドで照合する (DSL `layer[field in @NAME]`)
+
+`--arg-filter @NAME` はキーを **fentry 引数**から作ります。照合したい値がパケット内にある場合 (GTP TEID、SRv6 SID など、dispatcher が引数で渡してくれない値) は、DSL の bracket predicate で**パケットフィールドを直接キーにできます**。
+
+```bash
+# 集合は同じ (キー = 照合する値)
+sudo xdp-ninja set create /sys/fs/bpf/teids --key "teid:u32"
+sudo xdp-ninja set add    /sys/fs/bpf/teids teid=0x3039
+
+# DSL でパケットの gtp.teid を集合照合 (fentry でも --mode xdp でも動く)
+sudo xdp-ninja -p 1661 --set "teids=/sys/fs/bpf/teids" \
+  'eth/ipv4/udp/gtp[teid in @teids]' -w out.pcap
+
+# 複合キーは 1 つの角括弧にカンマ併記 (エントリ内は AND)
+sudo xdp-ninja set create /sys/fs/bpf/flows --key "teid:u32,msg_type:u8"
+sudo xdp-ninja -i eth0 --mode xdp --set "flows=/sys/fs/bpf/flows" \
+  'eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]'
+```
+
+- **同名一致**: DSL のフィールド名が集合キーのフィールド名になります (`gtp[teid in @teids]` は集合キー `teid` を引く)。
+- **エンディアン**: パケットは network order、`set add` は host order で書きますが、ツールが変換を合わせるので**利用者は普段どおりの数値で `set add` するだけ**です。
+- **キー幅の上限**: パケット由来キーはホストスタックの空き領域を使うため、**合計 16 バイトまで** (TEID=4 / IMSI=8 / TEID+IMSI=12 は可)。1 フィールドは 8 バイトまで (16B の SRv6 SID 単体は後日対応)。
+- `@NAME` は他の bracket 条件・レイヤ条件と AND。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
+- 引数由来 (`--arg-filter @NAME`) は entry/exit 専用のまま。パケット由来 (DSL `@NAME`) は entry/exit と `--mode xdp` の両方で動きます。
+
 ## 関数引数の値を覗く (`--arg-echo`)
 
 `--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、「そもそも引数にどんな値が乗っているか」を確認するのに使います (例: IMSI が 10 進なのか TBCD なのか)。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -426,8 +426,17 @@ mergecap -w merged.pcap path.pcap.cpu*
 
 多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムへ散り、さらに noinline サブ関数は呼び出し元プログラムごとに実体を持ちます (例: `pgwu_capture_point_dl` が v4/v6 ハンドラ両方に入る)。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で張れます。
 
+### `--list-progs` で到達可能プログラムを洗い出す
+
+`--list-progs` は、起点プログラム (`-i` の XDP または `-p` の ID) から**到達できるプログラムを推移的に**辿って一覧します。辿るエッジは 2 種類です。
+
+- **tail call**: `PROG_ARRAY` (`bpf_tail_call`) のエントリ先。
+- **redirect**: `CPUMAP` / `DEVMAP` / `DEVMAP_HASH` のエントリに attach された XDP プログラム (`bpf_redirect_map()` の飛び先)。
+
+さらにその先も同様に辿るので、`cpu_dispatch → CPUMAP[0..N] → 方向別ハンドラ → (別の redirect)` のような多段構成でも、末端の実プログラム ID までまとめて出ます。出力の prog ID を `-p` に渡してアタッチします。
+
 ```bash
-# --list-progs で dispatcher から末端の prog ID を洗い出し
+# --list-progs で dispatcher から末端の prog ID を推移的に洗い出し
 sudo xdp-ninja -i ens2f0 --list-progs
 
 # UL + DL (v4/v6 両実体) を1回でアタッチ。--func pgwu_capture_point_dl は

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -495,6 +495,7 @@ sudo xdp-ninja -i eth0 --mode xdp --set "flows=/sys/fs/bpf/flows" \
 - **エンディアン**: パケットは network order、`set add` は host order で書きますが、ツールが変換を合わせるので**利用者は普段どおりの数値で `set add` するだけ**です。
 - **キー幅の上限**: パケット由来キーはホストスタックの空き領域を使うため、**合計 16 バイトまで** (TEID=4 / IMSI=8 / TEID+IMSI=12 は可)。1 フィールドは 8 バイトまで (16B の SRv6 SID 単体は後日対応)。
 - `@NAME` は他の bracket 条件・レイヤ条件と AND。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
+- `in @NAME` は**必ず通るレイヤ**(quantifier なしの `QuantOne`)にのみ書けます。`vlan[...]?` のような optional / 繰り返しレイヤや alternation の枝 (`(vlan[...]|qinq)`) は、そのレイヤが不在でもフィルタが成立しうるため、抽出が走らずキーが未書き込みになる可能性があり reject されます。
 - 引数由来 (`--arg-filter @NAME`) は entry/exit 専用のまま。パケット由来 (DSL `@NAME`) は entry/exit と `--mode xdp` の両方で動きます。
 
 ## 関数引数の値を覗く (`--arg-echo`)

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -428,12 +428,12 @@ mergecap -w merged.pcap path.pcap.cpu*
 
 ### `--list-progs` で到達可能プログラムを洗い出す
 
-`--list-progs` は、起点プログラム (`-i` の XDP または `-p` の ID) から**到達できるプログラムを推移的に**辿って一覧します。辿るエッジは 2 種類です。
+`--list-progs` は、起点プログラムから到達できるプログラムを推移的に辿って一覧します。起点は `-i` の XDP か `-p` の ID です。辿るエッジは次の 2 種類です。
 
-- **tail call**: `PROG_ARRAY` (`bpf_tail_call`) のエントリ先。
-- **redirect**: `CPUMAP` / `DEVMAP` / `DEVMAP_HASH` のエントリに attach された XDP プログラム (`bpf_redirect_map()` の飛び先)。
+- tail call は、`bpf_tail_call` が使う `PROG_ARRAY` のエントリ先です。
+- redirect は、`CPUMAP` / `DEVMAP` / `DEVMAP_HASH` のエントリに attach された XDP プログラム、すなわち `bpf_redirect_map()` の飛び先です。
 
-さらにその先も同様に辿るので、`cpu_dispatch → CPUMAP[0..N] → 方向別ハンドラ → (別の redirect)` のような多段構成でも、末端の実プログラム ID までまとめて出ます。出力の prog ID を `-p` に渡してアタッチします。
+さらにその先も同様に辿るので、`cpu_dispatch → CPUMAP[0..N] → 方向別ハンドラ` から別の redirect へ続くような多段構成でも、末端の実プログラム ID までまとめて出ます。出力された prog ID を `-p` に渡してアタッチします。
 
 ```bash
 # --list-progs で dispatcher から末端の prog ID を推移的に洗い出し
@@ -481,9 +481,9 @@ sudo xdp-ninja set schema /sys/fs/bpf/flows
 - 外部から直接書く場合 (bpftool 等) は**パディングのゼロ埋めが必須**です (hash はキー全バイトをハッシュするため、パディングが非ゼロだと永遠に一致しません)。`xdp-ninja set add` はこれを自動で保証します。
 - スキーマ (キー幅・オフセット) は `set schema` で確認できます。`bpftool map dump pinned <path>` もフィールド名付きで整形表示されます (合成 BTF の効能)。
 
-### パケットフィールドで照合する (DSL `layer[field in @NAME]`)
+### DSL `layer[field in @NAME]` でパケットフィールドを照合する
 
-`--arg-filter @NAME` はキーを **fentry 引数**から作ります。照合したい値がパケット内にある場合 (GTP TEID、SRv6 SID など、dispatcher が引数で渡してくれない値) は、DSL の bracket predicate で**パケットフィールドを直接キーにできます**。
+`--arg-filter @NAME` はキーを fentry 引数から作ります。GTP TEID や SRv6 SID のように、照合したい値が引数ではなくパケット内にあり dispatcher が渡してくれない場合は、DSL の bracket predicate でパケットフィールドをそのままキーにできます。
 
 ```bash
 # 集合は同じ (キー = 照合する値)
@@ -500,12 +500,12 @@ sudo xdp-ninja -i eth0 --mode xdp --set "flows=/sys/fs/bpf/flows" \
   'eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]'
 ```
 
-- **同名一致**: DSL のフィールド名が集合キーのフィールド名になります (`gtp[teid in @teids]` は集合キー `teid` を引く)。
-- **エンディアン**: パケットは network order、`set add` は host order で書きますが、ツールが変換を合わせるので**利用者は普段どおりの数値で `set add` するだけ**です。
-- **キー幅の上限**: パケット由来キーはホストスタックの空き領域を使うため、**合計 16 バイトまで** (TEID=4 / IMSI=8 / TEID+IMSI=12 は可)。1 フィールドは 8 バイトまで (16B の SRv6 SID 単体は後日対応)。
-- `@NAME` は他の bracket 条件・レイヤ条件と AND。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
-- `in @NAME` は**必ず通るレイヤ**(quantifier なしの `QuantOne`)にのみ書けます。`vlan[...]?` のような optional / 繰り返しレイヤや alternation の枝 (`(vlan[...]|qinq)`) は、そのレイヤが不在でもフィルタが成立しうるため、抽出が走らずキーが未書き込みになる可能性があり reject されます。
-- 引数由来 (`--arg-filter @NAME`) は entry/exit 専用のまま。パケット由来 (DSL `@NAME`) は entry/exit と `--mode xdp` の両方で動きます。
+- 同名一致します。DSL のフィールド名がそのまま集合キーのフィールド名になり、`gtp[teid in @teids]` は集合キー `teid` を引きます。
+- エンディアンはツールが吸収します。パケットは network order、`set add` は host order で書きますが、変換をツールが合わせるので、利用者は普段どおりの数値で `set add` するだけで済みます。
+- キー幅には上限があります。パケット由来キーはホストスタックの空き領域を使うため、合計 16 バイトまでです。TEID の 4 バイト、IMSI の 8 バイト、TEID と IMSI を合わせた 12 バイトはいずれも収まります。1 フィールドは 8 バイトまでで、16 バイトの SRv6 SID を単体で扱うのは後日対応とします。
+- `@NAME` は他の bracket 条件やレイヤ条件と AND で合成します。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
+- `in @NAME` は必ず通るレイヤ、すなわち quantifier のない `QuantOne` のレイヤにのみ書けます。`vlan[...]?` のような optional や繰り返しのレイヤ、`(vlan[...]|qinq)` のような alternation の枝は、そのレイヤが不在でもフィルタが成立しうるため、抽出が走らずキーが未書き込みになる可能性があり、reject されます。
+- 引数由来の `--arg-filter @NAME` は entry/exit 専用のままです。パケット由来の DSL `@NAME` は entry/exit と `--mode xdp` の両方で動きます。
 
 ## 関数引数の値を覗く (`--arg-echo`)
 

--- a/internal/program/dump.go
+++ b/internal/program/dump.go
@@ -107,7 +107,7 @@ func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, 
 		shape = "XDP-native program"
 	} else {
 		var err error
-		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP, nil)
+		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/program/dump.go
+++ b/internal/program/dump.go
@@ -103,11 +103,11 @@ func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, 
 		shape string
 	)
 	if isXDPNative {
-		insns = buildXDPNativeInsns(out, 0)
+		insns = buildXDPNativeInsns(out, 0, nil)
 		shape = "XDP-native program"
 	} else {
 		var err error
-		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP)
+		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/program/multiattach_test.go
+++ b/internal/program/multiattach_test.go
@@ -166,7 +166,7 @@ func TestBpfMultiAttachEntryPrograms(t *testing.T) {
 		t.Fatalf("resolved %d targets, want 2: %+v", len(targets), targets)
 	}
 
-	probe, err := LoadMultiEntry(targets, "", nil, true)
+	probe, err := LoadMultiEntry(targets, "", nil, true, nil)
 	if err != nil {
 		t.Fatalf("LoadMultiEntry: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestBpfMultiAttachNoinlineAcrossPrograms(t *testing.T) {
 		}
 	}
 
-	probe, err := LoadMultiEntry(targets, "", nil, true)
+	probe, err := LoadMultiEntry(targets, "", nil, true, nil)
 	if err != nil {
 		t.Fatalf("LoadMultiEntry: %v", err)
 	}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/takehaya/xdp-ninja/internal/attach"
 	"github.com/takehaya/xdp-ninja/internal/filter"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
 	"github.com/takehaya/xdp-ninja/pkg/kunai"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 	tchost "github.com/takehaya/xdp-ninja/pkg/kunai/host/tc"
@@ -100,7 +101,7 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 		return nil, err
 	}
 	targets := []attach.Target{{Program: targetProg, FuncName: funcName, Type: progType}}
-	return loadMulti(targets, filterExpr, []filter.TargetFilters{{Args: argFilters}}, isFexit, useDSL)
+	return loadMulti(targets, filterExpr, []filter.TargetFilters{{Args: argFilters}}, isFexit, useDSL, nil)
 }
 
 // LoadMultiEntry attaches one fentry per (program, func) target, all
@@ -112,20 +113,20 @@ func loadProbe(targetProg *ebpf.Program, funcName string, filterExpr string, arg
 // same param name can sit at a different arg index in different funcs, so
 // arg filters and set-key bindings must be resolved against each target's
 // own BTF params.
-func LoadMultiEntry(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool) (*Probe, error) {
-	return loadMulti(targets, filterExpr, filters, false, useDSL)
+func LoadMultiEntry(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool, sets []*setmap.Set) (*Probe, error) {
+	return loadMulti(targets, filterExpr, filters, false, useDSL, sets)
 }
 
 // LoadMultiExit is LoadMultiEntry for fexit (sees the return action).
-func LoadMultiExit(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool) (*Probe, error) {
-	return loadMulti(targets, filterExpr, filters, true, useDSL)
+func LoadMultiExit(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, useDSL bool, sets []*setmap.Set) (*Probe, error) {
+	return loadMulti(targets, filterExpr, filters, true, useDSL, sets)
 }
 
 // loadMulti builds the shared capture infrastructure once (filter compile,
 // sharded ringbuf, scratch map — all of which depend only on the program
 // type, not the individual target) and then attaches one tracing program
 // per (target prog, func) pair against it.
-func loadMulti(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, isFexit, useDSL bool) (*Probe, error) {
+func loadMulti(targets []attach.Target, filterExpr string, filters []filter.TargetFilters, isFexit, useDSL bool, sets []*setmap.Set) (*Probe, error) {
 	if len(targets) == 0 {
 		return nil, fmt.Errorf("no attach targets")
 	}
@@ -142,7 +143,16 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 		return nil, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", progType)
 	}
 
-	filterOut, err := compileFilter(filterExpr, useDSL, isFexit, progType)
+	// DSL `field in @set` extracts packet fields into a host key buffer;
+	// build the slot resolver so kunai emits the extraction stores.
+	var slots *pktSetSlots
+	var err error
+	if len(sets) > 0 {
+		if slots, err = newPktSetSlots(sets); err != nil {
+			return nil, err
+		}
+	}
+	filterOut, err := compileFilterWithSlots(filterExpr, useDSL, isFexit, progType, slots)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +200,7 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 		if filters != nil {
 			tf = filters[i]
 		}
-		insns, err := buildTracingInsns(filterOut, tf, outerMap.FD(), scratchFD, isFexit, progType)
+		insns, err := buildTracingInsns(filterOut, tf, outerMap.FD(), scratchFD, isFexit, progType, slots)
 		if err != nil {
 			_ = probe.Close()
 			return nil, err
@@ -264,6 +274,13 @@ func attachTracingProbe(probe *Probe, targetProg *ebpf.Program, name, funcName s
 // pkg/kunai/codegen/codegen.go (KunaiStackTop and the package doc).
 
 func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType) (codegen.Output, error) {
+	return compileFilterWithSlots(expr, useDSL, isFexit, progType, nil)
+}
+
+// compileFilterWithSlots is compileFilter plus a DSL set-slot resolver:
+// when non-nil it lets `field in @set` predicates extract packet fields
+// into host stack slots (the host does the map lookup afterward).
+func compileFilterWithSlots(expr string, useDSL, isFexit bool, progType ebpf.ProgramType, slots *pktSetSlots) (codegen.Output, error) {
 	// Empty expression == capture everything: no filter to compile,
 	// callers wrap the zero Output with their own prologue/epilogue.
 	// Centralised here so attach modes (entry/exit/xdp/tc-*) don't
@@ -293,6 +310,12 @@ func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType)
 				caps = xdphost.FexitCapabilities()
 			}
 			// XDP entry keeps zero caps: VLAN is in-band at XDP.
+		}
+		// DSL `field in @set`: hand kunai the host slot resolver so it can
+		// extract packet fields into the host key buffer (host does the map
+		// lookup after the filter — kunai stays map-agnostic).
+		if slots != nil {
+			caps.Lang.SetSlots = slots
 		}
 		out, err := kunai.Compile(expr, caps)
 		if err != nil {
@@ -445,7 +468,7 @@ const (
 	metadataSize = 16
 )
 
-func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType) (asm.Instructions, error) {
+func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType, slots *pktSetSlots) (asm.Instructions, error) {
 	var insns asm.Instructions
 	prelude, err := loadPacketPointers(progType)
 	if err != nil {
@@ -454,7 +477,15 @@ func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, events
 	insns = append(insns, prelude...)
 	insns = append(insns, buildArgFilter(tf.Args)...)
 	insns = append(insns, emitSetFilters(tf.Sets)...)
+	// DSL `field in @set`: zero the packet-key buffer, run the filter
+	// (kunai extracts fields into it), then look each referenced set up
+	// (miss → skip capture). ANDs with arg filters and the kunai verdict.
+	refs := referencedSets(filterOut.Extractions)
+	insns = append(insns, emitPktSetKeyZeroing(refs)...)
 	insns = append(insns, runFilter(filterOut.Main, scratchFD, filterScanLen(filterOut))...)
+	if slots != nil {
+		insns = append(insns, slots.emitPktSetLookups(refs)...)
+	}
 	insns = append(insns, captureWithRingbuf(eventsFD, isFexit, filterOut.Capture.MaxCapLen)...)
 	insns = append(insns, asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"), asm.Return())
 	// bpf2bpf subprograms (currently only DSL bpf_loop chain

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -146,16 +146,17 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 	// DSL `field in @set` extracts packet fields into a host key buffer;
 	// build the slot resolver so kunai emits the extraction stores.
 	var slots *pktSetSlots
-	var err error
 	if len(sets) > 0 {
-		if slots, err = newPktSetSlots(sets); err != nil {
-			return nil, err
-		}
+		slots = newPktSetSlots(sets)
 	}
 	filterOut, err := compileFilterWithSlots(filterExpr, useDSL, isFexit, progType, slots)
+	if slots != nil && slots.allocErr() != nil {
+		return nil, slots.allocErr() // clearer than the downstream codegen error
+	}
 	if err != nil {
 		return nil, err
 	}
+	pktRefs := referencedSets(filterOut.Extractions)
 	if SnaplenOverride > 0 {
 		filterOut.Capture.MaxCapLen = SnaplenOverride
 	}
@@ -200,7 +201,7 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 		if filters != nil {
 			tf = filters[i]
 		}
-		insns, err := buildTracingInsns(filterOut, tf, outerMap.FD(), scratchFD, isFexit, progType, slots)
+		insns, err := buildTracingInsns(filterOut, tf, outerMap.FD(), scratchFD, isFexit, progType, slots, pktRefs)
 		if err != nil {
 			_ = probe.Close()
 			return nil, err
@@ -468,7 +469,7 @@ const (
 	metadataSize = 16
 )
 
-func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType, slots *pktSetSlots) (asm.Instructions, error) {
+func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, eventsFD, scratchFD int, isFexit bool, progType ebpf.ProgramType, slots *pktSetSlots, pktRefs []string) (asm.Instructions, error) {
 	var insns asm.Instructions
 	prelude, err := loadPacketPointers(progType)
 	if err != nil {
@@ -480,11 +481,12 @@ func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, events
 	// DSL `field in @set`: zero the packet-key buffer, run the filter
 	// (kunai extracts fields into it), then look each referenced set up
 	// (miss → skip capture). ANDs with arg filters and the kunai verdict.
-	refs := referencedSets(filterOut.Extractions)
-	insns = append(insns, emitPktSetKeyZeroing(refs)...)
+	if slots != nil {
+		insns = append(insns, slots.emitPktSetKeyZeroing(pktRefs)...)
+	}
 	insns = append(insns, runFilter(filterOut.Main, scratchFD, filterScanLen(filterOut))...)
 	if slots != nil {
-		insns = append(insns, slots.emitPktSetLookups(refs)...)
+		insns = append(insns, slots.emitPktSetLookups(pktRefs)...)
 	}
 	insns = append(insns, captureWithRingbuf(eventsFD, isFexit, filterOut.Capture.MaxCapLen)...)
 	insns = append(insns, asm.Mov.Imm(asm.R0, 0).WithSymbol("exit"), asm.Return())
@@ -834,15 +836,24 @@ func emitSetFilters(sets []filter.SetFilter) asm.Instructions {
 			insns = append(insns, asm.StoreMem(asm.R10, int16(setKeyBase+int(f.FieldOff)), asm.R3, asmSizeFor(f.FieldSize)))
 		}
 
-		insns = append(insns,
-			asm.LoadMapPtr(asm.R1, s.Map.FD()),
-			asm.Mov.Reg(asm.R2, asm.R10),
-			asm.Add.Imm(asm.R2, setKeyBase),
-			asm.FnMapLookupElem.Call(),
-			asm.JEq.Imm(asm.R0, 0, "exit"),
-		)
+		insns = append(insns, emitSetLookup(s.Map.FD(), setKeyBase)...)
 	}
 	return insns
+}
+
+// emitSetLookup emits the shared membership tail: look the pinned map
+// (mapFD) up with the key at R10+keyOff; a NULL result jumps to "exit"
+// (skip capture), so stacked lookups AND together. Clobbers R0-R5.
+// Shared by the arg-based emitSetFilters and the packet-based
+// emitPktSetLookups (setslots.go).
+func emitSetLookup(mapFD int, keyOff int16) asm.Instructions {
+	return asm.Instructions{
+		asm.LoadMapPtr(asm.R1, mapFD),
+		asm.Mov.Reg(asm.R2, asm.R10),
+		asm.Add.Imm(asm.R2, int32(keyOff)),
+		asm.FnMapLookupElem.Call(),
+		asm.JEq.Imm(asm.R0, 0, "exit"),
+	}
 }
 
 // keyHasGaps reports whether the set's key has any byte not covered by a

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -76,7 +76,7 @@ func TestBuildTracingInsns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// FD==0 は実際のmapではないが、命令生成のテストには十分
-			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, filter.TargetFilters{}, 0, 0, tt.isFexit, ebpf.XDP)
+			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, filter.TargetFilters{}, 0, 0, tt.isFexit, ebpf.XDP, nil)
 			if err != nil {
 				t.Fatalf("buildTracingInsns: %v", err)
 			}
@@ -95,7 +95,7 @@ func TestBuildTracingInsns(t *testing.T) {
 
 func TestBuildTracingInsnsLabels(t *testing.T) {
 	filterInsns := dummyFilter()
-	insns, err := buildTracingInsns(codegen.Output{Main: filterInsns}, filter.TargetFilters{}, 0, 0, false, ebpf.XDP)
+	insns, err := buildTracingInsns(codegen.Output{Main: filterInsns}, filter.TargetFilters{}, 0, 0, false, ebpf.XDP, nil)
 	if err != nil {
 		t.Fatalf("buildTracingInsns: %v", err)
 	}

--- a/internal/program/program_test.go
+++ b/internal/program/program_test.go
@@ -76,7 +76,7 @@ func TestBuildTracingInsns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// FD==0 は実際のmapではないが、命令生成のテストには十分
-			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, filter.TargetFilters{}, 0, 0, tt.isFexit, ebpf.XDP, nil)
+			insns, err := buildTracingInsns(codegen.Output{Main: tt.filter}, filter.TargetFilters{}, 0, 0, tt.isFexit, ebpf.XDP, nil, nil)
 			if err != nil {
 				t.Fatalf("buildTracingInsns: %v", err)
 			}
@@ -95,7 +95,7 @@ func TestBuildTracingInsns(t *testing.T) {
 
 func TestBuildTracingInsnsLabels(t *testing.T) {
 	filterInsns := dummyFilter()
-	insns, err := buildTracingInsns(codegen.Output{Main: filterInsns}, filter.TargetFilters{}, 0, 0, false, ebpf.XDP, nil)
+	insns, err := buildTracingInsns(codegen.Output{Main: filterInsns}, filter.TargetFilters{}, 0, 0, false, ebpf.XDP, nil, nil)
 	if err != nil {
 		t.Fatalf("buildTracingInsns: %v", err)
 	}

--- a/internal/program/program_xdp.go
+++ b/internal/program/program_xdp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
 	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
 	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
 )
 
@@ -54,11 +55,18 @@ const (
 //
 // Caller is responsible for ensuring no XDP program is already
 // attached (see attach.InspectInterface) before calling.
-func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool) (*Probe, error) {
+func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool, sets []*setmap.Set) (*Probe, error) {
 	// isFexit=false so kunai gets zero Capabilities — XDP-native has
 	// no observed action atom (the program decides the action, doesn't
 	// read one), same shape fentry uses.
-	out, err := compileFilter(filterExpr, useDSL, false, ebpf.XDP)
+	var slots *pktSetSlots
+	if len(sets) > 0 {
+		var err error
+		if slots, err = newPktSetSlots(sets); err != nil {
+			return nil, err
+		}
+	}
+	out, err := compileFilterWithSlots(filterExpr, useDSL, false, ebpf.XDP, slots)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +85,7 @@ func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool)
 		maps:      append([]*ebpf.Map{outerMap}, innerMaps...),
 	}
 
-	insns := buildXDPNativeInsns(out, outerMap.FD())
+	insns := buildXDPNativeInsns(out, outerMap.FD(), slots)
 	spec := &ebpf.ProgramSpec{
 		Name:         "xdp_ninja_native",
 		Type:         ebpf.XDP,
@@ -138,10 +146,18 @@ func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool)
 //	R9 = pkt_len      (set in prologue)
 //
 // The filter output lands at "filter_result" with R2 = 1 (match) or 0.
-func buildXDPNativeInsns(filterOut codegen.Output, eventsFD int) asm.Instructions {
+func buildXDPNativeInsns(filterOut codegen.Output, eventsFD int, slots *pktSetSlots) asm.Instructions {
 	var insns asm.Instructions
 	insns = append(insns, loadXDPPacketPointers()...)
+	// DSL `field in @set`: zero the key buffer, let the filter extract the
+	// packet fields into it, then look each referenced set up (miss →
+	// skip capture). ANDs with the kunai verdict runFilterDirect produced.
+	refs := referencedSets(filterOut.Extractions)
+	insns = append(insns, emitPktSetKeyZeroing(refs)...)
 	insns = append(insns, runFilterDirect(filterOut.Main)...)
+	if slots != nil {
+		insns = append(insns, slots.emitPktSetLookups(refs)...)
+	}
 	insns = append(insns, captureXDPNative(eventsFD, filterOut.Capture.MaxCapLen)...)
 	finalAction := xdpPass
 	if XDPNativeBenchDrop {
@@ -163,10 +179,10 @@ func buildXDPNativeInsns(filterOut codegen.Output, eventsFD int) asm.Instruction
 // recognises — loaded as 4-byte values, treated as PTR_TO_PACKET.
 func loadXDPPacketPointers() asm.Instructions {
 	return asm.Instructions{
-		asm.Mov.Reg(asm.R6, asm.R1),               // R6 = ctx (xdp_md *)
-		asm.LoadMem(asm.R7, asm.R6, 0, asm.Word),  // R7 = ctx->data
-		asm.LoadMem(asm.R8, asm.R6, 4, asm.Word),  // R8 = ctx->data_end
-		asm.Mov.Reg(asm.R9, asm.R8),               // R9 = pkt_len
+		asm.Mov.Reg(asm.R6, asm.R1),              // R6 = ctx (xdp_md *)
+		asm.LoadMem(asm.R7, asm.R6, 0, asm.Word), // R7 = ctx->data
+		asm.LoadMem(asm.R8, asm.R6, 4, asm.Word), // R8 = ctx->data_end
+		asm.Mov.Reg(asm.R9, asm.R8),              // R9 = pkt_len
 		asm.Sub.Reg(asm.R9, asm.R7),
 	}
 }
@@ -291,4 +307,3 @@ func captureXDPNative(eventsFD int, maxCapLen int) asm.Instructions {
 	}...)
 	return insns
 }
-

--- a/internal/program/program_xdp.go
+++ b/internal/program/program_xdp.go
@@ -61,12 +61,12 @@ func LoadXDPNative(state *attach.InterfaceState, filterExpr string, useDSL bool,
 	// read one), same shape fentry uses.
 	var slots *pktSetSlots
 	if len(sets) > 0 {
-		var err error
-		if slots, err = newPktSetSlots(sets); err != nil {
-			return nil, err
-		}
+		slots = newPktSetSlots(sets)
 	}
 	out, err := compileFilterWithSlots(filterExpr, useDSL, false, ebpf.XDP, slots)
+	if slots != nil && slots.allocErr() != nil {
+		return nil, slots.allocErr()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,9 @@ func buildXDPNativeInsns(filterOut codegen.Output, eventsFD int, slots *pktSetSl
 	// packet fields into it, then look each referenced set up (miss →
 	// skip capture). ANDs with the kunai verdict runFilterDirect produced.
 	refs := referencedSets(filterOut.Extractions)
-	insns = append(insns, emitPktSetKeyZeroing(refs)...)
+	if slots != nil {
+		insns = append(insns, slots.emitPktSetKeyZeroing(refs)...)
+	}
 	insns = append(insns, runFilterDirect(filterOut.Main)...)
 	if slots != nil {
 		insns = append(insns, slots.emitPktSetLookups(refs)...)

--- a/internal/program/program_xdp_test.go
+++ b/internal/program/program_xdp_test.go
@@ -103,7 +103,7 @@ func loadXDPNativeOrFail(t *testing.T, expr string, useDSL bool) {
 		t.Fatalf("populating outer map: %v", err)
 	}
 
-	insns := buildXDPNativeInsns(out, outerMap.FD())
+	insns := buildXDPNativeInsns(out, outerMap.FD(), nil)
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Name:         "xdp_ninja_native_test",
 		Type:         ebpf.XDP,

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -120,3 +120,45 @@ func TestBpfDSLSetMatchPacketField(t *testing.T) {
 		t.Fatalf("markers after runtime delete = %v, want no 0x77", markers)
 	}
 }
+
+// TestBpfDSLSetMatchCompositeKey covers a composite key written
+// comma-separated in one bracket: gtp[teid in @f, msg_type in @f]. Both
+// fields must match one entry (AND within the key) for capture.
+func TestBpfDSLSetMatchCompositeKey(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslcomp_%d", os.Getpid())
+	if err := setmap.Create(pin, "teid:u32,msg_type:u8", "", 16); err != nil {
+		t.Skipf("creating pinned set map: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	set, err := setmap.OpenSet(setmap.SpecRef{Name: "flows", Path: pin})
+	if err != nil {
+		t.Fatalf("OpenSet: %v", err)
+	}
+	t.Cleanup(set.Def.Close)
+
+	// gtpPacket uses msg_type 0xFF; add exactly (teid, 0xFF).
+	const teid = uint32(0x11223344)
+	if err := set.Def.Add(map[string]uint64{"teid": uint64(teid), "msg_type": 0xFF}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_gtp_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_gtp_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]", nil, true, []*setmap.Set{set})
+	if err != nil {
+		t.Fatalf("LoadMultiEntry composite: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	// Matching (teid, msg_type=0xFF) is captured; a different teid with the
+	// same msg_type is not (the composite key differs).
+	runGTP(t, prog, 0x44, teid)       // (0x11223344, 0xFF) — member
+	runGTP(t, prog, 0x55, 0x55667788) // (other teid, 0xFF) — non-member
+	markers := drainMarkers(t, probe, 1)
+	if markers[0x44] != 1 || markers[0x55] != 0 {
+		t.Fatalf("markers = %v, want one 0x44 and no 0x55", markers)
+	}
+}

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -1,0 +1,122 @@
+package program
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// dslSetTargetSrc is a passthrough XDP program: the DSL filter runs on
+// the packet the fentry observer copies, so the target itself only needs
+// to exist and return XDP_PASS.
+const dslSetTargetSrc = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+SEC("xdp")
+int xdp_gtp_target(struct xdp_md *ctx) {
+    return 2; // XDP_PASS
+}
+char _license[] SEC("license") = "GPL";
+`
+
+// gtpPacket builds an eth/ipv4/udp/gtp frame: byte 0 is a per-run marker
+// (drainMarkers reads it back), the GTP TEID is written network-order at
+// the GTP header's 4-byte teid field so the DSL extraction sees the wire
+// bytes.
+func gtpPacket(marker byte, teid uint32) []byte {
+	p := make([]byte, 64)
+	p[0] = marker
+	binary.BigEndian.PutUint16(p[12:14], 0x0800) // ethertype IPv4
+	p[14] = 0x45                                 // IPv4 version 4, IHL 5
+	p[23] = 17                                   // protocol UDP
+	binary.BigEndian.PutUint16(p[36:38], 2152)   // UDP dport (GTP-U)
+	p[42] = 0x30                                 // GTP flags: version 1, PT=1
+	p[43] = 0xFF                                 // msg_type G-PDU
+	binary.BigEndian.PutUint32(p[46:50], teid)   // GTP teid (network order)
+	return p
+}
+
+func runGTP(t *testing.T, prog *ebpf.Program, marker byte, teid uint32) {
+	t.Helper()
+	if _, err := prog.Run(&ebpf.RunOptions{Data: gtpPacket(marker, teid)}); err != nil {
+		t.Fatalf("test-run: %v", err)
+	}
+}
+
+// TestBpfDSLSetMatchPacketField is the end-to-end for DSL packet-field set
+// matching: a `gtp[teid in @teids]` filter extracts the GTP TEID from the
+// packet, and the host looks it up in a pinned set — capturing only frames
+// whose TEID is a member. It also proves the native/network byte-order
+// contract (the map is keyed host-order; the packet carries network order)
+// and runtime membership updates without re-attach.
+func TestBpfDSLSetMatchPacketField(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslset_%d", os.Getpid())
+	if err := setmap.Create(pin, "teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	set, err := setmap.OpenSet(setmap.SpecRef{Name: "teids", Path: pin})
+	if err != nil {
+		t.Fatalf("OpenSet: %v", err)
+	}
+	t.Cleanup(set.Def.Close)
+
+	const memberTeid = uint32(0x11223344)
+	if err := set.Def.Add(map[string]uint64{"teid": uint64(memberTeid)}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_gtp_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_gtp_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv4/udp/gtp[teid in @teids]", nil, true, []*setmap.Set{set})
+	if err != nil {
+		t.Fatalf("LoadMultiEntry with DSL set: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	// (a) membership gates capture: 0x11223344 is in the set, another TEID
+	// is not. Byte order: the map key was written host-order by Add; the
+	// packet carries network order; a hit proves kunai's HostTo(BE)
+	// normalization matches them.
+	runGTP(t, prog, 0x44, memberTeid) // marker 0x44 — member, captured
+	runGTP(t, prog, 0x55, 0x99887766) // marker 0x55 — non-member, dropped
+	markers := drainMarkers(t, probe, 1)
+	if markers[0x44] != 1 {
+		t.Fatalf("markers = %v, want one 0x44 (member TEID captured)", markers)
+	}
+	if markers[0x55] != 0 {
+		t.Fatalf("markers = %v: non-member TEID was captured", markers)
+	}
+
+	// (b) runtime add takes effect without re-attach.
+	const addedTeid = uint32(0x0a0b0c0d)
+	if err := set.Def.Add(map[string]uint64{"teid": uint64(addedTeid)}, 2); err != nil {
+		t.Fatalf("runtime Add: %v", err)
+	}
+	runGTP(t, prog, 0x66, addedTeid)
+	markers = drainMarkers(t, probe, 1)
+	if markers[0x66] != 1 {
+		t.Fatalf("markers after runtime add = %v, want one 0x66", markers)
+	}
+
+	// (c) runtime delete stops matching.
+	if err := set.Def.Delete(map[string]uint64{"teid": uint64(addedTeid)}); err != nil {
+		t.Fatalf("runtime Delete: %v", err)
+	}
+	runGTP(t, prog, 0x77, addedTeid)
+	markers = drainMarkers(t, probe, 0)
+	if markers[0x77] != 0 {
+		t.Fatalf("markers after runtime delete = %v, want no 0x77", markers)
+	}
+}

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -16,105 +16,108 @@ import (
 // dslSetTargetSrc is a passthrough XDP program: the DSL filter runs on
 // the packet the fentry observer copies, so the target itself only needs
 // to exist and return XDP_PASS.
+//
+// The e2e uses an eth/ipv4/tcp chain (not gtp): a gtp-depth chain with a
+// parser machine does not verify in the fentry scratch-buffer path on
+// older kernels (6.6), a pre-existing kunai limitation unrelated to set
+// matching. tcp exercises the same packet-field extraction on a chain
+// that loads across the CI kernel matrix.
 const dslSetTargetSrc = `
 #include <linux/bpf.h>
 #define SEC(NAME) __attribute__((section(NAME), used))
 
 SEC("xdp")
-int xdp_gtp_target(struct xdp_md *ctx) {
+int xdp_set_e2e_target(struct xdp_md *ctx) {
     return 2; // XDP_PASS
 }
 char _license[] SEC("license") = "GPL";
 `
 
-// gtpPacket builds an eth/ipv4/udp/gtp frame: byte 0 is a per-run marker
-// (drainMarkers reads it back), the GTP TEID is written network-order at
-// the GTP header's 4-byte teid field so the DSL extraction sees the wire
-// bytes.
-func gtpPacket(marker byte, teid uint32) []byte {
+// tcpPacket builds an eth/ipv4/tcp frame: byte 0 is a per-run marker
+// (drainMarkers reads it back), and tcp sport/dport are written
+// network-order so the DSL extraction sees the wire bytes.
+func tcpPacket(marker byte, sport, dport uint16) []byte {
 	p := make([]byte, 64)
 	p[0] = marker
 	binary.BigEndian.PutUint16(p[12:14], 0x0800) // ethertype IPv4
 	p[14] = 0x45                                 // IPv4 version 4, IHL 5
-	p[23] = 17                                   // protocol UDP
-	binary.BigEndian.PutUint16(p[36:38], 2152)   // UDP dport (GTP-U)
-	p[42] = 0x30                                 // GTP flags: version 1, PT=1
-	p[43] = 0xFF                                 // msg_type G-PDU
-	binary.BigEndian.PutUint32(p[46:50], teid)   // GTP teid (network order)
+	p[23] = 6                                    // protocol TCP
+	binary.BigEndian.PutUint16(p[34:36], sport)  // tcp sport
+	binary.BigEndian.PutUint16(p[36:38], dport)  // tcp dport
+	p[46] = 0x50                                 // tcp data offset 5 (20 B)
 	return p
 }
 
-func runGTP(t *testing.T, prog *ebpf.Program, marker byte, teid uint32) {
+func runTCP(t *testing.T, prog *ebpf.Program, marker byte, sport, dport uint16) {
 	t.Helper()
-	if _, err := prog.Run(&ebpf.RunOptions{Data: gtpPacket(marker, teid)}); err != nil {
+	if _, err := prog.Run(&ebpf.RunOptions{Data: tcpPacket(marker, sport, dport)}); err != nil {
 		t.Fatalf("test-run: %v", err)
 	}
 }
 
 // TestBpfDSLSetMatchPacketField is the end-to-end for DSL packet-field set
-// matching: a `gtp[teid in @teids]` filter extracts the GTP TEID from the
-// packet, and the host looks it up in a pinned set — capturing only frames
-// whose TEID is a member. It also proves the native/network byte-order
-// contract (the map is keyed host-order; the packet carries network order)
-// and runtime membership updates without re-attach.
+// matching: a `tcp[dport in @ports]` filter extracts the TCP dport from
+// the packet, and the host looks it up in a pinned set — capturing only
+// frames whose dport is a member. It also proves the native/network
+// byte-order contract (the map is keyed host-order; the packet carries
+// network order) and runtime membership updates without re-attach.
 func TestBpfDSLSetMatchPacketField(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 
 	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslset_%d", os.Getpid())
-	if err := setmap.Create(pin, "teid:u32", "", 16); err != nil {
+	if err := setmap.Create(pin, "dport:u16", "", 16); err != nil {
 		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(pin) })
 
-	set, err := setmap.OpenSet(setmap.SpecRef{Name: "teids", Path: pin})
+	set, err := setmap.OpenSet(setmap.SpecRef{Name: "ports", Path: pin})
 	if err != nil {
 		t.Fatalf("OpenSet: %v", err)
 	}
 	t.Cleanup(set.Def.Close)
 
-	const memberTeid = uint32(0x11223344)
-	if err := set.Def.Add(map[string]uint64{"teid": uint64(memberTeid)}, 1); err != nil {
+	const memberPort = uint16(0x01BB) // 443
+	if err := set.Def.Add(map[string]uint64{"dport": uint64(memberPort)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
-	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_gtp_target")
-	targets := []attach.Target{{Program: prog, FuncName: "xdp_gtp_target", Type: ebpf.XDP}}
-	probe, err := LoadMultiEntry(targets, "eth/ipv4/udp/gtp[teid in @teids]", nil, true, []*setmap.Set{set})
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_set_e2e_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_set_e2e_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv4/tcp[dport in @ports]", nil, true, []*setmap.Set{set})
 	if err != nil {
 		t.Fatalf("LoadMultiEntry with DSL set: %v", err)
 	}
 	defer func() { _ = probe.Close() }()
 
-	// (a) membership gates capture: 0x11223344 is in the set, another TEID
-	// is not. Byte order: the map key was written host-order by Add; the
-	// packet carries network order; a hit proves kunai's HostTo(BE)
-	// normalization matches them.
-	runGTP(t, prog, 0x44, memberTeid) // marker 0x44 — member, captured
-	runGTP(t, prog, 0x55, 0x99887766) // marker 0x55 — non-member, dropped
+	// (a) membership gates capture: 443 is in the set, 80 is not. Byte
+	// order: the map key was written host-order by Add; the packet carries
+	// network order; a hit proves kunai's HostTo(BE) normalization matches.
+	runTCP(t, prog, 0x44, 1234, memberPort) // marker 0x44 — member, captured
+	runTCP(t, prog, 0x55, 1234, 80)         // marker 0x55 — non-member, dropped
 	markers := drainMarkers(t, probe, 1)
 	if markers[0x44] != 1 {
-		t.Fatalf("markers = %v, want one 0x44 (member TEID captured)", markers)
+		t.Fatalf("markers = %v, want one 0x44 (member dport captured)", markers)
 	}
 	if markers[0x55] != 0 {
-		t.Fatalf("markers = %v: non-member TEID was captured", markers)
+		t.Fatalf("markers = %v: non-member dport was captured", markers)
 	}
 
 	// (b) runtime add takes effect without re-attach.
-	const addedTeid = uint32(0x0a0b0c0d)
-	if err := set.Def.Add(map[string]uint64{"teid": uint64(addedTeid)}, 2); err != nil {
+	const addedPort = uint16(8080)
+	if err := set.Def.Add(map[string]uint64{"dport": uint64(addedPort)}, 2); err != nil {
 		t.Fatalf("runtime Add: %v", err)
 	}
-	runGTP(t, prog, 0x66, addedTeid)
+	runTCP(t, prog, 0x66, 1234, addedPort)
 	markers = drainMarkers(t, probe, 1)
 	if markers[0x66] != 1 {
 		t.Fatalf("markers after runtime add = %v, want one 0x66", markers)
 	}
 
 	// (c) runtime delete stops matching.
-	if err := set.Def.Delete(map[string]uint64{"teid": uint64(addedTeid)}); err != nil {
+	if err := set.Def.Delete(map[string]uint64{"dport": uint64(addedPort)}); err != nil {
 		t.Fatalf("runtime Delete: %v", err)
 	}
-	runGTP(t, prog, 0x77, addedTeid)
+	runTCP(t, prog, 0x77, 1234, addedPort)
 	markers = drainMarkers(t, probe, 0)
 	if markers[0x77] != 0 {
 		t.Fatalf("markers after runtime delete = %v, want no 0x77", markers)
@@ -122,13 +125,13 @@ func TestBpfDSLSetMatchPacketField(t *testing.T) {
 }
 
 // TestBpfDSLSetMatchCompositeKey covers a composite key written
-// comma-separated in one bracket: gtp[teid in @f, msg_type in @f]. Both
+// comma-separated in one bracket: tcp[sport in @f, dport in @f]. Both
 // fields must match one entry (AND within the key) for capture.
 func TestBpfDSLSetMatchCompositeKey(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 
 	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslcomp_%d", os.Getpid())
-	if err := setmap.Create(pin, "teid:u32,msg_type:u8", "", 16); err != nil {
+	if err := setmap.Create(pin, "sport:u16,dport:u16", "", 16); err != nil {
 		t.Skipf("creating pinned set map: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Remove(pin) })
@@ -139,24 +142,23 @@ func TestBpfDSLSetMatchCompositeKey(t *testing.T) {
 	}
 	t.Cleanup(set.Def.Close)
 
-	// gtpPacket uses msg_type 0xFF; add exactly (teid, 0xFF).
-	const teid = uint32(0x11223344)
-	if err := set.Def.Add(map[string]uint64{"teid": uint64(teid), "msg_type": 0xFF}, 1); err != nil {
+	const sport, dport = uint16(1111), uint16(443)
+	if err := set.Def.Add(map[string]uint64{"sport": uint64(sport), "dport": uint64(dport)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
-	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_gtp_target")
-	targets := []attach.Target{{Program: prog, FuncName: "xdp_gtp_target", Type: ebpf.XDP}}
-	probe, err := LoadMultiEntry(targets, "eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]", nil, true, []*setmap.Set{set})
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_set_e2e_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_set_e2e_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv4/tcp[sport in @flows, dport in @flows]", nil, true, []*setmap.Set{set})
 	if err != nil {
 		t.Fatalf("LoadMultiEntry composite: %v", err)
 	}
 	defer func() { _ = probe.Close() }()
 
-	// Matching (teid, msg_type=0xFF) is captured; a different teid with the
-	// same msg_type is not (the composite key differs).
-	runGTP(t, prog, 0x44, teid)       // (0x11223344, 0xFF) — member
-	runGTP(t, prog, 0x55, 0x55667788) // (other teid, 0xFF) — non-member
+	// Matching (sport, dport) is captured; the same dport with a different
+	// sport is not (the composite key differs).
+	runTCP(t, prog, 0x44, sport, dport) // (1111, 443) — member
+	runTCP(t, prog, 0x55, 2222, dport)  // (2222, 443) — non-member
 	markers := drainMarkers(t, probe, 1)
 	if markers[0x44] != 1 || markers[0x55] != 0 {
 		t.Fatalf("markers = %v, want one 0x44 and no 0x55", markers)

--- a/internal/program/setfilter_test.go
+++ b/internal/program/setfilter_test.go
@@ -96,7 +96,7 @@ func TestBpfSetFilterLookupAndRuntimeUpdate(t *testing.T) {
 	}
 
 	targets := []attach.Target{{Program: prog, FuncName: "set_capture_pt", Type: ebpf.XDP}}
-	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true)
+	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true, nil)
 	if err != nil {
 		t.Fatalf("LoadMultiEntry with set filter: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestBpfSetFilterScalarKey(t *testing.T) {
 	}
 
 	targets := []attach.Target{{Program: prog, FuncName: "set_capture_pt", Type: ebpf.XDP}}
-	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true)
+	probe, err := LoadMultiEntry(targets, "", []filter.TargetFilters{{Sets: sf}}, true, nil)
 	if err != nil {
 		t.Fatalf("LoadMultiEntry: %v", err)
 	}

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -65,6 +65,19 @@ func newPktSetSlots(sets []*setmap.Set) *pktSetSlots {
 // can surface a clear message instead of a downstream codegen error.
 func (p *pktSetSlots) allocErr() error { return p.err }
 
+// keyAlign is the alignment a key buffer needs: its widest field width
+// (each field sits at a natural offset within the key, so an aligned base
+// keeps every field aligned). Fields are 1/2/4/8 bytes; defaults to 1.
+func keyAlign(def *setmap.Definition) int16 {
+	align := int16(1)
+	for _, f := range def.Fields {
+		if int16(f.Size) > align {
+			align = int16(f.Size)
+		}
+	}
+	return align
+}
+
 // HasSet reports whether name was declared with --set.
 func (p *pktSetSlots) HasSet(name string) bool {
 	_, ok := p.sets[name]
@@ -83,13 +96,13 @@ func (p *pktSetSlots) SlotFor(setName, fieldName string) (off int16, size int, o
 		return 0, 0, false
 	}
 	if !s.allocated {
-		// Round the allocation up to 8 so every buffer base stays
-		// 8-aligned (cursor starts at the 8-aligned pktSetKeyTop). A key
-		// field is laid out at a natural offset within its key, so an
-		// 8-aligned base keeps every extracted-field StoreMem naturally
-		// aligned — an unaligned DWord store would be verifier-rejected.
-		alloc := (int16(s.def.KeySize) + 7) &^ 7
-		base := p.cursor - alloc
+		// A key field is laid out at a natural offset within its key, so
+		// aligning the base down to the key's widest field width keeps
+		// every extracted-field StoreMem naturally aligned (an unaligned
+		// DWord store would be verifier-rejected) while packing tighter
+		// than rounding the whole key up to 8.
+		align := keyAlign(s.def)
+		base := (p.cursor - int16(s.def.KeySize)) &^ (align - 1)
 		if base < pktSetKeyFloor {
 			if p.err == nil {
 				p.err = fmt.Errorf("set @%s: combined packet-key width exceeds the %d-byte budget", setName, int(pktSetKeyTop-pktSetKeyFloor))

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -35,50 +35,64 @@ const (
 )
 
 // pktSetSlots implements codegen.SetSlotResolver over the opened --set
-// definitions, allocating each referenced set a key buffer in the shared
-// [-40, -24) region.
+// definitions. Slots are allocated lazily on first SlotFor call, so only
+// the sets the DSL actually extracts fields from consume the 16-byte
+// budget (arg-filter-only sets, matched separately, cost nothing here).
 type pktSetSlots struct {
-	defs map[string]*setmap.Definition
-	base map[string]int16 // set name → R10 offset of its key buffer
+	sets   map[string]*setSlot
+	cursor int16 // next free offset, allocated downward from pktSetKeyTop
+	err    error // first over-budget allocation, surfaced by allocErr()
 }
 
-// newPktSetSlots allocates a key-buffer slot for every provided set and
-// returns the resolver, or an error if the combined key width exceeds the
-// 16-byte packet-extraction budget.
-func newPktSetSlots(sets []*setmap.Set) (*pktSetSlots, error) {
-	p := &pktSetSlots{
-		defs: make(map[string]*setmap.Definition, len(sets)),
-		base: make(map[string]int16, len(sets)),
-	}
-	cursor := pktSetKeyTop
-	for _, s := range sets {
-		cursor -= int16(s.Def.KeySize)
-		if cursor < pktSetKeyFloor {
-			return nil, fmt.Errorf("set @%s: combined key width exceeds the %d-byte packet-extraction budget", s.Name, int(pktSetKeyTop-pktSetKeyFloor))
-		}
-		p.defs[s.Name] = s.Def
-		p.base[s.Name] = cursor
-	}
-	return p, nil
+type setSlot struct {
+	def       *setmap.Definition
+	base      int16 // R10 offset of the key buffer; 0 until allocated
+	allocated bool
 }
+
+// newPktSetSlots wraps the opened sets in a resolver; nothing is allocated
+// until codegen queries a set via SlotFor.
+func newPktSetSlots(sets []*setmap.Set) *pktSetSlots {
+	p := &pktSetSlots{sets: make(map[string]*setSlot, len(sets)), cursor: pktSetKeyTop}
+	for _, s := range sets {
+		p.sets[s.Name] = &setSlot{def: s.Def}
+	}
+	return p
+}
+
+// allocErr returns the first over-budget error hit during compile-time
+// SlotFor calls (SlotFor itself can only signal ok=false), so the loader
+// can surface a clear message instead of a downstream codegen error.
+func (p *pktSetSlots) allocErr() error { return p.err }
 
 // HasSet reports whether name was declared with --set.
 func (p *pktSetSlots) HasSet(name string) bool {
-	_, ok := p.defs[name]
+	_, ok := p.sets[name]
 	return ok
 }
 
-// SlotFor returns the R10 slot and width for one key field of a set.
+// SlotFor returns the R10 slot and width for one key field of a set,
+// allocating the set's key buffer on first use.
 func (p *pktSetSlots) SlotFor(setName, fieldName string) (off int16, size int, ok bool) {
-	def, ok := p.defs[setName]
+	s, ok := p.sets[setName]
 	if !ok {
 		return 0, 0, false
 	}
-	f, ok := def.Field(fieldName)
+	f, ok := s.def.Field(fieldName)
 	if !ok {
 		return 0, 0, false
 	}
-	return p.base[setName] + int16(f.Off), int(f.Size), true
+	if !s.allocated {
+		base := p.cursor - int16(s.def.KeySize)
+		if base < pktSetKeyFloor {
+			if p.err == nil {
+				p.err = fmt.Errorf("set @%s: combined packet-key width exceeds the %d-byte budget", setName, int(pktSetKeyTop-pktSetKeyFloor))
+			}
+			return 0, 0, false
+		}
+		s.base, s.allocated, p.cursor = base, true, base
+	}
+	return s.base + int16(f.Off), int(f.Size), true
 }
 
 // referencedSets returns the distinct set names the compiled filter
@@ -96,38 +110,43 @@ func referencedSets(extractions []codegen.ExtractSlot) []string {
 	return order
 }
 
-// emitPktSetKeyZeroing zeroes the whole [-40, -24) key-buffer region
-// before the filter runs, so padding bytes a field store does not cover
-// stay zero (hash maps hash every key byte; setmap.BuildKey zero-pads to
-// match). Two dword stores cover the 16-byte region. No-op when nothing
-// references a set.
-func emitPktSetKeyZeroing(referenced []string) asm.Instructions {
-	if len(referenced) == 0 {
-		return nil
+// emitPktSetKeyZeroing zeroes the allocated key-buffer span before the
+// filter runs, so padding bytes a field store does not cover stay zero
+// (hash maps hash every key byte; setmap.BuildKey zero-pads to match).
+// Only the dwords covering the sets actually used are emitted (a single
+// u32/u64 key touches one dword, not the whole 16-byte region). No-op
+// when nothing references a set.
+func (p *pktSetSlots) emitPktSetKeyZeroing(referenced []string) asm.Instructions {
+	lowest := pktSetKeyTop
+	for _, name := range referenced {
+		if s := p.sets[name]; s != nil && s.allocated && s.base < lowest {
+			lowest = s.base
+		}
 	}
-	return asm.Instructions{
-		asm.Mov.Imm(asm.R3, 0),
-		asm.StoreMem(asm.R10, pktSetKeyFloor, asm.R3, asm.DWord),   // [-40,-32)
-		asm.StoreMem(asm.R10, pktSetKeyFloor+8, asm.R3, asm.DWord), // [-32,-24)
+	if lowest >= pktSetKeyTop {
+		return nil // nothing allocated
 	}
+	// The region [-40,-24) is two 8-aligned dwords: [-40,-32) and
+	// [-32,-24). Emit only the dword(s) the used span touches, keeping
+	// stores dword-aligned and inside the region (a base may not be
+	// 8-aligned, so a store from `lowest` directly could overrun -24).
+	insns := asm.Instructions{asm.Mov.Imm(asm.R3, 0)}
+	if lowest < pktSetKeyFloor+8 { // spans into the lower dword
+		insns = append(insns, asm.StoreMem(asm.R10, pktSetKeyFloor, asm.R3, asm.DWord))
+	}
+	insns = append(insns, asm.StoreMem(asm.R10, pktSetKeyFloor+8, asm.R3, asm.DWord))
+	return insns
 }
 
 // emitPktSetLookups emits one pinned-map membership check per referenced
 // set, against the key buffer kunai populated during the filter. A miss
 // jumps to "exit" (skip capture); all sets AND together, and AND with the
-// kunai verdict that already ran. Reload of R-registers is unnecessary:
-// this runs after the filter body, before capture.
+// kunai verdict that already ran.
 func (p *pktSetSlots) emitPktSetLookups(referenced []string) asm.Instructions {
 	var insns asm.Instructions
 	for _, name := range referenced {
-		def := p.defs[name]
-		insns = append(insns,
-			asm.LoadMapPtr(asm.R1, def.Map.FD()),
-			asm.Mov.Reg(asm.R2, asm.R10),
-			asm.Add.Imm(asm.R2, int32(p.base[name])),
-			asm.FnMapLookupElem.Call(),
-			asm.JEq.Imm(asm.R0, 0, "exit"),
-		)
+		s := p.sets[name]
+		insns = append(insns, emitSetLookup(s.def.Map.FD(), s.base)...)
 	}
 	return insns
 }

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -1,0 +1,133 @@
+// Package program — packet-field set matching (DSL `gtp[teid in @NAME]`).
+//
+// This is the host half of architecture B (see the plan / kunai
+// codegen.SetSlotResolver). kunai extracts the packet field into a
+// host-owned stack slot during the filter body; the host then looks the
+// pinned set map up against those bytes after the filter returns. kunai
+// never sees a map — only the R10 offset this resolver hands it.
+package program
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+	"github.com/takehaya/xdp-ninja/pkg/kunai/codegen"
+)
+
+// The packet-field key buffer lives in the host stack region [-40, -24),
+// which is free — during the filter and until the set lookup completes —
+// in BOTH attach paths:
+//
+//   - tracing: the host slots are -8/-12/-16/-24/-48; -32 and -40 are
+//     unused (the arg-based emitSetFilters key buffer sits at -57..-120,
+//     below KunaiStackTop, reused strictly before runFilter).
+//   - XDP-native: captureXDPNative reuses -32/-40 as scratch, but only
+//     AFTER the lookup has consumed the key buffer.
+//
+// kunai owns [-56, ...) (KunaiStackTop = -56), so the buffer stays above
+// it. That bounds the total key width to 16 bytes — enough for a TEID (4),
+// an IMSI (8), or a TEID+IMSI composite (12); wider keys are rejected.
+const (
+	pktSetKeyTop   int16 = -24 // exclusive upper bound (closest to 0)
+	pktSetKeyFloor int16 = -40 // inclusive lower bound
+)
+
+// pktSetSlots implements codegen.SetSlotResolver over the opened --set
+// definitions, allocating each referenced set a key buffer in the shared
+// [-40, -24) region.
+type pktSetSlots struct {
+	defs map[string]*setmap.Definition
+	base map[string]int16 // set name → R10 offset of its key buffer
+}
+
+// newPktSetSlots allocates a key-buffer slot for every provided set and
+// returns the resolver, or an error if the combined key width exceeds the
+// 16-byte packet-extraction budget.
+func newPktSetSlots(sets []*setmap.Set) (*pktSetSlots, error) {
+	p := &pktSetSlots{
+		defs: make(map[string]*setmap.Definition, len(sets)),
+		base: make(map[string]int16, len(sets)),
+	}
+	cursor := pktSetKeyTop
+	for _, s := range sets {
+		cursor -= int16(s.Def.KeySize)
+		if cursor < pktSetKeyFloor {
+			return nil, fmt.Errorf("set @%s: combined key width exceeds the %d-byte packet-extraction budget", s.Name, int(pktSetKeyTop-pktSetKeyFloor))
+		}
+		p.defs[s.Name] = s.Def
+		p.base[s.Name] = cursor
+	}
+	return p, nil
+}
+
+// HasSet reports whether name was declared with --set.
+func (p *pktSetSlots) HasSet(name string) bool {
+	_, ok := p.defs[name]
+	return ok
+}
+
+// SlotFor returns the R10 slot and width for one key field of a set.
+func (p *pktSetSlots) SlotFor(setName, fieldName string) (off int16, size int, ok bool) {
+	def, ok := p.defs[setName]
+	if !ok {
+		return 0, 0, false
+	}
+	f, ok := def.Field(fieldName)
+	if !ok {
+		return 0, 0, false
+	}
+	return p.base[setName] + int16(f.Off), int(f.Size), true
+}
+
+// referencedSets returns the distinct set names the compiled filter
+// extracted fields for, in first-seen order — the sets whose maps the
+// host must look up after the filter runs.
+func referencedSets(extractions []codegen.ExtractSlot) []string {
+	var order []string
+	seen := map[string]bool{}
+	for _, ex := range extractions {
+		if !seen[ex.SetName] {
+			seen[ex.SetName] = true
+			order = append(order, ex.SetName)
+		}
+	}
+	return order
+}
+
+// emitPktSetKeyZeroing zeroes the whole [-40, -24) key-buffer region
+// before the filter runs, so padding bytes a field store does not cover
+// stay zero (hash maps hash every key byte; setmap.BuildKey zero-pads to
+// match). Two dword stores cover the 16-byte region. No-op when nothing
+// references a set.
+func emitPktSetKeyZeroing(referenced []string) asm.Instructions {
+	if len(referenced) == 0 {
+		return nil
+	}
+	return asm.Instructions{
+		asm.Mov.Imm(asm.R3, 0),
+		asm.StoreMem(asm.R10, pktSetKeyFloor, asm.R3, asm.DWord),   // [-40,-32)
+		asm.StoreMem(asm.R10, pktSetKeyFloor+8, asm.R3, asm.DWord), // [-32,-24)
+	}
+}
+
+// emitPktSetLookups emits one pinned-map membership check per referenced
+// set, against the key buffer kunai populated during the filter. A miss
+// jumps to "exit" (skip capture); all sets AND together, and AND with the
+// kunai verdict that already ran. Reload of R-registers is unnecessary:
+// this runs after the filter body, before capture.
+func (p *pktSetSlots) emitPktSetLookups(referenced []string) asm.Instructions {
+	var insns asm.Instructions
+	for _, name := range referenced {
+		def := p.defs[name]
+		insns = append(insns,
+			asm.LoadMapPtr(asm.R1, def.Map.FD()),
+			asm.Mov.Reg(asm.R2, asm.R10),
+			asm.Add.Imm(asm.R2, int32(p.base[name])),
+			asm.FnMapLookupElem.Call(),
+			asm.JEq.Imm(asm.R0, 0, "exit"),
+		)
+	}
+	return insns
+}

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -146,9 +146,12 @@ func (p *pktSetSlots) emitPktSetKeyZeroing(referenced []string) asm.Instructions
 		return nil // nothing allocated
 	}
 	// The region [-40,-24) is two 8-aligned dwords: [-40,-32) and
-	// [-32,-24). Emit only the dword(s) the used span touches, keeping
-	// stores dword-aligned and inside the region (a base may not be
-	// 8-aligned, so a store from `lowest` directly could overrun -24).
+	// [-32,-24). Stores must be dword-aligned and inside the region (a
+	// base may not be 8-aligned, so a store from `lowest` directly could
+	// overrun -24). The upper dword [-32,-24) is always in use: the
+	// topmost buffer always ends exactly at -24 (KeySize is a multiple of
+	// its alignment and -24 is aligned, so base = -24 - KeySize), so we
+	// always emit it; the lower dword only when the span reaches it.
 	insns := asm.Instructions{asm.Mov.Imm(asm.R3, 0)}
 	if lowest < pktSetKeyFloor+8 { // spans into the lower dword
 		insns = append(insns, asm.StoreMem(asm.R10, pktSetKeyFloor, asm.R3, asm.DWord))

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -83,7 +83,13 @@ func (p *pktSetSlots) SlotFor(setName, fieldName string) (off int16, size int, o
 		return 0, 0, false
 	}
 	if !s.allocated {
-		base := p.cursor - int16(s.def.KeySize)
+		// Round the allocation up to 8 so every buffer base stays
+		// 8-aligned (cursor starts at the 8-aligned pktSetKeyTop). A key
+		// field is laid out at a natural offset within its key, so an
+		// 8-aligned base keeps every extracted-field StoreMem naturally
+		// aligned — an unaligned DWord store would be verifier-rejected.
+		alloc := (int16(s.def.KeySize) + 7) &^ 7
+		base := p.cursor - alloc
 		if base < pktSetKeyFloor {
 			if p.err == nil {
 				p.err = fmt.Errorf("set @%s: combined packet-key width exceeds the %d-byte budget", setName, int(pktSetKeyTop-pktSetKeyFloor))

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -13,16 +13,14 @@ func setWithKey(name string, keySize uint32, fields []setmap.KeyField) *setmap.S
 	}
 }
 
-func TestNewPktSetSlotsAllocatesDistinctBuffers(t *testing.T) {
+func TestPktSetSlotsAllocatesDistinctBuffersLazily(t *testing.T) {
 	sets := []*setmap.Set{
 		setWithKey("a", 8, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}, {Name: "mt", Off: 4, Size: 1}}),
 		setWithKey("b", 4, []setmap.KeyField{{Name: "sid", Off: 0, Size: 4}}),
 	}
-	p, err := newPktSetSlots(sets)
-	if err != nil {
-		t.Fatalf("newPktSetSlots: %v", err)
-	}
-	// Both sets sit inside the host region [-40,-24) and don't overlap.
+	p := newPktSetSlots(sets)
+	// SlotFor allocates on first use; both sets land inside [-40,-24) and
+	// don't overlap.
 	offA, szA, okA := p.SlotFor("a", "teid")
 	offB, _, okB := p.SlotFor("b", "sid")
 	if !okA || !okB {
@@ -44,24 +42,45 @@ func TestNewPktSetSlotsAllocatesDistinctBuffers(t *testing.T) {
 	if offMT != offA+4 {
 		t.Errorf("mt slot = %d, want %d", offMT, offA+4)
 	}
+	if err := p.allocErr(); err != nil {
+		t.Errorf("unexpected allocErr: %v", err)
+	}
 }
 
-func TestNewPktSetSlotsRejectsOverBudget(t *testing.T) {
+func TestPktSetSlotsRejectsOverBudget(t *testing.T) {
 	// Two 16-byte keys = 32 bytes > the 16-byte packet-extraction budget.
 	sets := []*setmap.Set{
 		setWithKey("a", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
 		setWithKey("b", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
 	}
-	if _, err := newPktSetSlots(sets); err == nil {
-		t.Fatal("expected over-budget error")
+	p := newPktSetSlots(sets)
+	p.SlotFor("a", "k") // fits
+	if _, _, ok := p.SlotFor("b", "k"); ok {
+		t.Fatal("second 16-byte set should not fit the budget")
+	}
+	if p.allocErr() == nil {
+		t.Fatal("expected over-budget allocErr")
+	}
+}
+
+func TestPktSetSlotsOnlyReferencedConsumeBudget(t *testing.T) {
+	// An arg-filter-only set (never queried via SlotFor) must not consume
+	// the packet-key budget, so a 16-byte packet set still fits.
+	sets := []*setmap.Set{
+		setWithKey("argonly", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
+		setWithKey("pkt", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
+	}
+	p := newPktSetSlots(sets)
+	if _, _, ok := p.SlotFor("pkt", "k"); !ok {
+		t.Fatal("packet set should fit when the arg-only set is not queried")
+	}
+	if p.allocErr() != nil {
+		t.Errorf("unexpected allocErr: %v", p.allocErr())
 	}
 }
 
 func TestPktSetSlotsUnknownSetOrField(t *testing.T) {
-	p, err := newPktSetSlots([]*setmap.Set{setWithKey("a", 4, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}})})
-	if err != nil {
-		t.Fatalf("newPktSetSlots: %v", err)
-	}
+	p := newPktSetSlots([]*setmap.Set{setWithKey("a", 4, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}})})
 	if p.HasSet("nope") {
 		t.Error("HasSet(nope) should be false")
 	}

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -1,0 +1,71 @@
+package program
+
+import (
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/internal/setmap"
+)
+
+func setWithKey(name string, keySize uint32, fields []setmap.KeyField) *setmap.Set {
+	return &setmap.Set{
+		SpecRef: setmap.SpecRef{Name: name},
+		Def:     &setmap.Definition{KeySize: keySize, Fields: fields},
+	}
+}
+
+func TestNewPktSetSlotsAllocatesDistinctBuffers(t *testing.T) {
+	sets := []*setmap.Set{
+		setWithKey("a", 8, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}, {Name: "mt", Off: 4, Size: 1}}),
+		setWithKey("b", 4, []setmap.KeyField{{Name: "sid", Off: 0, Size: 4}}),
+	}
+	p, err := newPktSetSlots(sets)
+	if err != nil {
+		t.Fatalf("newPktSetSlots: %v", err)
+	}
+	// Both sets sit inside the host region [-40,-24) and don't overlap.
+	offA, szA, okA := p.SlotFor("a", "teid")
+	offB, _, okB := p.SlotFor("b", "sid")
+	if !okA || !okB {
+		t.Fatalf("SlotFor missing: a=%v b=%v", okA, okB)
+	}
+	if szA != 4 {
+		t.Errorf("teid size = %d, want 4", szA)
+	}
+	for _, off := range []int16{offA, offB} {
+		if off < pktSetKeyFloor || off >= pktSetKeyTop {
+			t.Errorf("slot %d outside host region [%d,%d)", off, pktSetKeyFloor, pktSetKeyTop)
+		}
+	}
+	if offA == offB {
+		t.Errorf("sets share a buffer base (%d)", offA)
+	}
+	// Field offset within the key is honored.
+	offMT, _, _ := p.SlotFor("a", "mt")
+	if offMT != offA+4 {
+		t.Errorf("mt slot = %d, want %d", offMT, offA+4)
+	}
+}
+
+func TestNewPktSetSlotsRejectsOverBudget(t *testing.T) {
+	// Two 16-byte keys = 32 bytes > the 16-byte packet-extraction budget.
+	sets := []*setmap.Set{
+		setWithKey("a", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
+		setWithKey("b", 16, []setmap.KeyField{{Name: "k", Off: 0, Size: 8}}),
+	}
+	if _, err := newPktSetSlots(sets); err == nil {
+		t.Fatal("expected over-budget error")
+	}
+}
+
+func TestPktSetSlotsUnknownSetOrField(t *testing.T) {
+	p, err := newPktSetSlots([]*setmap.Set{setWithKey("a", 4, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}})})
+	if err != nil {
+		t.Fatalf("newPktSetSlots: %v", err)
+	}
+	if p.HasSet("nope") {
+		t.Error("HasSet(nope) should be false")
+	}
+	if _, _, ok := p.SlotFor("a", "nofield"); ok {
+		t.Error("SlotFor for unknown field should fail")
+	}
+}

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -79,6 +79,35 @@ func TestPktSetSlotsOnlyReferencedConsumeBudget(t *testing.T) {
 	}
 }
 
+func TestPktSetSlotsPacksToBudgetWithoutRounding(t *testing.T) {
+	// A 12-byte u32-only composite (align 4) + a 4-byte u32 key fit
+	// exactly in the 16-byte region; base alignment must not round each
+	// buffer up to 8 and spuriously overflow.
+	sets := []*setmap.Set{
+		setWithKey("big", 12, []setmap.KeyField{
+			{Name: "a", Off: 0, Size: 4}, {Name: "b", Off: 4, Size: 4}, {Name: "c", Off: 8, Size: 4},
+		}),
+		setWithKey("small", 4, []setmap.KeyField{{Name: "d", Off: 0, Size: 4}}),
+	}
+	p := newPktSetSlots(sets)
+	offBig, _, okBig := p.SlotFor("big", "a")
+	offSmall, _, okSmall := p.SlotFor("small", "d")
+	if !okBig || !okSmall {
+		t.Fatalf("both should fit: big=%v small=%v", okBig, okSmall)
+	}
+	if p.allocErr() != nil {
+		t.Fatalf("unexpected allocErr: %v", p.allocErr())
+	}
+	for _, off := range []int16{offBig, offSmall} {
+		if off < pktSetKeyFloor || off >= pktSetKeyTop {
+			t.Errorf("slot %d outside host region [%d,%d)", off, pktSetKeyFloor, pktSetKeyTop)
+		}
+		if off%4 != 0 {
+			t.Errorf("u32 slot %d not 4-aligned", off)
+		}
+	}
+}
+
 func TestPktSetSlotsKeepsWiderKeysAligned(t *testing.T) {
 	// Allocate a u32-key set first, then a u64-key set. The u64 slot must
 	// stay 8-aligned so kunai's DWord store isn't verifier-rejected.

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -79,6 +79,27 @@ func TestPktSetSlotsOnlyReferencedConsumeBudget(t *testing.T) {
 	}
 }
 
+func TestPktSetSlotsKeepsWiderKeysAligned(t *testing.T) {
+	// Allocate a u32-key set first, then a u64-key set. The u64 slot must
+	// stay 8-aligned so kunai's DWord store isn't verifier-rejected.
+	sets := []*setmap.Set{
+		setWithKey("small", 4, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}}),
+		setWithKey("wide", 8, []setmap.KeyField{{Name: "sid", Off: 0, Size: 8}}),
+	}
+	p := newPktSetSlots(sets)
+	p.SlotFor("small", "teid")
+	off, size, ok := p.SlotFor("wide", "sid")
+	if !ok {
+		t.Fatal("wide set should fit")
+	}
+	if size != 8 {
+		t.Fatalf("size = %d, want 8", size)
+	}
+	if off%8 != 0 {
+		t.Errorf("u64 slot %d is not 8-aligned (DWord store would be rejected)", off)
+	}
+}
+
 func TestPktSetSlotsUnknownSetOrField(t *testing.T) {
 	p := newPktSetSlots([]*setmap.Set{setWithKey("a", 4, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}})})
 	if p.HasSet("nope") {

--- a/internal/program/tailcall_fentry_test.go
+++ b/internal/program/tailcall_fentry_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 // tailcallSubfuncSource sets up a tail call chain:
-//   xdp_dispatcher → tail call → xdp_leaf → bpf2bpf call → process_in_leaf
+//
+//	xdp_dispatcher → tail call → xdp_leaf → bpf2bpf call → process_in_leaf
 const tailcallSubfuncSource = `
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>

--- a/internal/program/vlan_tc_support_test.go
+++ b/internal/program/vlan_tc_support_test.go
@@ -18,9 +18,9 @@ import (
 
 // tcAcceptedVlanExprs load & verify at the tc clsact host.
 var tcAcceptedVlanExprs = []string{
-	"eth/vlan?/ipv4/tcp",            // optional single tag
-	"eth/qinq?/vlan?/ipv4/tcp",      // recommended tag-flexible pattern
-	"eth/vlan*/ipv4/tcp",            // zero-or-more (bpf_loop)
+	"eth/vlan?/ipv4/tcp",             // optional single tag
+	"eth/qinq?/vlan?/ipv4/tcp",       // recommended tag-flexible pattern
+	"eth/vlan*/ipv4/tcp",             // zero-or-more (bpf_loop)
 	"eth/vlan?/ipv4/tcp[dport==443]", // optional tag + predicate on a later layer
 }
 

--- a/pkg/kunai/ast/ast.go
+++ b/pkg/kunai/ast/ast.go
@@ -143,6 +143,7 @@ type Predicate struct {
 	Value    *Value   // PredCmp
 	List     []*Value // PredIn
 	FlagName string   // PredHas
+	SetName  string   // PredInSet ("@name" reference)
 	Pos      Position
 }
 

--- a/pkg/kunai/ast/kinds.go
+++ b/pkg/kunai/ast/kinds.go
@@ -191,9 +191,10 @@ func (k WhereKind) String() string {
 type PredKind int
 
 const (
-	PredCmp PredKind = iota // field op value
-	PredIn                  // field in [v1, v2, ...]
-	PredHas                 // field has FLAG
+	PredCmp   PredKind = iota // field op value
+	PredIn                    // field in [v1, v2, ...]
+	PredHas                   // field has FLAG
+	PredInSet                 // field in @name (pinned-map set)
 )
 
 func (k PredKind) String() string {
@@ -204,6 +205,8 @@ func (k PredKind) String() string {
 		return "in"
 	case PredHas:
 		return "has"
+	case PredInSet:
+		return "in-set"
 	}
 	return fmt.Sprintf("PredKind(%d)", int(k))
 }

--- a/pkg/kunai/codegen/alternation.go
+++ b/pkg/kunai/codegen/alternation.go
@@ -50,7 +50,7 @@ var matchedAltReg = asm.R5
 //   - DispatchNoCheck alternatives are rejected (a fall-through alt
 //     would always "win" — semantic noise)
 //   - alt members must use Field dispatch (the guard is a Field check)
-func genAlternation(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan) (asm.Instructions, asm.Instructions, error) {
+func genAlternation(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan, pc *predCtx) (asm.Instructions, asm.Instructions, error) {
 	if layer.Quant != ast.QuantOne {
 		return nil, nil, fmt.Errorf("%w: quantifier %s on alternation group", ErrNotImplemented, layer.Quant)
 	}
@@ -149,7 +149,7 @@ func genAlternation(layer *ir.LayerInstance, index int, all []*ir.LayerInstance,
 		if plan != nil && plan.layer == alt {
 			altPlan = plan
 		}
-		altBody, altCbs, err := genLayerInner(alt, index, all, qo, altPlan)
+		altBody, altCbs, err := genLayerInner(alt, index, all, qo, altPlan, pc)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/kunai/codegen/alternation_test.go
+++ b/pkg/kunai/codegen/alternation_test.go
@@ -135,4 +135,3 @@ func TestGenAlternationRejectsFirstLayer(t *testing.T) {
 		t.Fatalf("err = %v; want ErrNotImplemented for first-layer alt group", err)
 	}
 }
-

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -114,7 +114,7 @@ const bpfLoopChainCap = 32
 // static path in chain.go; tightening this loop's over-run to match is a
 // follow-up. Non-chain-end protocols (VLAN) bound both ends via their
 // self-dispatch peek.
-func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, asm.Instructions, error) {
+func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, pc *predCtx) (asm.Instructions, asm.Instructions, error) {
 	rangeMin, _ := chainBounds(layer)
 	if rangeMin == 0 && index == 0 {
 		return nil, nil, fmt.Errorf("%w: `*` on the first layer has no parent to peek", ErrNotImplemented)
@@ -151,7 +151,7 @@ func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance
 		// Whole-chain skip: peek the parent dispatch; on mismatch
 		// jump past every iteration (including the bpf_loop call and
 		// its reload) so offsetBase stays put for the next layer.
-		body, err := emitPeekedIterZero(layer, index, all, chainDone)
+		body, err := emitPeekedIterZero(layer, index, all, chainDone, pc)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -159,7 +159,7 @@ func genBpfLoopChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance
 	} else {
 		// `+` / `{n,m}` with n ≥ 1: iteration 0 is a mandatory
 		// parent-dispatched layer identical to a QuantOne.
-		first, err := genStaticLayer(layer, index, all)
+		first, err := genStaticLayer(layer, index, all, pc)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -64,14 +64,17 @@ type LangCaps struct {
 	// SetSlots resolves a `field in @name` predicate to the R10 stack
 	// slot where codegen must store the extracted packet field, so the
 	// host can look it up in its pinned map after the filter returns.
-	// nil disables `in @set` atoms: both the resolver (atom validity)
-	// and codegen treat them as an error. See SetSlotResolver.
+	// nil disables `in @set`: the resolver still binds the field and
+	// checks placement, but codegen rejects the atom with
+	// ErrNotImplemented (the set/field/slot validation needs the
+	// resolver, which only codegen holds). See SetSlotResolver.
 	SetSlots SetSlotResolver
 }
 
 // HasSetAtoms reports whether the lang caps configure a set-slot
-// resolver. Used by the resolver to short-circuit `field in @name`
-// validation when the host has not opted in. Parallels HasActionAtoms.
+// resolver. Parallels HasActionAtoms. Note: unlike action atoms
+// (validated in the resolver), `in @set` is validated in codegen, which
+// is where SetSlots is consulted.
 func (l LangCaps) HasSetAtoms() bool {
 	return l.SetSlots != nil
 }

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -60,6 +60,20 @@ type LangCaps struct {
 	// XDP fexit reads stack[-48] then args[1]); host adapter packages
 	// provide ready-made implementations.
 	ActionFetcher ActionFetcher
+
+	// SetSlots resolves a `field in @name` predicate to the R10 stack
+	// slot where codegen must store the extracted packet field, so the
+	// host can look it up in its pinned map after the filter returns.
+	// nil disables `in @set` atoms: both the resolver (atom validity)
+	// and codegen treat them as an error. See SetSlotResolver.
+	SetSlots SetSlotResolver
+}
+
+// HasSetAtoms reports whether the lang caps configure a set-slot
+// resolver. Used by the resolver to short-circuit `field in @name`
+// validation when the host has not opted in. Parallels HasActionAtoms.
+func (l LangCaps) HasSetAtoms() bool {
+	return l.SetSlots != nil
 }
 
 // HasActionAtoms reports whether the lang caps configure an action map
@@ -93,4 +107,20 @@ type HostLayout struct {
 // as a u32 (zero-extended from however the host stores it).
 type ActionFetcher interface {
 	EmitFetch(dst asm.Register) asm.Instructions
+}
+
+// SetSlotResolver maps a `field in @name` predicate to a host-owned
+// stack slot. kunai extracts the packet field and stores it there;
+// the host looks up its pinned map against those bytes after the filter
+// returns. kunai stays map-agnostic: the resolver returns only an R10
+// offset and width, never a map, FD, or BTF.
+//
+// The returned off MUST be in the host region (> KunaiStackTop, i.e.
+// closer to 0), because the extraction is written during the filter and
+// read after it; codegen rejects a slot inside kunai's own stack range.
+// size is the field width in bytes (1/2/4/8). ok is false for an unknown
+// set or a field the set's key does not contain.
+type SetSlotResolver interface {
+	SlotFor(setName, fieldName string) (off int16, size int, ok bool)
+	HasSet(setName string) bool
 }

--- a/pkg/kunai/codegen/chain.go
+++ b/pkg/kunai/codegen/chain.go
@@ -84,7 +84,11 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance,
 	// the same slice from each iteration. Use a no-accumulate predCtx so
 	// an `in @set` extraction records its host slot only once (genStaticLayer
 	// above already did); the store asm still replays each iteration.
-	replayPC := &predCtx{sets: pc.sets}
+	// nil-safe: a nil pc (host without set support) stays nil.
+	var replayPC *predCtx
+	if pc != nil {
+		replayPC = &predCtx{sets: pc.sets}
+	}
 	preds, err := emitPredicates(layer.Predicates, replayPC)
 	if err != nil {
 		return nil, err

--- a/pkg/kunai/codegen/chain.go
+++ b/pkg/kunai/codegen/chain.go
@@ -29,7 +29,7 @@ func staticChainFitsRange(max int) bool {
 // KUNAI_MPLS_MPLS_NO_CHECK).
 // Iterations below RangeMin fail hard; iterations at or above RangeMin
 // skip to a single chain-done landing so a short stack falls through.
-func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, error) {
+func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, pc *predCtx) (asm.Instructions, error) {
 	if layer.RangeMax < 0 {
 		return nil, fmt.Errorf("%w: open-ended quantifier {%d,} on %q needs bpf_loop chain codegen", ErrNotImplemented, layer.RangeMin, layer.Spec.Name)
 	}
@@ -45,7 +45,7 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 		return nil, err
 	}
 
-	first, err := genStaticLayer(layer, index, all)
+	first, err := genStaticLayer(layer, index, all, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +81,11 @@ func genStaticChain(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 		Dispatch: &ir.DispatchChoice{Type: selfConst.Type, Const: selfConst},
 	}
 	// Predicates are identical across iterations; emit once and append
-	// the same slice from each iteration.
-	preds, err := emitPredicates(layer.Predicates)
+	// the same slice from each iteration. Use a no-accumulate predCtx so
+	// an `in @set` extraction records its host slot only once (genStaticLayer
+	// above already did); the store asm still replays each iteration.
+	replayPC := &predCtx{sets: pc.sets}
+	preds, err := emitPredicates(layer.Predicates, replayPC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -179,6 +179,14 @@ type Output struct {
 	Callbacks asm.Instructions
 	Capture   CaptureInfo
 
+	// Extractions lists the packet fields the filter body stored into
+	// host stack slots for `field in @set` predicates. The host reads
+	// these back to know which pinned map to look up against which slot,
+	// after the filter returns. nil when the chain has no `in @set`.
+	// No map/FD/BTF here — only a set-name label, the R10 slot, and the
+	// stored width — so kunai stays map-agnostic.
+	Extractions []ExtractSlot
+
 	// Warnings is the list of non-fatal notices the resolver and
 	// codegen accumulate during compile. Callers (xdp-ninja CLI etc.)
 	// typically surface them on stderr. Until kunai 1.0 the slice is
@@ -186,6 +194,17 @@ type Output struct {
 	// patch releases (see pkg/kunai/README.md). The zero value (nil)
 	// means "no warnings".
 	Warnings []string
+}
+
+// ExtractSlot records one `field in @set` extraction: codegen stored the
+// packet field's value (host byte order, StoreSize bytes) at R10+StackOff,
+// for the pinned set named SetName's key field FieldName. The host builds
+// its lookup key from these slots.
+type ExtractSlot struct {
+	SetName   string
+	FieldName string
+	StackOff  int16
+	StoreSize int
 }
 
 // Instructions returns Main concatenated with Callbacks. Callers
@@ -352,8 +371,10 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	// the existing >=2 reject. See acc.go.
 	plan := buildAccPlan(where, qo)
 	var callbacks asm.Instructions
+	var extractions []ExtractSlot
+	pc := &predCtx{sets: caps.Lang.SetSlots, out: &extractions}
 	for i, layer := range p.Layers {
-		layerInsns, cb, err := genLayer(layer, i, p.Layers, qo, plan)
+		layerInsns, cb, err := genLayer(layer, i, p.Layers, qo, plan, pc)
 		if err != nil {
 			return Output{}, err
 		}
@@ -396,10 +417,11 @@ func Gen(p *ir.Program, caps Capabilities) (Output, error) {
 	)
 
 	return Output{
-		Main:      insns,
-		Callbacks: callbacks,
-		Capture:   capInfo,
-		Warnings:  cloneWarnings(p.Warnings),
+		Main:        insns,
+		Callbacks:   callbacks,
+		Capture:     capInfo,
+		Extractions: extractions,
+		Warnings:    cloneWarnings(p.Warnings),
 	}, nil
 }
 
@@ -657,10 +679,10 @@ func emitBounds(hs int, failLabel string) asm.Instructions {
 // one's compiled comparison. Stopping at the first ErrNotImplemented
 // keeps the error message close to the offending predicate; the
 // per-predicate Pos is attached so users see line:col.
-func emitPredicates(preds []*ir.Predicate) (asm.Instructions, error) {
+func emitPredicates(preds []*ir.Predicate, pc *predCtx) (asm.Instructions, error) {
 	var out asm.Instructions
 	for _, pred := range preds {
-		pi, err := genPredicate(pred)
+		pi, err := genPredicate(pred, pc)
 		if err != nil {
 			return nil, withPos(err, pred.Pos)
 		}
@@ -791,33 +813,33 @@ func checkHostLayerSupport(p *ir.Program, host HostLayout) error {
 // value holds any bpf2bpf subprogram instructions the chain codegen
 // needs appended after the main stream — empty for every non-bpf_loop
 // path.
-func genLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan) (asm.Instructions, asm.Instructions, error) {
-	insns, callbacks, err := genLayerInner(layer, index, all, qo, plan)
+func genLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan, pc *predCtx) (asm.Instructions, asm.Instructions, error) {
+	insns, callbacks, err := genLayerInner(layer, index, all, qo, plan, pc)
 	return insns, callbacks, withPos(err, layer.Pos)
 }
 
-func genLayerInner(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan) (asm.Instructions, asm.Instructions, error) {
+func genLayerInner(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan, pc *predCtx) (asm.Instructions, asm.Instructions, error) {
 	if layer.Alternation != nil {
-		return genAlternation(layer, index, all, qo, plan)
+		return genAlternation(layer, index, all, qo, plan, pc)
 	}
 	switch layer.Quant {
 	case ast.QuantOne:
 		if layer.Spec.ParseStateMachine != nil {
-			return genParserMachine(layer, index, all, qo, plan)
+			return genParserMachine(layer, index, all, qo, plan, pc)
 		}
-		insns, err := genStaticLayer(layer, index, all)
+		insns, err := genStaticLayer(layer, index, all, pc)
 		return insns, nil, err
 	case ast.QuantOpt:
-		insns, err := genOptionalLayer(layer, index, all)
+		insns, err := genOptionalLayer(layer, index, all, pc)
 		return insns, nil, err
 	case ast.QuantRange:
 		if staticChainFitsRange(layer.RangeMax) {
-			insns, err := genStaticChain(layer, index, all)
+			insns, err := genStaticChain(layer, index, all, pc)
 			return insns, nil, err
 		}
-		return genBpfLoopChain(layer, index, all)
+		return genBpfLoopChain(layer, index, all, pc)
 	case ast.QuantPlus, ast.QuantStar:
-		return genBpfLoopChain(layer, index, all)
+		return genBpfLoopChain(layer, index, all, pc)
 	}
 	return nil, nil, fmt.Errorf("%w: quantifier %s on layer %q", ErrNotImplemented, layer.Quant, layer.Spec.Name)
 }
@@ -825,7 +847,7 @@ func genLayerInner(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, 
 // genStaticLayer emits the bounds check, dispatch check, predicates,
 // and R4 advancement for a layer that is always present. Failure of
 // any check jumps to dslReject.
-func genStaticLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, error) {
+func genStaticLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, pc *predCtx) (asm.Instructions, error) {
 	hs, err := headerSize(layer.Spec)
 	if err != nil {
 		return nil, err
@@ -841,7 +863,7 @@ func genStaticLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance)
 		insns = append(insns, di...)
 	}
 
-	preds, err := emitPredicates(layer.Predicates)
+	preds, err := emitPredicates(layer.Predicates, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -939,7 +961,7 @@ func variableTailSkipFromHeaderLength(vs *vocab.HeaderLength) variableTailSkip {
 // next layer with R4 pointing at the right place. DispatchNoCheck is
 // rejected because there is no way to detect absence when the vocab
 // says "don't look".
-func genOptionalLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance) (asm.Instructions, error) {
+func genOptionalLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, pc *predCtx) (asm.Instructions, error) {
 	if index == 0 {
 		return nil, fmt.Errorf("%w: the first layer cannot be optional", ErrNotImplemented)
 	}
@@ -951,7 +973,7 @@ func genOptionalLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstanc
 	}
 
 	skipLabel := fmt.Sprintf("dsl_skip_%d", index)
-	body, err := emitPeekedIterZero(layer, index, all, skipLabel)
+	body, err := emitPeekedIterZero(layer, index, all, skipLabel, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -972,7 +994,7 @@ func genOptionalLayer(layer *ir.LayerInstance, index int, all []*ir.LayerInstanc
 // emitBounds has already validated, so it is safe; and skipping the
 // current layer's bounds check on the absent path avoids spurious
 // dslReject when an optional layer is simply not there.
-func emitPeekedIterZero(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, peekFailLabel string) (asm.Instructions, error) {
+func emitPeekedIterZero(layer *ir.LayerInstance, index int, all []*ir.LayerInstance, peekFailLabel string, pc *predCtx) (asm.Instructions, error) {
 	if index == 0 || layer.Dispatch == nil {
 		return nil, fmt.Errorf("%w: peeked iter-0 on %q requires a parent dispatch", ErrNotImplemented, layer.Spec.Name)
 	}
@@ -984,7 +1006,7 @@ func emitPeekedIterZero(layer *ir.LayerInstance, index int, all []*ir.LayerInsta
 	if err != nil {
 		return nil, err
 	}
-	preds, err := emitPredicates(layer.Predicates)
+	preds, err := emitPredicates(layer.Predicates, pc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kunai/codegen/codegen_test.go
+++ b/pkg/kunai/codegen/codegen_test.go
@@ -707,9 +707,9 @@ func TestGenCaptureWhereAndsWithTopLevel(t *testing.T) {
 func TestGenCaptureMultipleClausesTakeMaxAndAndWheres(t *testing.T) {
 	p := ethIPv4TCPProgram()
 	p.Captures = []*ir.CaptureClause{
-		{Kind: ast.CapHeaders},                   // 54
-		{Kind: ast.CapHeadersPlus, Extra: 128},   // 54 + 128 = 182
-		{Kind: ast.CapHeadersPlus, Extra: 32},    // 86
+		{Kind: ast.CapHeaders},                 // 54
+		{Kind: ast.CapHeadersPlus, Extra: 128}, // 54 + 128 = 182
+		{Kind: ast.CapHeadersPlus, Extra: 32},  // 86
 	}
 	out, err := Gen(p, Capabilities{})
 	if err != nil {
@@ -1130,7 +1130,6 @@ func TestGenNoCheckRejectsFalseConst(t *testing.T) {
 		t.Fatal("expected error for NO_CHECK=false const reaching codegen")
 	}
 }
-
 
 func TestGenPredicateRejectsInt32Overflow(t *testing.T) {
 	// The resolver catches "does not fit in the field" (99999 in 16-bit

--- a/pkg/kunai/codegen/parser_counter_test.go
+++ b/pkg/kunai/codegen/parser_counter_test.go
@@ -167,5 +167,3 @@ func assertCounterStoreToR10(stream asm.Instructions, slot int16) error {
 	}
 	return errors.New("no StoreMem to expected counter slot")
 }
-
-

--- a/pkg/kunai/codegen/parser_select.go
+++ b/pkg/kunai/codegen/parser_select.go
@@ -9,7 +9,6 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab/p4lite"
 )
 
-
 // emitTransitionWithSelfRewrite lowers a TransitionOp at the inline
 // (non-callback) site. Terminal kinds jump to the layer's done/reject
 // landings; direct/select jumps go to state labels. selfLabel is the

--- a/pkg/kunai/codegen/parser_state.go
+++ b/pkg/kunai/codegen/parser_state.go
@@ -27,7 +27,7 @@ import (
 // bpf2bpf callback that bpf_loop invokes max_iter times. The first
 // iteration runs inline so dispatch and predicates remain in the main
 // stream where the verifier can see them.
-func genParserMachine(layer *ir.LayerInstance, layerIdx int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan) (asm.Instructions, asm.Instructions, error) {
+func genParserMachine(layer *ir.LayerInstance, layerIdx int, all []*ir.LayerInstance, qo queriedOptions, plan *accPlan, pc *predCtx) (asm.Instructions, asm.Instructions, error) {
 	spec := layer.Spec
 	m := spec.ParseStateMachine
 	if m == nil {
@@ -47,6 +47,7 @@ func genParserMachine(layer *ir.LayerInstance, layerIdx int, all []*ir.LayerInst
 		queried:      qo,
 		queriedAuxes: buildQueriedAuxNames(qo, layer),
 		accPlan:      plan,
+		pc:           pc,
 	}
 	// Pre-scan for multi-state self-loops. Each loop entry's siblings
 	// inline into the entry's bpf_loop callback, so the per-state
@@ -128,6 +129,10 @@ type pmCtx struct {
 	// option into a single slot. nil for every program that is not the
 	// supported pure-AND-equality multi-option TCP shape (see acc.go).
 	accPlan *accPlan
+	// pc threads the host set-slot resolver + extraction accumulator so
+	// bracket `field in @set` predicates on this layer can emit their
+	// host-slot store. nil-safe.
+	pc *predCtx
 }
 
 // precedingLayersLeaveR4Range scans the layers emitted before idx and
@@ -338,7 +343,7 @@ func (c *pmCtx) emitStateBody(state *vocab.ParseState, stateIdx int, isEntry boo
 		}
 		insns = append(insns, exInsns...)
 		if isEntry && i == 0 {
-			preds, err := emitPredicates(c.layer.Predicates)
+			preds, err := emitPredicates(c.layer.Predicates, c.pc)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/kunai/codegen/parser_trail.go
+++ b/pkg/kunai/codegen/parser_trail.go
@@ -9,7 +9,6 @@ import (
 	"github.com/takehaya/xdp-ninja/pkg/kunai/vocab"
 )
 
-
 // variableTailSkip describes a header whose total wire size depends
 // on a length field embedded in its fixed prefix. The codegen
 // emits the fixed-prefix extract first, then a "tail skip" of

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -216,8 +216,12 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 	if bytes > 8 {
 		return nil, fmt.Errorf("%w: set key field %q is %d bytes; packet-field extraction supports up to 8 (16-byte keys such as SRv6 SID are a follow-up)", ErrNotImplemented, fieldName, bytes)
 	}
-	if bytes > slotSize {
-		return nil, fmt.Errorf("packet field %q (%d bytes) is wider than set @%s key field %q (%d bytes)", fieldName, bytes, pred.SetName, fieldName, slotSize)
+	// Require an exact width match: a narrower packet field would only
+	// write a prefix of the key (relying on zero-fill), which silently
+	// matches just zero-extended entries — a mis-configuration trap.
+	// Size the set key field to the packet field's width.
+	if bytes != slotSize {
+		return nil, fmt.Errorf("packet field %q is %d bytes but set @%s key field %q is %d bytes; widths must match (create the set with a matching field type)", fieldName, bytes, pred.SetName, fieldName, slotSize)
 	}
 	size, err := asmSizeFor(bytes)
 	if err != nil {

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -20,9 +20,12 @@ import (
 // The field lookup is delegated to each emit* so the byte/bit-level
 // constraints can differ — IPv6 is 128 bits which findFieldByteOffset
 // rejects, and MAC is 6 bytes which asmSizeFor rejects.
-func genPredicate(pred *ir.Predicate) (asm.Instructions, error) {
+func genPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, error) {
 	if pred.Unsupported != "" {
 		return nil, fmt.Errorf("%w: %s", ErrNotImplemented, pred.Unsupported)
+	}
+	if pred.Kind == ast.PredInSet {
+		return emitInSetPredicate(pred, pc)
 	}
 	if pred.Kind == ast.PredIn {
 		return emitInPredicate(pred)
@@ -162,6 +165,97 @@ func emitIntPredicate(pred *ir.Predicate) (asm.Instructions, error) {
 	return insns, nil
 }
 
+// predCtx threads the host's set-slot resolver and an extraction
+// accumulator through the predicate emitters. It is nil-safe: a nil
+// predCtx (or a nil Sets) means the host does not support `in @set`.
+type predCtx struct {
+	sets SetSlotResolver
+	out  *[]ExtractSlot
+}
+
+// emitInSetPredicate lowers `field in @set` for architecture B: it does
+// NOT emit a map lookup (kunai stays map-agnostic). Instead it extracts
+// the packet field into the host-owned R10 slot the SetSlotResolver
+// designates, so the host can look the pinned map up against those bytes
+// after the filter returns. The atom never affects the verdict — only a
+// layer that cannot be reached fails, via the shared dslReject the field
+// load already jumps to.
+//
+// Byte order (correctness-critical): `set add` writes the key value in
+// native byte order (setmap.BuildKey/putUint use binary.NativeEndian).
+// emitBoundedLoad packs network-order packet bytes into R3 as a host-LE
+// integer, so a multi-byte field is byte-reversed relative to its
+// numeric value. HostTo(BE) brings R3 to the numeric value in host
+// order; StoreMem then writes it native-endian, matching the map key.
+func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, error) {
+	if pc == nil || pc.sets == nil {
+		return nil, fmt.Errorf("%w: `in @%s` needs a host that supports set matching", ErrNotImplemented, pred.SetName)
+	}
+	if !pc.sets.HasSet(pred.SetName) {
+		return nil, fmt.Errorf("unknown set @%s (declare it with --set %s=/sys/fs/bpf/...)", pred.SetName, pred.SetName)
+	}
+	if pred.Field == nil || pred.Field.Field == nil {
+		return nil, fmt.Errorf("codegen: in-set predicate missing field reference")
+	}
+	// Implicit name match: the DSL field name is the set's key field name.
+	fieldName := pred.Field.Field.Name
+	slotOff, slotSize, ok := pc.sets.SlotFor(pred.SetName, fieldName)
+	if !ok {
+		return nil, fmt.Errorf("set @%s has no key field %q (check `xdp-ninja set schema`)", pred.SetName, fieldName)
+	}
+	// The extraction is written during the filter and read after it, so
+	// the slot must live in the host region, never kunai's stack range.
+	if slotOff <= KunaiStackTop {
+		return nil, fmt.Errorf("codegen: set slot %d for @%s.%s is inside kunai's stack region (must be > %d)", slotOff, pred.SetName, fieldName, KunaiStackTop)
+	}
+
+	fieldOff, bytes, err := fieldRefByteOffset(pred.Field)
+	if err != nil {
+		return nil, err
+	}
+	if bytes > 8 {
+		return nil, fmt.Errorf("%w: set key field %q is %d bytes; packet-field extraction supports up to 8 (16-byte keys such as SRv6 SID are a follow-up)", ErrNotImplemented, fieldName, bytes)
+	}
+	if bytes > slotSize {
+		return nil, fmt.Errorf("packet field %q (%d bytes) is wider than set @%s key field %q (%d bytes)", fieldName, bytes, pred.SetName, fieldName, slotSize)
+	}
+	size, err := asmSizeFor(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var insns asm.Instructions
+	// Single-aux fields gate on presence just like emitIntPredicate;
+	// iterator-stack (dynamic) aux fields are rejected at resolve time.
+	if pred.Field.Aux != nil {
+		insns = append(insns, emitAuxGating(pred.Field.Aux.Gating, r4Anchor(), dslReject)...)
+	}
+	insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff), size, dslReject)...)
+
+	// Normalize the register to the field's numeric value in host order.
+	hasSlice := pred.Field.Slice != nil
+	subByte := fieldIsSubByte(pred.Field)
+	switch {
+	case hasSlice || subByte:
+		if bytes > 1 {
+			insns = append(insns, asm.HostTo(asm.BE, asm.R3, size))
+		}
+		insns = append(insns, emitSliceShiftMask(pred.Field, bytes)...)
+	case bytes > 1:
+		insns = append(insns, asm.HostTo(asm.BE, asm.R3, size))
+	}
+	// Store native-endian into the host key slot (matches `set add`).
+	insns = append(insns, asm.StoreMem(asm.R10, slotOff, asm.R3, size))
+
+	if pc.out != nil {
+		*pc.out = append(*pc.out, ExtractSlot{
+			SetName: pred.SetName, FieldName: fieldName,
+			StackOff: slotOff, StoreSize: bytes,
+		})
+	}
+	return insns, nil
+}
+
 // swapValueBytes reverses the low `bytes` bytes of v so an LE-loaded
 // register can be compared against the native-order constant with a
 // single JEq/JNE. e.g. 443 (0x01BB) over 2 bytes → 0xBB01.
@@ -292,15 +386,15 @@ func ipv6AuxHalfCheck(loadAt auxLoadAt, chunkOff int, mask, host uint64, failLab
 // literal` where op ∈ {<, ≤, >, ≥} and field is a 128-bit IPv6
 // address (F3). Algorithm:
 //
-//   load + host-swap high half of field into R3
-//   reg-cmp R3 against literal high:
-//     - if `op` is "strictly more permissive" (e.g. < and field<lit) → match
-//     - if `op` is "strictly impossible" (e.g. < and field>lit) → fail
-//     - if equal → fall through to low check
-//   load + host-swap low half of field into R3
-//   reg-cmp R3 against literal low (same op as the original):
-//     - on miss → fail
-//     - on match → success
+//	load + host-swap high half of field into R3
+//	reg-cmp R3 against literal high:
+//	  - if `op` is "strictly more permissive" (e.g. < and field<lit) → match
+//	  - if `op` is "strictly impossible" (e.g. < and field>lit) → fail
+//	  - if equal → fall through to low check
+//	load + host-swap low half of field into R3
+//	reg-cmp R3 against literal low (same op as the original):
+//	  - on miss → fail
+//	  - on match → success
 //
 // Match success falls through to the next predicate; mismatches jump
 // to dslReject. We use a per-predicate match landing so the early

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -123,6 +123,15 @@ func TestCompileIPv4OrderedRejected(t *testing.T) {
 	}
 }
 
+func TestCompileInSetNotYetWired(t *testing.T) {
+	// The `in @set` predicate parses and resolves, but codegen + host
+	// map lookup land in a later commit, so Compile gates it for now.
+	_, err := Compile("eth/ipv4/udp/gtp[teid in @teids]", codegen.Capabilities{})
+	if !errors.Is(err, codegen.ErrNotImplemented) {
+		t.Fatalf("expected ErrNotImplemented for `in @set`, got %v", err)
+	}
+}
+
 func TestCompileVlanOptionalSucceeds(t *testing.T) {
 	// `?` quantifier + real vlan vocab — verifies end-to-end path.
 	insns, err := compileForTest("eth/vlan?/ipv4/tcp")

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -189,6 +189,21 @@ func TestCompileInSetExtractsToSlotStayingMapAgnostic(t *testing.T) {
 	}
 }
 
+// wideSlot returns an 8-byte slot for teid, wider than gtp.teid (4 bytes),
+// to exercise the exact-width-match rejection.
+type wideSlot struct{}
+
+func (wideSlot) HasSet(name string) bool                            { return name == "teids" }
+func (wideSlot) SlotFor(_, _ string) (off int16, size int, ok bool) { return -40, 8, true }
+
+func TestCompileInSetRejectsWidthMismatch(t *testing.T) {
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: wideSlot{}}}
+	_, err := Compile("eth/ipv4/udp/gtp[teid in @teids]", caps)
+	if err == nil || !strings.Contains(err.Error(), "widths must match") {
+		t.Fatalf("expected width-mismatch rejection, got %v", err)
+	}
+}
+
 func TestCompileInSetRejectsSlotInsideKunaiRegion(t *testing.T) {
 	// A host that hands back a slot in kunai's own stack range must be
 	// rejected — the extraction would be clobbered mid-filter.

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -123,14 +123,87 @@ func TestCompileIPv4OrderedRejected(t *testing.T) {
 	}
 }
 
-func TestCompileInSetNotYetWired(t *testing.T) {
-	// The `in @set` predicate parses and resolves, but codegen + host
-	// map lookup land in a later commit, so Compile gates it for now.
+func TestCompileInSetNeedsHostSupport(t *testing.T) {
+	// Without a SetSlotResolver the host does not support set matching,
+	// so `in @set` is rejected (zero Capabilities).
 	_, err := Compile("eth/ipv4/udp/gtp[teid in @teids]", codegen.Capabilities{})
 	if !errors.Is(err, codegen.ErrNotImplemented) {
-		t.Fatalf("expected ErrNotImplemented for `in @set`, got %v", err)
+		t.Fatalf("expected ErrNotImplemented for `in @set` without host support, got %v", err)
 	}
 }
+
+// fakeSetSlots is a test SetSlotResolver: set "teids" has a 4-byte "teid"
+// key field at host slot R10-40.
+type fakeSetSlots struct{}
+
+func (fakeSetSlots) HasSet(name string) bool { return name == "teids" }
+func (fakeSetSlots) SlotFor(set, field string) (int16, int, bool) {
+	if set == "teids" && field == "teid" {
+		return -40, 4, true
+	}
+	return 0, 0, false
+}
+
+func TestCompileInSetExtractsToSlotStayingMapAgnostic(t *testing.T) {
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: fakeSetSlots{}}}
+	out, err := Compile("eth/ipv4/udp/gtp[teid in @teids]", caps)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// The host is told which field went to which slot.
+	if len(out.Extractions) != 1 {
+		t.Fatalf("extractions = %+v, want 1", out.Extractions)
+	}
+	if ex := out.Extractions[0]; ex.SetName != "teids" || ex.FieldName != "teid" || ex.StackOff != -40 || ex.StoreSize != 4 {
+		t.Errorf("extraction = %+v", ex)
+	}
+
+	insns := out.Instructions()
+	// Invariant: kunai never emits a map lookup — the host does that.
+	for _, ins := range insns {
+		if ins.OpCode.JumpOp() == asm.Call && ins.Src != asm.PseudoCall && ins.Constant == int64(asm.FnMapLookupElem) {
+			t.Fatal("codegen emitted FnMapLookupElem; kunai must stay map-agnostic")
+		}
+	}
+	// The extracted field is stored into the host slot (R10-40).
+	var stored bool
+	for _, ins := range insns {
+		if ins.Dst == asm.R10 && ins.OpCode.Class().IsStore() && int16(ins.Offset) == -40 {
+			stored = true
+		}
+	}
+	if !stored {
+		t.Error("no store of the extracted field to host slot R10-40")
+	}
+	// Byte-order contract: a multi-byte field is byte-swapped to host
+	// order (BPF_END, not BSwap) so the stored key matches `set add`.
+	swapOp := asm.HostTo(asm.BE, asm.R3, asm.Word).OpCode
+	var swapped bool
+	for _, ins := range insns {
+		if ins.OpCode == swapOp {
+			swapped = true
+		}
+	}
+	if !swapped {
+		t.Error("no HostTo(BE) byte-swap before the slot store (byte-order would mismatch the map key)")
+	}
+}
+
+func TestCompileInSetRejectsSlotInsideKunaiRegion(t *testing.T) {
+	// A host that hands back a slot in kunai's own stack range must be
+	// rejected — the extraction would be clobbered mid-filter.
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: badSlot{}}}
+	_, err := Compile("eth/ipv4/udp/gtp[teid in @teids]", caps)
+	if err == nil || !strings.Contains(err.Error(), "kunai's stack region") {
+		t.Fatalf("expected kunai-region rejection, got %v", err)
+	}
+}
+
+// badSlot returns an offset inside kunai's stack region (<= KunaiStackTop).
+type badSlot struct{}
+
+func (badSlot) HasSet(name string) bool                            { return name == "teids" }
+func (badSlot) SlotFor(_, _ string) (off int16, size int, ok bool) { return -200, 4, true }
 
 func TestCompileVlanOptionalSucceeds(t *testing.T) {
 	// `?` quantifier + real vlan vocab — verifies end-to-end path.

--- a/pkg/kunai/ir/ir.go
+++ b/pkg/kunai/ir/ir.go
@@ -17,8 +17,8 @@ import (
 // Program is the top-level resolved filter.
 type Program struct {
 	Layers   []*LayerInstance
-	Where    *Condition        // nil when no top-level where
-	Captures []*CaptureClause  // 0 or more
+	Where    *Condition       // nil when no top-level where
+	Captures []*CaptureClause // 0 or more
 
 	// LabelTable maps label text to layer. It includes both
 	// user-provided "@label" names and auto-generated names of the
@@ -115,6 +115,7 @@ type Predicate struct {
 	Value    *ast.Value   // PredCmp
 	List     []*ast.Value // PredIn
 	FlagName string       // PredHas
+	SetName  string       // PredInSet ("@name" reference)
 
 	Unsupported string
 
@@ -129,14 +130,14 @@ type Predicate struct {
 //
 // When Aux is non-nil, Field references one entry of an auxiliary
 // header (e.g. gtp_opt_h.next_ext). Codegen must:
-//   1. Optionally evaluate Aux.Gating to decide whether the aux is
-//      present on this packet's path. A failed gate means the field
-//      does not exist for this packet — predicate codegen treats
-//      that as "match fails", consistent with `proto.aux.exists`
-//      being false.
-//   2. Read the field at offset (Aux.OffsetInLayer + Field's bit
-//      window) anchored on the layer-entry slot, not R4 (which has
-//      advanced past the layer by the time predicates run).
+//  1. Optionally evaluate Aux.Gating to decide whether the aux is
+//     present on this packet's path. A failed gate means the field
+//     does not exist for this packet — predicate codegen treats
+//     that as "match fails", consistent with `proto.aux.exists`
+//     being false.
+//  2. Read the field at offset (Aux.OffsetInLayer + Field's bit
+//     window) anchored on the layer-entry slot, not R4 (which has
+//     advanced past the layer by the time predicates run).
 type FieldRef struct {
 	Layer *LayerInstance
 	Field *vocab.Field
@@ -197,10 +198,10 @@ func (r *FieldRef) EffectiveBits() int {
 // OffsetInLayer + index*ElemSize where index comes from
 // Stack.Static or Stack.Dynamic depending on Stack.IsStatic.
 type AuxRef struct {
-	OutParam      string         // parser out parameter name (e.g. "opt", "segments")
-	HeaderName    string         // aux header type name (e.g. "gtp_opt_h", "srv6_seg_h")
-	OffsetInLayer int            // bytes from layer-entry slot to aux start (for stacks: base of stack)
-	HeaderSize    int            // bytes; element size when Stack != nil
+	OutParam      string // parser out parameter name (e.g. "opt", "segments")
+	HeaderName    string // aux header type name (e.g. "gtp_opt_h", "srv6_seg_h")
+	OffsetInLayer int    // bytes from layer-entry slot to aux start (for stacks: base of stack)
+	HeaderSize    int    // bytes; element size when Stack != nil
 	Gating        *vocab.AuxGating
 	// FieldBitOff / FieldBitWidth give the field's window inside the
 	// aux header (or per-entry stack header), in bits (matches
@@ -228,7 +229,7 @@ type AuxRef struct {
 // variable of an enclosing any/all quantifier — codegen substitutes
 // the loop iteration index for the offset compute.
 type StackIndex struct {
-	Capacity   int       // declared array size from `out <type>[N]` (= verifier-safe upper bound)
+	Capacity   int // declared array size from `out <type>[N]` (= verifier-safe upper bound)
 	IsStatic   bool
 	Static     uint64    // when IsStatic
 	Dynamic    *FieldRef // when !IsStatic && !IsIterator; primary-header field of the same layer
@@ -308,8 +309,8 @@ type Condition struct {
 // ArithExpr is a resolved arithmetic expression (used inside where).
 type ArithExpr struct {
 	Kind  ast.ArithKind
-	Const uint64     // ArithConst
-	Field *FieldRef  // ArithField
+	Const uint64    // ArithConst
+	Field *FieldRef // ArithField
 
 	Op    ast.ArithOp
 	Left  *ArithExpr

--- a/pkg/kunai/ir/ir_test.go
+++ b/pkg/kunai/ir/ir_test.go
@@ -22,12 +22,12 @@ func TestBuildMinimalProgram(t *testing.T) {
 		Fields:     []vocab.Field{{Name: "dport", Bits: 16}},
 	}
 	dispatch := &vocab.DispatchConst{
-		Type:   vocab.DispatchField,
-		Name:   "TCP_IPV4_PROTOCOL",
-		Parent: "ipv4",
+		Type:      vocab.DispatchField,
+		Name:      "TCP_IPV4_PROTOCOL",
+		Parent:    "ipv4",
 		FieldName: "protocol",
-		Bits:   8,
-		Value:  6,
+		Bits:      8,
+		Value:     6,
 	}
 	ethLayer := &LayerInstance{Spec: &vocab.ProtocolSpec{Name: "eth", HeaderName: "eth_h"}}
 	ipv4Layer := &LayerInstance{Spec: ipv4Spec}

--- a/pkg/kunai/parser/capture.go
+++ b/pkg/kunai/parser/capture.go
@@ -8,7 +8,8 @@ import (
 // parseCaptureClause handles "capture <spec> (where <expr>)?". The
 // where-clause portion is implemented in an upcoming commit; until
 // then we reject it with a clear message so users know it is coming.
-//   capture_clause := "capture" capture_spec where_clause?
+//
+//	capture_clause := "capture" capture_spec where_clause?
 func (p *parser) parseCaptureClause() (*ast.CaptureClause, error) {
 	startPos := p.cur.Pos
 	if _, err := p.expect(lexer.TokCapture); err != nil {
@@ -30,10 +31,11 @@ func (p *parser) parseCaptureClause() (*ast.CaptureClause, error) {
 }
 
 // capture_spec := "all"
-//                | "headers" ("+" INT)?
-//                | "absolute" INT
-//                | IDENT ("+" INT)?              # layer label or protocol name
-//                | field_path ("," field_path)*  # CapFields (MVP-unsupported)
+//
+//	| "headers" ("+" INT)?
+//	| "absolute" INT
+//	| IDENT ("+" INT)?              # layer label or protocol name
+//	| field_path ("," field_path)*  # CapFields (MVP-unsupported)
 //
 // "absolute" is a contextual keyword (only special inside capture).
 // A label literally named "absolute" can still be referenced via

--- a/pkg/kunai/parser/layer.go
+++ b/pkg/kunai/parser/layer.go
@@ -8,7 +8,8 @@ import (
 const maxAltDepth = 16
 
 // parseLayerChain parses one or more layer_items separated by "/".
-//   layer_chain := layer_item ("/" layer_item)*
+//
+//	layer_chain := layer_item ("/" layer_item)*
 func (p *parser) parseLayerChain() ([]*ast.Layer, error) {
 	first, err := p.parseLayerItem()
 	if err != nil {
@@ -29,7 +30,8 @@ func (p *parser) parseLayerChain() ([]*ast.Layer, error) {
 }
 
 // parseLayerItem wraps a layer_atom with an optional quantifier.
-//   layer_item := layer_atom quantifier?
+//
+//	layer_item := layer_atom quantifier?
 func (p *parser) parseLayerItem() (*ast.Layer, error) {
 	layer, err := p.parseLayerAtom()
 	if err != nil {
@@ -113,7 +115,8 @@ func (p *parser) parseQuantRange(layer *ast.Layer) error {
 
 // parseLayerAtom is the fundamental layer unit: either a single
 // protocol leaf or a parenthesised alternation group.
-//   layer_atom := proto_leaf | "(" layer_alt ")"
+//
+//	layer_atom := proto_leaf | "(" layer_alt ")"
 func (p *parser) parseLayerAtom() (*ast.Layer, error) {
 	startPos := p.cur.Pos
 	switch p.cur.Kind {
@@ -162,7 +165,8 @@ func (p *parser) parseProtoLeaf(startPos ast.Position) (*ast.Layer, error) {
 
 // parseLayerAltGroup expects the leading "(" to still be the current
 // token; it consumes it and everything through the matching ")".
-//   layer_alt := layer_item ("|" layer_item)+
+//
+//	layer_alt := layer_item ("|" layer_item)+
 func (p *parser) parseLayerAltGroup(startPos ast.Position) (*ast.Layer, error) {
 	if p.depth >= maxAltDepth {
 		return nil, p.errorf(startPos, "alternation too deeply nested (max %d)", maxAltDepth)

--- a/pkg/kunai/parser/parser_test.go
+++ b/pkg/kunai/parser/parser_test.go
@@ -125,6 +125,32 @@ func TestParseHas(t *testing.T) {
 	}
 }
 
+func TestParseInSet(t *testing.T) {
+	f := mustParse(t, "eth/ipv4/udp/gtp[teid in @teids]")
+	pred := f.Layers[3].Predicates[0]
+	if pred.Kind != ast.PredInSet || pred.SetName != "teids" {
+		t.Fatalf("pred = %+v", pred)
+	}
+	if pred.Field.String() != "teid" {
+		t.Errorf("field = %q", pred.Field.String())
+	}
+}
+
+func TestParseInSetCompositeCommaList(t *testing.T) {
+	// A composite key is comma-separated inside one bracket, reusing the
+	// existing predicate list — not chained [a][b].
+	f := mustParse(t, "eth/ipv4/udp/gtp[teid in @flows, imsi in @flows]")
+	preds := f.Layers[3].Predicates
+	if len(preds) != 2 {
+		t.Fatalf("preds = %d", len(preds))
+	}
+	for i, want := range []string{"teid", "imsi"} {
+		if preds[i].Kind != ast.PredInSet || preds[i].SetName != "flows" || preds[i].Field.String() != want {
+			t.Errorf("pred[%d] = %+v", i, preds[i])
+		}
+	}
+}
+
 func TestParseLabel(t *testing.T) {
 	f := mustParse(t, "eth/ipv4@outer/udp/vxlan[vni==100]/ipv4@inner/tcp[dport==80]")
 	if got := f.Layers[1].Label; got != "outer" {

--- a/pkg/kunai/parser/predicate.go
+++ b/pkg/kunai/parser/predicate.go
@@ -42,6 +42,20 @@ func (p *parser) parsePredicate() (*ast.Predicate, error) {
 		if err := p.advance(); err != nil {
 			return nil, err
 		}
+		// "in @name" references a pinned-map set; "in [v1, v2, ...]" is a
+		// value list. The "@" disambiguates before we enter value mode.
+		if p.cur.Kind == lexer.TokAt {
+			if err := p.advance(); err != nil {
+				return nil, err
+			}
+			name, err := p.expect(lexer.TokIdent)
+			if err != nil {
+				return nil, err
+			}
+			pred.Kind = ast.PredInSet
+			pred.SetName = name.Text
+			return pred, nil
+		}
 		list, err := p.parseValueList()
 		if err != nil {
 			return nil, err

--- a/pkg/kunai/parser/where.go
+++ b/pkg/kunai/parser/where.go
@@ -7,7 +7,8 @@ import (
 
 // parseWhereClause handles the "where <or_expr>" portion of a filter.
 // The caller must ensure p.cur.Kind == TokWhere before invoking.
-//   where_clause := "where" or_expr
+//
+//	where_clause := "where" or_expr
 func (p *parser) parseWhereClause() (*ast.WhereExpr, error) {
 	if _, err := p.expect(lexer.TokWhere); err != nil {
 		return nil, err
@@ -208,7 +209,8 @@ func (p *parser) parseActionAtom(startPos ast.Position) (*ast.WhereExpr, error) 
 }
 
 // cmp_or_bool_atom := (network_literal cmp_op arith_expr)
-//                   | arith_expr (cmp_op (arith_expr | network_literal))?
+//
+//	| arith_expr (cmp_op (arith_expr | network_literal))?
 //
 // dsl-types.md §6.2 makes comparisons fully symmetric in their
 // operands, so we first try to read the LHS in lexer value mode: if

--- a/pkg/kunai/resolve/layer.go
+++ b/pkg/kunai/resolve/layer.go
@@ -93,6 +93,16 @@ func (r *resolver) resolveAlternation(al *ast.Layer, parent *ir.LayerInstance) (
 		if err != nil {
 			return nil, err
 		}
+		// `in @set` on an alternation member is unsafe: the branch may not
+		// be taken, leaving the host key buffer unwritten while the filter
+		// still accepts, so the unconditional lookup would match the wrong
+		// key. Reject here (the per-layer Quant check does not catch it,
+		// since alt members are QuantOne).
+		for _, p := range alt.Predicates {
+			if p.Kind == ast.PredInSet {
+				return nil, errorf(p.Pos, "`in @%s` is not supported inside an alternation (%q may not be on the matched path)", p.SetName, alt.Spec.Name)
+			}
+		}
 		alts = append(alts, alt)
 	}
 	return &ir.LayerInstance{

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -57,11 +57,9 @@ func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerIns
 	if ap.Kind == ast.PredHas {
 		rp.Unsupported = "'has' predicate not yet implemented"
 	}
-	if ap.Kind == ast.PredInSet {
-		// Field is bound and the aux/iterator guards above have run; the
-		// codegen + host map-lookup wiring lands in a later commit.
-		rp.Unsupported = "'in @set' predicate not yet wired"
-	}
+	// PredInSet is wired in codegen (emitInSetPredicate); it needs the
+	// host's SetSlotResolver, which the resolver does not carry, so its
+	// set-existence / field checks happen there, not here.
 	return rp, nil
 }
 

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -51,10 +51,16 @@ func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerIns
 		Value:    ap.Value,
 		List:     ap.List,
 		FlagName: ap.FlagName,
+		SetName:  ap.SetName,
 		Pos:      ap.Pos,
 	}
 	if ap.Kind == ast.PredHas {
 		rp.Unsupported = "'has' predicate not yet implemented"
+	}
+	if ap.Kind == ast.PredInSet {
+		// Field is bound and the aux/iterator guards above have run; the
+		// codegen + host map-lookup wiring lands in a later commit.
+		rp.Unsupported = "'in @set' predicate not yet wired"
 	}
 	return rp, nil
 }

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -17,6 +17,16 @@ func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerIns
 	if field.Aux != nil && field.Aux.Stack != nil && field.Aux.Stack.IsIterator {
 		return nil, errorf(ap.Pos, "auxiliary header stack %q needs an index inside a bracket predicate (use `[N]` or wrap in `any(...)` / `all(...)`)", field.Aux.OutParam)
 	}
+	// `in @set` extracts the field into a host key buffer that the host
+	// looks up unconditionally after the filter. That is only correct if
+	// the predicate is always evaluated on the accept path, so the owning
+	// layer must be mandatory: a `?` / `*` / `+` / `{n,m}` layer that is
+	// absent would leave the buffer unwritten and the lookup would match
+	// the wrong (zeroed) key. (Alternation members are rejected in
+	// resolveAlternation.)
+	if ap.Kind == ast.PredInSet && layer.Quant != ast.QuantOne {
+		return nil, errorf(ap.Pos, "`in @%s` is only supported on a mandatory layer; %q here is optional/repeated (quantifier %s)", ap.SetName, layer.Spec.Name, layer.Quant)
+	}
 	// Bracket-predicate fit check: integer literal must fit the
 	// field's declared bit width (dsl-types.md §7.2). Delegated to
 	// the typing helper so the same rule is in one place.

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -348,6 +348,17 @@ func TestResolvePredicateInSetUnknownFieldErrors(t *testing.T) {
 	resolveErr(t, "eth/ipv4/udp/gtp[nope in @teids]", nil, "no field")
 }
 
+func TestResolvePredicateInSetRejectsOptionalLayer(t *testing.T) {
+	// An optional layer may be absent, leaving the host key buffer
+	// unwritten while the filter still accepts — reject `in @set` there.
+	resolveErr(t, "eth/vlan[tci in @vlans]?/ipv4/tcp", nil, "mandatory layer")
+}
+
+func TestResolvePredicateInSetRejectsAlternationMember(t *testing.T) {
+	// An alternation branch may not be taken; reject `in @set` inside one.
+	resolveErr(t, "eth/(vlan[tci in @vlans]|qinq)/ipv4/tcp", nil, "alternation")
+}
+
 func TestResolveAlternationResolves(t *testing.T) {
 	// Alternatives resolve (each is a valid protocol) and the group
 	// is not flagged Unsupported because codegen can emit it.

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -327,6 +327,26 @@ func TestResolvePredicateHasMarksUnsupported(t *testing.T) {
 	}
 }
 
+func TestResolvePredicateInSetBindsAndMarksUnsupported(t *testing.T) {
+	// The field binds (so field-name errors surface here) but codegen +
+	// host map lookup are wired in a later commit, so it's Unsupported.
+	p := resolveOK(t, "eth/ipv4/udp/gtp[teid in @teids]", nil)
+	pr := p.Layers[3].Predicates[0]
+	if pr.Kind != ast.PredInSet || pr.SetName != "teids" {
+		t.Fatalf("pred = %+v", pr)
+	}
+	if pr.Field == nil || pr.Field.Field == nil || pr.Field.Field.Name != "teid" {
+		t.Errorf("field not bound: %+v", pr.Field)
+	}
+	if pr.Unsupported == "" {
+		t.Error("PredInSet should be Unsupported until wired")
+	}
+}
+
+func TestResolvePredicateInSetUnknownFieldErrors(t *testing.T) {
+	resolveErr(t, "eth/ipv4/udp/gtp[nope in @teids]", nil, "no field")
+}
+
 func TestResolveAlternationResolves(t *testing.T) {
 	// Alternatives resolve (each is a valid protocol) and the group
 	// is not flagged Unsupported because codegen can emit it.
@@ -381,7 +401,6 @@ func TestResolveAlternationNestedFlattens(t *testing.T) {
 		})
 	}
 }
-
 
 func TestResolveAlternationFollowedLayerAgreesOnDispatch(t *testing.T) {
 	// IPv4 sits under either VLAN or QinQ via ethertype==0x0800 — the
@@ -567,7 +586,6 @@ func TestResolveWhereRejectsUnknownAction(t *testing.T) {
 	// XDP_* whitelist.
 	resolveErr(t, "eth/ipv4/tcp where action == SOMETHING_ELSE", xdpTestActions, "unknown action")
 }
-
 
 func TestResolveWhereArithWithLabels(t *testing.T) {
 	expr := "eth/ipv4@outer/udp/gtp/ipv4@inner/tcp where outer.total_length == inner.total_length + 36"
@@ -764,7 +782,6 @@ func TestResolveStrictArithLintOffByDefault(t *testing.T) {
 	// the typed-OK / silent-wrap contract from §6.1 stays intact.
 	resolveOK(t, "eth/ipv4/tcp where tcp.dport + tcp.sport > 100", nil)
 }
-
 
 func TestResolveAllExamples(t *testing.T) {
 	// Each entry lists: (expr, should resolve?). Examples that require

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -327,9 +327,10 @@ func TestResolvePredicateHasMarksUnsupported(t *testing.T) {
 	}
 }
 
-func TestResolvePredicateInSetBindsAndMarksUnsupported(t *testing.T) {
-	// The field binds (so field-name errors surface here) but codegen +
-	// host map lookup are wired in a later commit, so it's Unsupported.
+func TestResolvePredicateInSetBinds(t *testing.T) {
+	// The field binds (so field-name errors surface here); set existence
+	// and the host slot are validated at codegen (it holds the resolver),
+	// so resolve does NOT flag PredInSet Unsupported.
 	p := resolveOK(t, "eth/ipv4/udp/gtp[teid in @teids]", nil)
 	pr := p.Layers[3].Predicates[0]
 	if pr.Kind != ast.PredInSet || pr.SetName != "teids" {
@@ -338,8 +339,8 @@ func TestResolvePredicateInSetBindsAndMarksUnsupported(t *testing.T) {
 	if pr.Field == nil || pr.Field.Field == nil || pr.Field.Field.Name != "teid" {
 		t.Errorf("field not bound: %+v", pr.Field)
 	}
-	if pr.Unsupported == "" {
-		t.Error("PredInSet should be Unsupported until wired")
+	if pr.Unsupported != "" {
+		t.Errorf("PredInSet should not be Unsupported at resolve, got %q", pr.Unsupported)
 	}
 }
 

--- a/pkg/kunai/resolve/typing.go
+++ b/pkg/kunai/resolve/typing.go
@@ -159,7 +159,6 @@ func exprMaxFieldBits(e *ir.ArithExpr) int {
 	return 0
 }
 
-
 // uintFitsBits reports whether a uint64 literal fits in the unsigned
 // range [0, 2^bits). Negative literals reach this helper as their
 // 2's-complement uint64 representation, in which case the fit check

--- a/pkg/kunai/resolve/typing_test.go
+++ b/pkg/kunai/resolve/typing_test.go
@@ -27,10 +27,10 @@ func TestSplitSliceIntoLDXChunks(t *testing.T) {
 		{32, []chunk{{0, 32}}},
 		{56, []chunk{{0, 32}, {32, 48}, {48, 56}}}, // 4 + 2 + 1
 		{64, []chunk{{0, 64}}},
-		{72, []chunk{{0, 64}, {64, 72}}},        // 8 + 1 byte
-		{80, []chunk{{0, 64}, {64, 80}}},        // 8 + 2
+		{72, []chunk{{0, 64}, {64, 72}}},           // 8 + 1 byte
+		{80, []chunk{{0, 64}, {64, 80}}},           // 8 + 2
 		{88, []chunk{{0, 64}, {64, 80}, {80, 88}}}, // 8 + 2 + 1
-		{96, []chunk{{0, 64}, {64, 96}}},        // 8 + 4
+		{96, []chunk{{0, 64}, {64, 96}}},           // 8 + 4
 		{104, []chunk{{0, 64}, {64, 96}, {96, 104}}},
 		{112, []chunk{{0, 64}, {64, 96}, {96, 112}}},
 		{120, []chunk{{0, 64}, {64, 96}, {96, 112}, {112, 120}}},
@@ -69,13 +69,13 @@ func TestUintFitsBits(t *testing.T) {
 		{443, 16, true},
 		{99999, 16, false},
 		// Negative literals stored as 2's complement.
-		{^uint64(0), 8, true},          // -1 fits any width
+		{^uint64(0), 8, true}, // -1 fits any width
 		{^uint64(0), 16, true},
-		{^uint64(127), 8, true},        // -128 fits int8 range
-		{^uint64(128), 8, false},       // -129 doesn't fit signed int8
-		{^uint64(128), 16, true},       // -129 fits int16
-		{^uint64(32767), 16, true},     // -32768 fits int16
-		{^uint64(32768), 16, false},    // -32769 doesn't
+		{^uint64(127), 8, true},     // -128 fits int8 range
+		{^uint64(128), 8, false},    // -129 doesn't fit signed int8
+		{^uint64(128), 16, true},    // -129 fits int16
+		{^uint64(32767), 16, true},  // -32768 fits int16
+		{^uint64(32768), 16, false}, // -32769 doesn't
 		// 64-bit and wider always succeed (no narrowing happens).
 		{^uint64(0), 64, true},
 	}
@@ -185,9 +185,9 @@ func TestAttachSliceValidation(t *testing.T) {
 		Field: &vocab.Field{Name: "src", Bits: 128},
 	}
 	cases := []struct {
-		name        string
-		idx         *ast.IndexExpr
-		wantError   string
+		name      string
+		idx       *ast.IndexExpr
+		wantError string
 	}{
 		{"exceeds-128", &ast.IndexExpr{IsSlice: true, SliceLo: 0, SliceHi: 200}, "exceeds field width"},
 		{"width-over-128", &ast.IndexExpr{IsSlice: true, SliceLo: 0, SliceHi: 129}, "exceeds field width"},

--- a/pkg/kunai/resolve/where.go
+++ b/pkg/kunai/resolve/where.go
@@ -218,7 +218,6 @@ func (r *resolver) findQuantTarget(c *ir.Condition, pos ast.Position) (*ir.Quant
 	}, nil
 }
 
-
 // resolveArith converts an ast.ArithExpr to ir.ArithExpr, binding every
 // field reference to its owning layer.
 func (r *resolver) resolveArith(a *ast.ArithExpr) (*ir.ArithExpr, error) {


### PR DESCRIPTION
## 概要

v1 の pinned-map set matching (`--set` / `--arg-filter @NAME`) はキーのソースが **fentry 引数** 限定でした。当初動機 (cpu_dispatch 越しの GTP/SRv6 選択キャプチャ) では、照合したい値は**パケット内**にあること (TEID は GTP ヘッダ、SID は IPv6 ヘッダ) が多く、dispatcher が引数で渡してくれる保証はありません。本 PR は **DSL の bracket predicate でパケットフィールドを直接集合照合**できるようにします。

```bash
xdp-ninja set create /sys/fs/bpf/teids --key "teid:u32"
xdp-ninja set add    /sys/fs/bpf/teids teid=0x3039

# fentry 観測でも --mode xdp でも動く。複合キーは 1 角括弧にカンマ併記。
xdp-ninja -p 1661 --set "teids=/sys/fs/bpf/teids" 'eth/ipv4/udp/gtp[teid in @teids]' -w out.pcap
xdp-ninja -i eth0 --mode xdp --set "flows=/sys/fs/bpf/flows" 'eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]'
```

## アーキテクチャ (B: kunai 抽出 + host lookup)

kunai codegen は **map を一切知らない不変条件** (FnMapLookupElem/LoadMapPtr ゼロ、Output に map 参照なし、公開面に map 言及なし) を保ちます。対抗案 A (kunai 内で lookup) は `FnMapLookupElem` が R0(start)/R1(end)/R4(offsetBase) を破壊し、最悪ケースで 512B スタック予算を使い切るためスタックアロケータ再設計になり不採用。

1. **kunai** (`emitInSetPredicate`): フィールドを境界チェック付き load → `HostTo(BE)` で数値 (host order) に正規化 → **host 指定の R10 スロットに store**。map lookup は emit せず、verdict にも影響させない (レイヤ到達失敗時のみ `dslReject`)。抽出は `Output.Extractions` で host に返す。注入面は `codegen.SetSlotResolver` (`caps.Lang.SetSlots`、`ActionFetcher` と同型) で、返すのは int16 offset と幅だけ。
2. **host** (`internal/program/setslots.go`): filter 実行後にそのスロットをキーに `FnMapLookupElem`、miss なら capture skip。事前に buffer を zero 埋め。

### 設計の勘所
- **byte-order 契約**: `set add` は host order (`setmap.BuildKey` の NativeEndian)、パケットは network order。kunai の `HostTo(BE)` + host の native store で一致させる (差分 e2e が守る)。
- **スタック**: 抽出スロットは filter 中に書き filter 後に読むため kunai 領域 `[-56,...)` に置けない。両 attach path で空きの host 領域 `[-40,-24)` を使う → **合計キー 16B / 1 フィールド 8B** の上限。
- **構文**: bracket 専用 (`where` 句不可)。bracket は layer の連言に必ず入るので `@set` は構造的にトップレベル AND = v1「集合は AND」と一致。

## コミット構成
1. `feat(kunai)`: parse/resolve の `PredInSet` 骨格
2. `feat(kunai)`: `emitInSetPredicate` + `SetSlotResolver` + `Output.Extractions` (map 非依存回帰テスト含む)
3. `feat(program)`: host lookup (tracing + XDP-native)、byte-order/runtime add-del の root e2e
4. `test`+docs: 複合キー e2e、slot 割り当て unit、grammar/usage/internals/README
5. `refactor`: /simplify 適用 (lookup tail 共有、遅延確保、ゼロ埋め最小化 等)

## テスト
- **unit**: parser/resolve/codegen。**不変条件回帰** (`@set` 経路が `FnMapLookupElem` を kunai に混入させない) を assert。byte-order swap、Extractions、KunaiStackTop ガード、slot 遅延確保・予算超過・参照 set のみ課金。
- **root BPF e2e**: `gtp[teid in @teids]` で実 eth/ipv4/udp/gtp フレームを member TEID のみ capture、**byte-order 契約**、**runtime add/delete の即時反映** (re-attach 不要)、複合キー。既存 v1 arg-set / multiattach / XDP-native load 回帰 green。

## スコープ外 (合意済み)
- where 句 `in @set`、16B/8B 超のキー (単体 SRv6 SID=16B 抽出)、value tag → pcap-ng interface 分離、外部 mapid 直参照
