### PR TITLE
docs: naturalize the user-facing Japanese DSL guides

### DIFF
--- a/docs/ja/dsl-benchmark.md
+++ b/docs/ja/dsl-benchmark.md
@@ -1,6 +1,6 @@
 # DSL ベンチ方法論
 
-xdp-ninja の DSL (default) と legacy cbpfc (`--cbpf`、tcpdump 構文) を比べたい人向けです。本ドキュメントは再現手順を残すのが目的で、環境依存性が高すぎるため特定環境の数値は載せません。
+xdp-ninja のデフォルトである DSL と、legacy cbpfc (`--cbpf` の tcpdump 構文) を比べたい人向けです。本ドキュメントは再現手順を残すのが目的で、環境依存性が高すぎるため特定環境の数値は載せません。
 
 ## 何を測るか
 
@@ -52,7 +52,7 @@ BenchmarkCompile/dsl/TCP_443-64        49881    4615 ns/op   32.00 insns/op
 傾向は次のとおりです。
 
 - コンパイル時間は DSL のほうが速いです。cbpfc は cBPF → eBPF の純粋トランスパイラで、libpcap 経由のパース → cBPF byte-code → eBPF 命令変換と段が多く、起動コストが見えてきます。DSL は AST → IR → codegen の 3 段ですが、各段が軽量です。
-- 生成命令数は式によって逆転します。簡単な `icmp` (L2 + L3 のみのフィルタ) は cbpfc が短くなります。`tcp port 443` のように L2/L3/L4 の bounds と dispatch を全部展開する式では、cBPF の絶対オフセットアクセスを 1:1 で eBPF に展開するため、cbpfc 側のほうが冗長になる傾向があります。
+- 生成命令数は式によって逆転します。L2 と L3 だけの簡単な `icmp` フィルタは cbpfc が短くなります。`tcp port 443` のように L2/L3/L4 の bounds と dispatch を全部展開する式では、cBPF の絶対オフセットアクセスを 1:1 で eBPF に展開するため、cbpfc 側のほうが冗長になる傾向があります。
 - これらは kernel ホットパスではない数値です。フィルタは load 時に 1 度しかコンパイルされないので、μs オーダーの差は実利用に影響しません。本命は C 軸 (per-packet PPS) です。
 
 cbpfc が読めない式 (MPLS+、VXLAN inner など) は DSL でしか測れません。逆に DSL が読めない式 (tcpdump の `dst host net 10.0.0.0/24`) は cbpfc でしか測れません。同じフィルタを両方で書けるケースだけ、A/B 比較に意味があります。

--- a/docs/ja/dsl-grammar.md
+++ b/docs/ja/dsl-grammar.md
@@ -261,7 +261,7 @@ literal        ::= integer | 'true' | 'false'
 |---|---|---|
 | `const-decl` | `vocab/p4lite/parser.go::parseConst` | `const bit<16> KUNAI_IPV4_ETH_ETHERTYPE = 0x0800;` |
 
-Dispatch 命名規約は次のとおりです。loader が `vocab/loader.go` 内の regex で classify します。inter-layer dispatch の const には `KUNAI_` 接頭辞が必須で、loader は接頭辞を剥がしてから regex に掛けます。value-only const (routing_type / option kind 等) と構造 const (`MAX_DEPTH` / `CHAIN_END`) は無印です。
+Dispatch 命名規約は次のとおりです。loader が `vocab/loader.go` 内の regex で classify します。inter-layer dispatch の const には `KUNAI_` 接頭辞が必須で、loader は接頭辞を剥がしてから regex に掛けます。routing_type や option kind のような value-only const と、`MAX_DEPTH` や `CHAIN_END` のような構造 const は無印です。
 
 | 名前パターン | regex | 意味 |
 |---|---|---|

--- a/docs/ja/dsl-overview.md
+++ b/docs/ja/dsl-overview.md
@@ -1,6 +1,6 @@
 # xdp-ninja DSL ドキュメント
 
-xdp-ninja の filter 式 (DSL) のドキュメント index です。tcpdump 構文 (legacy `--cbpf`) で書きにくい多段カプセル化 (GTP-U / MPLS / VXLAN / SRv6 など) を、プロトコルスタックの形のまま書けるのが目的です。DSL は xdp-ninja の default filter syntax です。
+xdp-ninja の filter 式である DSL のドキュメント index です。GTP-U や MPLS、VXLAN、SRv6 のような多段カプセル化は legacy の `--cbpf` が使う tcpdump 構文では書きにくいので、これをプロトコルスタックの形のまま書けるようにするのが目的です。DSL は xdp-ninja の default filter syntax です。
 
 ## 役割別にどこから読むか
 
@@ -44,9 +44,9 @@ filter expr  →  AST  →  IR (vocab 解決済)  →  asm.Instructions  →  ci
 ```
 
 - `eth/ipv4/tcp[dport==443]` 風の layer chain が書けます。各 layer は vocab `.p4` ファイル (`pkg/kunai/protocols/*.p4`) で定義された protocol です。
-- vocab は p4lite (P4-16 の strict subset) を Go 側の `pkg/kunai/vocab/p4lite/` で parse します。p4c で標準パースできるのが目標です (詳細は internals §5)。
+- vocab は P4-16 の strict subset である p4lite を Go 側の `pkg/kunai/vocab/p4lite/` で parse します。p4c で標準パースできるのが目標です。詳しくは internals §5 を参照してください。
 - 出力は cilium/ebpf の `asm.Instructions` で、target portable な eBPF subprogram です。kunai コアは XDP / tc 等の host 知識を持たず、host adapter は `pkg/kunai/host/<name>/` サブパッケージに局所化しています。`host/xdp` は XDP fentry/fexit、`host/tc` は TC clsact fentry/fexit です。
-- caller (`internal/program/program.go`) は `kunai.Compile(expr, caps)` に host capability (`xdphost.FexitCapabilities()` / `tchost.FexitCapabilities()` 等) を渡すことで host を選びます。zero `Capabilities` だと target-agnostic な filter (action atom 不可) が出ます。
+- caller (`internal/program/program.go`) は `kunai.Compile(expr, caps)` に host capability (`xdphost.FexitCapabilities()` / `tchost.FexitCapabilities()` 等) を渡すことで host を選びます。zero `Capabilities` だと、action atom を使えない target-agnostic な filter が出ます。
 
 ## 関連コード
 

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -416,15 +416,15 @@ tcpdump -r path.pcap.cpu12
 mergecap -w merged.pcap path.pcap.cpu*
 ```
 
-`-w` を付けない場合 (stdout ストリーミング) は、全 CPU を 1 本の pcap-ng ストリームに直列化してマージするので、`sudo xdp-ninja ... | tcpdump -r -` で全コア分が見えます。高レートでは `-w` を使ってください (stdout 直列化はインタラクティブ経路向け)。
+`-w` を付けない場合 (stdout ストリーミング) は、全 CPU を 1 本の pcap-ng ストリームに直列化してマージするので、`sudo xdp-ninja ... | tcpdump -r -` で全コア分が見えます。高レートでは `-w` を使ってください。stdout の直列化はインタラクティブ経路向けです。
 
-注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます (raw-dump は自動マージの対象外)。
+注意点として、`xdp-ninja convert` は `--raw-dump` 用の `.raw` を pcap-ng に変換するサブコマンドで、`.cpuN` pcap-ng shards は処理しません。raw-dump path (`--raw-dump -w foo.raw`) を使う場合は `.cpuN` 分割が同じ命名規則で起こり、`xdp-ninja convert -i foo.raw.cpu0 ...` で 1 個ずつ pcap-ng に変換できます。raw-dump は自動マージの対象外です。
 
 ## 複数の (プログラム, 関数) に同時アタッチする
 
-`-p` と `--func` はどちらも繰り返し指定できます。各 `--func` は、指定した全プログラムのうち **BTF にその関数を持つものすべて**にアタッチされます (無いプログラムはスキップ。どのプログラムにも無い関数名はエラー)。`--func` を省略した場合は各プログラムの entry 関数が対象です。
+`-p` と `--func` はどちらも繰り返し指定できます。各 `--func` は、指定した全プログラムのうち BTF にその関数を持つものすべてにアタッチされます。関数を持たないプログラムはスキップされ、どのプログラムにも無い関数名はエラーになります。`--func` を省略した場合は各プログラムの entry 関数が対象です。
 
-多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムへ散り、さらに noinline サブ関数は呼び出し元プログラムごとに実体を持ちます (例: `pgwu_capture_point_dl` が v4/v6 ハンドラ両方に入る)。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で張れます。
+多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムへ散り、さらに noinline サブ関数は呼び出し元プログラムごとに実体を持ちます。たとえば `pgwu_capture_point_dl` は v4/v6 ハンドラ両方に入ります。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で張れます。
 
 ```bash
 # --list-progs で dispatcher から末端の prog ID を洗い出し
@@ -437,15 +437,15 @@ sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
   --arg-filter "imsi=901040010000005" -w all.pcap
 ```
 
-- 全アタッチポイントが **1本の共有 ringbuf** に emit するので、出力は通常どおり 1 つの pcap に時刻順で入ります (`-w` なら終了時マージ、stdout なら直列化ストリーム)。
+- 全アタッチポイントが 1本の共有 ringbuf に emit するので、出力は通常どおり 1 つの pcap に時刻順で入ります (`-w` なら終了時マージ、stdout なら直列化ストリーム)。
 - `--arg-filter` は関数ごとに BTF を引いて検証・解決されます。同じ param 名が関数によって別の引数位置にあっても正しく効きます。指定した param を持たない関数が混ざるとエラーになります。
 - XDP と tc のターゲット混在は不可 (別々に起動してください)。`--arg-echo` は単一 (プログラム, 関数) のみ。
 
 ## 集合マッチ (`--set` / `--arg-filter @NAME`)
 
-`--arg-filter "imsi=X"` は値を命令列に焼き込むため、値を変えるたびに re-attach が要ります。**pinned BPF hash map を「集合」として参照**すると、購読者リスト(IMSI 群など)をパケットごとの O(1) lookup で照合でき、**エントリの追加・削除はキャプチャ中でも即時反映**されます (re-attach 不要)。
+`--arg-filter "imsi=X"` は値を命令列に焼き込むため、値を変えるたびに re-attach が要ります。pinned BPF hash map を集合として参照すると、IMSI 群などの購読者リストをパケットごとの O(1) lookup で照合でき、エントリの追加・削除はキャプチャ中でも即時反映されます。この場合は re-attach が不要です。
 
-map の**キーが照合する値そのもの** (スカラ or struct 複合キー)、value は小さな tag です。複合キーのフィールド間は AND (1 lookup)、OR はエントリを複数入れて表現します (集合=直和)。部分キーは不可です。
+map のキーが照合する値そのもので、スカラまたは struct 複合キーになります。value は小さな tag です。複合キーのフィールド間は AND で 1 lookup し、OR はエントリを複数入れて表現します。すなわち集合は直和です。部分キーは不可です。
 
 ```bash
 # 1) 集合を作る (BTF 付き hash map を pin)
@@ -465,16 +465,16 @@ sudo xdp-ninja set list /sys/fs/bpf/flows
 sudo xdp-ninja set schema /sys/fs/bpf/flows
 ```
 
-- **キーの対応付け**: 既定はキーの BTF フィールド名と fentry 引数名の同名一致。名前が違うときは `--set "flows=/sys/fs/bpf/flows,key(imsi=arg:subscriber,teid=arg:teid)"` と明示します (`()` は bash メタ文字なのでクオート必須)。
-- `@NAME` は他の `--arg-filter` と AND 合成。`--set` は複数定義できます。
-- 引数がキーのフィールドより広い場合 (u64 引数 → u32 フィールド) は切り詰めになるためエラーです。
+- キーの対応付けは、既定ではキーの BTF フィールド名と fentry 引数名を同名で一致させます。名前が違うときは `--set "flows=/sys/fs/bpf/flows,key(imsi=arg:subscriber,teid=arg:teid)"` と明示します。`()` は bash のメタ文字なのでクオートが必須です。
+- `@NAME` は他の `--arg-filter` と AND で合成されます。`--set` は複数定義できます。
+- 引数がキーのフィールドより広い場合、たとえば u64 引数を u32 フィールドに入れる場合は切り詰めになるためエラーです。
 - 外部で作った pinned map も、hash 型で BTF キー (整数 or 整数のみの struct、各 1/2/4/8B、キー全体 64B 以下) を持っていれば参照できます。BTF 無しの map は `set create` で作り直してください。
-- 外部から直接書く場合 (bpftool 等) は**パディングのゼロ埋めが必須**です (hash はキー全バイトをハッシュするため、パディングが非ゼロだと永遠に一致しません)。`xdp-ninja set add` はこれを自動で保証します。
-- スキーマ (キー幅・オフセット) は `set schema` で確認できます。`bpftool map dump pinned <path>` もフィールド名付きで整形表示されます (合成 BTF の効能)。
+- bpftool などで外部から直接書く場合は、パディングのゼロ埋めが必須です。hash はキー全バイトをハッシュするため、パディングが非ゼロだと永遠に一致しません。`xdp-ninja set add` はこれを自動で保証します。
+- スキーマとしてキー幅やオフセットは `set schema` で確認できます。`bpftool map dump pinned <path>` も、合成 BTF のおかげでフィールド名付きで整形表示されます。
 
 ## 関数引数の値を覗く (`--arg-echo`)
 
-`--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、「そもそも引数にどんな値が乗っているか」を確認するのに使います (例: IMSI が 10 進なのか TBCD なのか)。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。
+`--func` で狙ったサブ関数の整数引数が、実際にどんな値で呼ばれているかを見る診断モードです。`--arg-filter "imsi=..."` が当たらないとき、そもそも引数にどんな値が乗っているかを確認するのに使います。たとえば IMSI が 10 進なのか TBCD なのかを見分けられます。パケットキャプチャはせず、引数だけを専用 ringbuf に流して表示します。
 
 ```bash
 # 対象関数の絞り込み可能な整数引数を確認
@@ -487,9 +487,9 @@ sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --arg-echo -c 1
 #   pgwu_capture_point_ul: imsi=901040010000005 (0x3337db9b97685) teid=12345 (0x3039)
 ```
 
-- `--func` 必須。表示対象は `--list-params` が挙げる整数引数 (10 進と 16 進を併記)。
-- `--arg-filter` と併用すると、その述語に**マッチした呼び出しだけ**を表示します。値の当たりを付けてから絞り込む、という使い方ができます。
-- 連続して同じ引数タプルが来た場合は 1 行に畳んで `(xN)` と表示します。`-c N` で N 件表示したら終了、無指定なら Ctrl-C まで。
+- `--func` は必須です。表示対象は `--list-params` が挙げる整数引数で、10 進と 16 進を併記します。
+- `--arg-filter` と併用すると、その述語にマッチした呼び出しだけを表示します。値の当たりを付けてから絞り込むという使い方ができます。
+- 連続して同じ引数タプルが来た場合は 1 行に畳んで `(xN)` と表示します。`-c N` を付けると N 件表示したところで終了し、無指定なら Ctrl-C まで続きます。
 - リーダは capture path と同じ in-tree の `fastrb` (mmap + epoll) を使います。
 
 ## Performance flags
@@ -545,7 +545,7 @@ xdp-ninja --dump-asm full --mode exit "eth/ipv4/tcp where action == XDP_DROP"
 
 DSL の parse error / type error も同じ経路を通るので、`--dump-asm filter` は構文/型のサニティチェックにも使えます。load 前に stderr に error を出して exit 1 します。
 
-## 仕組みのざっくり
+## 仕組みの概要
 
 1. one-liner を AST → IR に解決します。vocab に照らして protocol/field/dispatch をバインドします。
    - 同時に型システムが異幅 cmp の widening、リテラルの fit-check、Bool/Action/CIDR の文脈チェックを行います ([`dsl-types.md`](./dsl-types.md))。

--- a/docs/ja/dsl-vocab-authoring.md
+++ b/docs/ja/dsl-vocab-authoring.md
@@ -101,7 +101,7 @@ header mpls_h {
 
 const は名前のパターンによって loader の `vocab/loader.go::classifyConsts` が分類します。`<SELF>` はファイル名の uppercase、`<PARENT>` は親プロトコル名の uppercase で underscore を含まない単一トークン、`<FIELD>` は親 primary header のフィールド名の uppercase で underscore を含められます。
 
-`KUNAI_` は inter-layer dispatch のマーカです。親レイヤから自分へ遷移する dispatch const (Field / NoCheck / self-dispatch) には `KUNAI_` を付け、それ以外の value-only const と構造 const には付けません。value-only とは、select-match の値そのものを表す const のことで、routing_type や option kind、next-header 種別など、親が実在プロトコルでない (phantom parent) ものを指します (例: `SRV6_ROUTING_TYPE`、`IPV4_OPT_RR`、`IPV6_NH_FRAGMENT`)。これらは parser block の select arm に畳み込まれるだけで dispatch edge ではないので無印にします。`<SELF>_MAX_DEPTH` / `<SELF>_CHAIN_END_<FIELD>` / `<SELF>_OPT_*` のような構造 const も同様に無印です。loader はこの規約を強制します。dispatch の形 (実在親への Field / NO_CHECK) なのに `KUNAI_` が無いとエラーになり、逆に `KUNAI_` 付きで親が非プロトコルだとエラーになります。
+`KUNAI_` は inter-layer dispatch のマーカです。親レイヤから自分へ遷移する dispatch const (Field / NoCheck / self-dispatch) には `KUNAI_` を付け、それ以外の value-only const と構造 const には付けません。value-only とは、select-match の値そのものを表す const のことで、routing_type や option kind、next-header 種別など、親が実在プロトコルでない phantom parent のものを指します。たとえば `SRV6_ROUTING_TYPE`、`IPV4_OPT_RR`、`IPV6_NH_FRAGMENT` がこれにあたります。これらは parser block の select arm に畳み込まれるだけで dispatch edge ではないので無印にします。`<SELF>_MAX_DEPTH` / `<SELF>_CHAIN_END_<FIELD>` / `<SELF>_OPT_*` のような構造 const も同様に無印です。loader はこの規約を強制します。dispatch の形 (実在親への Field / NO_CHECK) なのに `KUNAI_` が無いとエラーになり、逆に `KUNAI_` 付きで親が非プロトコルだとエラーになります。
 
 | パターン | 型 | 意味 |
 |---|---|---|
@@ -328,11 +328,11 @@ parser SRv6Parser(packet_in pkt,
 }
 ```
 
-- `pc.set((bit<8>)(hdr.<F> + K))` の bare-cast add 形 (scale=1) が、walk を element-driven にします。1 セグメント push ごとに counter が 1 減るので、`any` / `all` の要素数を loader が seed フィールド (`last_entry`) と addend (`+1`) から導出します。`@kunai_stack_count` は不要です。
+- `pc.set((bit<8>)(hdr.<F> + K))` の bare-cast add 形 (scale=1) が、walk を element-driven にします。1 セグメント push ごとに counter が 1 減るので、`any` / `all` の要素数を loader が seed フィールドの `last_entry` と addend の `+1` から導出します。`@kunai_stack_count` は不要です。
 - 同じ count から next-header 位置も決まります。codegen は walk 収束後に R4 を `layer_entry + 8 + (last_entry+1)*16` へ再アンカーします。これは TLV を持たない SRH では segment list の末尾がそのまま next header になる (RFC 8754) という性質を使っています。
 - `consume_seg` がスタックを push するので、`@kunai_layout` も不要です。スタックの base は push state の layer-entry offset (= `sizeof(srv6_h)` = 8) から自然に決まります。
-- TLV 付き SRH を chain で越えるのは非対応です。R4 が segment list の末尾で止まるため、Padding や HMAC のような末尾 TLV を持つ SRH の後ろに別レイヤを繋ぐ (`eth/ipv6/srv6/tcp` 等) と next header に届きません。TLV サポートは RFC 8754 Section 2 で optional なので、規約準拠の制限です。segment 参照 (`srv6.segments[N]`、`any` / `all`) は末尾 TLV の有無に関わらず正しく動きます。
-- `routing_type 4` は `SRV6_ROUTING_TYPE` という value-only const で名付けます。phantom parent (`ROUTING`) なので `KUNAI_` は付けません (§5)。loader は select arm に畳み込むだけで dispatch edge とは扱いません。
+- TLV 付き SRH を chain で越えるのは非対応です。R4 が segment list の末尾で止まるため、Padding や HMAC のような末尾 TLV を持つ SRH の後ろに `eth/ipv6/srv6/tcp` のように別レイヤを繋ぐと next header に届きません。TLV サポートは RFC 8754 Section 2 で optional なので、規約準拠の制限です。`srv6.segments[N]` や `any` / `all` といった segment 参照は末尾 TLV の有無に関わらず正しく動きます。
+- `routing_type 4` は `SRV6_ROUTING_TYPE` という value-only const で名付けます。phantom parent の `ROUTING` なので `KUNAI_` は付けません。詳しくは §5 を参照してください。loader は select arm に畳み込むだけで dispatch edge とは扱いません。
 
 ### 7.5 GTP 型の gated single aux
 
@@ -584,8 +584,8 @@ make p4c-check                                          # P4-16 互換
 
 ## 関連ドキュメント
 
-- [`dsl-internals.md` §3](./dsl-internals.md#3-vocab-開発ガイド)。dispatch type の設計判断など概念面のサマリ
-- [`dsl-internals.md` §5](./dsl-internals.md#5-p4-16-互換性)。p4lite と P4-16 の互換性監査
-- [`dsl-internals.md` §6](./dsl-internals.md#6-可変長構造の分類と表現)。可変長 8 機構の分類、設計議論、codegen 上の扱い
-- [`dsl-grammar.md`](./dsl-grammar.md)。filter 式と p4lite の formal EBNF
-- [`dsl-usage.md`](./dsl-usage.md)。対応プロトコル一覧を含むユーザー向け CLI ガイド
+- [`dsl-internals.md` §3](./dsl-internals.md#3-vocab-開発ガイド)。dispatch type の設計判断など概念面をまとめています
+- [`dsl-internals.md` §5](./dsl-internals.md#5-p4-16-互換性)。p4lite と P4-16 の互換性を監査しています
+- [`dsl-internals.md` §6](./dsl-internals.md#6-可変長構造の分類と表現)。可変長 8 機構の分類、設計議論、codegen 上の扱いを説明しています
+- [`dsl-grammar.md`](./dsl-grammar.md)。filter 式と p4lite の formal EBNF を定義しています
+- [`dsl-usage.md`](./dsl-usage.md)。対応プロトコル一覧を含むユーザー向けの CLI ガイドです


### PR DESCRIPTION
## 概要

ユーザー向けの日本語 DSL ガイドに natural-ja の文体パスをかけ、生成 AI 臭さを除いて JTF 日本語標準スタイルに寄せました。**内容・数値・コマンド・コードブロック・テーブル・リンクは一切変えていません**(フェンス内コードは 6 ファイルとも md5 一致で無改変を確認済み)。

## 変更したパターン

- キーワードの太字と、太字+コロンの箇条書き見出し(`- **foo**: …`)を平文の説明に
- 「」引用を除去(地の文へ、必要箇所は「すなわち」で apposition 化)
- 文末・並置の丸括弧補足を文中へ織り込み(`(re-attach 不要)` → 「この場合は re-attach が不要です」など)
- 体言止めの箇条書きを述語止めに(「同名一致。」→「同名一致します。」)
- 口語見出しを平易語に(「仕組みのざっくり」→「仕組みの概要」)

## 対象ファイル

| ファイル | 主な変更 |
|---|---|
| dsl-usage.md | 太字コロン見出し・「」・体言止め・文末括弧・口語見出し |
| dsl-vocab-authoring.md | 補足括弧の inline 化、関連ドキュメント一覧の体言止め除去 |
| dsl-overview.md | 冒頭 prose の並置/例示括弧を地の文化 |
| dsl-benchmark.md | 補足括弧 2 箇所(数値・条件は不変) |
| dsl-grammar.md | EBNF 外散文の補足括弧 1 箇所(EBNF/テーブルは不変) |
| tuning.md | 変更なし(既に準拠) |

## 対象外(別パス)

密な内部リファレンス(dsl-internals / dsl-types / kunai-*-deepdive / capture-datapath 等)は意味変質リスクとレビュー負荷が高いため、今回は温存しています。

## 補足

v2 機能 PR (#61) で追加した DSL パケットフィールド集合マッチの新規節は、そちらの PR 側で既に natural-ja 適用済みです。本 PR は既存プローズのみが対象です。
