### PR TITLE
feat: 128-bit (IPv6/SRv6 SID) packet-field set matching (ipv6[dst in @sids])

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ sudo xdp-ninja set create /sys/fs/bpf/teids --key "teid:u32"
 sudo xdp-ninja set add /sys/fs/bpf/teids teid=0x3039
 sudo xdp-ninja -p 1661 --set "teids=/sys/fs/bpf/teids" \
   'eth/ipv4/udp/gtp[teid in @teids]' -w teids.pcap
+
+# A 128-bit SRv6 SID (the IPv6 destination): key type "ipv6", value an IPv6 literal
+sudo xdp-ninja set create /sys/fs/bpf/sids --key "dst:ipv6"
+sudo xdp-ninja set add /sys/fs/bpf/sids dst=fc00::1
+sudo xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
+  'eth/ipv6[dst in @sids]'
 ```
 
 ### Filter syntax

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -38,7 +38,7 @@ var setCreateCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name: "key", Required: true,
-			Usage: "key schema, e.g. \"imsi:u64,teid:u32\" (types: u8/u16/u32/u64; fields are laid out with natural alignment)",
+			Usage: "key schema, e.g. \"imsi:u64,teid:u32\" (types: u8/u16/u32/u64, or ipv6 for a 16-byte address / SRv6 SID; fields are laid out with natural alignment)",
 		},
 		&cli.StringFlag{
 			Name: "value", Value: "tag:u32",

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -141,7 +141,7 @@ func setOpen(cmd *cli.Command) (*setmap.Definition, error) {
 
 // setOpenWithFields opens the map and parses the trailing field=value
 // args (with the optional tag=N split off).
-func setOpenWithFields(cmd *cli.Command) (*setmap.Definition, map[string]uint64, uint64, error) {
+func setOpenWithFields(cmd *cli.Command) (*setmap.Definition, map[string]string, uint64, error) {
 	def, err := setOpen(cmd)
 	if err != nil {
 		return nil, nil, 0, err

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -38,7 +38,7 @@ var setCreateCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name: "key", Required: true,
-			Usage: "key schema, e.g. \"imsi:u64,teid:u32\" (types: u8/u16/u32/u64, or ipv6 for a 16-byte address / SRv6 SID; fields are laid out with natural alignment)",
+			Usage: "key schema, e.g. \"imsi:u64,teid:u32\" (types: u8/u16/u32/u64, or ipv6 for a 16-byte address / SRv6 SID; numeric fields align to their width, ipv6 to 8)",
 		},
 		&cli.StringFlag{
 			Name: "value", Value: "tag:u32",

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -498,11 +498,17 @@ sudo xdp-ninja -p 1661 --set "teids=/sys/fs/bpf/teids" \
 sudo xdp-ninja set create /sys/fs/bpf/flows --key "teid:u32,msg_type:u8"
 sudo xdp-ninja -i eth0 --mode xdp --set "flows=/sys/fs/bpf/flows" \
   'eth/ipv4/udp/gtp[teid in @flows, msg_type in @flows]'
+
+# 128bit の SRv6 SID (= IPv6 宛先) を照合する。キー型は ipv6、値は IPv6 リテラル
+sudo xdp-ninja set create /sys/fs/bpf/sids --key "dst:ipv6"
+sudo xdp-ninja set add    /sys/fs/bpf/sids dst=fc00::1
+sudo xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
+  'eth/ipv6[dst in @sids]'
 ```
 
-- 同名一致します。DSL のフィールド名がそのまま集合キーのフィールド名になり、`gtp[teid in @teids]` は集合キー `teid` を引きます。
-- エンディアンはツールが吸収します。パケットは network order、`set add` は host order で書きますが、変換をツールが合わせるので、利用者は普段どおりの数値で `set add` するだけで済みます。
-- キー幅には上限があります。パケット由来キーはホストスタックの空き領域を使うため、合計 16 バイトまでです。TEID の 4 バイト、IMSI の 8 バイト、TEID と IMSI を合わせた 12 バイトはいずれも収まります。1 フィールドは 8 バイトまでで、16 バイトの SRv6 SID を単体で扱うのは後日対応とします。
+- 同名一致します。DSL のフィールド名がそのまま集合キーのフィールド名になり、`gtp[teid in @teids]` は集合キー `teid` を引きます。ただしスカラ集合、つまりフィールドが 1 個のキーは名前がラベルにすぎないので、`ipv6[dst in @sids]` を `sid:ipv6` のようにフィールド名が違うキーへ当てても照合できます。
+- エンディアンはツールが吸収します。数値フィールドはパケットが network order、`set add` は host order で書きますが変換をツールが合わせるので、利用者は普段どおりの数値で `set add` するだけで済みます。`ipv6` フィールドは IPv6 アドレスのバイト列そのものが値なので、パケットも `set add fc00::1` も同じ network order のまま照合します。
+- キー幅には上限があります。パケット由来キーはホストスタックの空き領域を使うため、合計 16 バイトまでです。TEID の 4 バイト、IMSI の 8 バイト、TEID と IMSI を合わせた 12 バイト、SRv6 SID の 16 バイトはいずれも収まります。数値フィールドは 1 個 8 バイトまで、`ipv6` フィールドは 16 バイトで、16 バイトのキーはそれ 1 個で予算を使い切ります。
 - `@NAME` は他の bracket 条件やレイヤ条件と AND で合成します。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
 - `in @NAME` は必ず通るレイヤ、すなわち quantifier のない `QuantOne` のレイヤにのみ書けます。`vlan[...]?` のような optional や繰り返しのレイヤ、`(vlan[...]|qinq)` のような alternation の枝は、そのレイヤが不在でもフィルタが成立しうるため、抽出が走らずキーが未書き込みになる可能性があり、reject されます。
 - 引数由来の `--arg-filter @NAME` は entry/exit 専用のままです。パケット由来の DSL `@NAME` は entry/exit と `--mode xdp` の両方で動きます。

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -77,7 +77,7 @@ func TestBpfDSLSetMatchPacketField(t *testing.T) {
 	t.Cleanup(set.Def.Close)
 
 	const memberPort = uint16(0x01BB) // 443
-	if err := set.Def.Add(map[string]uint64{"dport": uint64(memberPort)}, 1); err != nil {
+	if err := set.Def.Add(map[string]string{"dport": fmt.Sprintf("%d", memberPort)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
@@ -104,7 +104,7 @@ func TestBpfDSLSetMatchPacketField(t *testing.T) {
 
 	// (b) runtime add takes effect without re-attach.
 	const addedPort = uint16(8080)
-	if err := set.Def.Add(map[string]uint64{"dport": uint64(addedPort)}, 2); err != nil {
+	if err := set.Def.Add(map[string]string{"dport": fmt.Sprintf("%d", addedPort)}, 2); err != nil {
 		t.Fatalf("runtime Add: %v", err)
 	}
 	runTCP(t, prog, 0x66, 1234, addedPort)
@@ -114,7 +114,7 @@ func TestBpfDSLSetMatchPacketField(t *testing.T) {
 	}
 
 	// (c) runtime delete stops matching.
-	if err := set.Def.Delete(map[string]uint64{"dport": uint64(addedPort)}); err != nil {
+	if err := set.Def.Delete(map[string]string{"dport": fmt.Sprintf("%d", addedPort)}); err != nil {
 		t.Fatalf("runtime Delete: %v", err)
 	}
 	runTCP(t, prog, 0x77, 1234, addedPort)
@@ -143,7 +143,7 @@ func TestBpfDSLSetMatchCompositeKey(t *testing.T) {
 	t.Cleanup(set.Def.Close)
 
 	const sport, dport = uint16(1111), uint16(443)
-	if err := set.Def.Add(map[string]uint64{"sport": uint64(sport), "dport": uint64(dport)}, 1); err != nil {
+	if err := set.Def.Add(map[string]string{"sport": fmt.Sprintf("%d", sport), "dport": fmt.Sprintf("%d", dport)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -1,8 +1,10 @@
 package program
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"testing"
 
@@ -162,5 +164,97 @@ func TestBpfDSLSetMatchCompositeKey(t *testing.T) {
 	markers := drainMarkers(t, probe, 1)
 	if markers[0x44] != 1 || markers[0x55] != 0 {
 		t.Fatalf("markers = %v, want one 0x44 and no 0x55", markers)
+	}
+}
+
+// ipv6Packet builds an eth/ipv6 frame: byte 0 is a per-run marker, and the
+// IPv6 destination (an SRv6 active SID) is written network-order at bytes
+// 38..54 (ipv6 header offset 24) so the DSL extraction sees the wire bytes.
+func ipv6Packet(marker byte, dst net.IP) []byte {
+	p := make([]byte, 64)
+	p[0] = marker
+	binary.BigEndian.PutUint16(p[12:14], 0x86DD) // ethertype IPv6
+	p[14] = 0x60                                 // IPv6 version 6
+	p[20] = 59                                   // next header = No Next Header
+	copy(p[38:54], dst.To16())                   // ipv6 dst = SID (network order)
+	return p
+}
+
+func runIPv6(t *testing.T, prog *ebpf.Program, marker byte, dst string) {
+	t.Helper()
+	if _, err := prog.Run(&ebpf.RunOptions{Data: ipv6Packet(marker, net.ParseIP(dst))}); err != nil {
+		t.Fatalf("test-run: %v", err)
+	}
+}
+
+// TestBpfDSLSetMatchIPv6Dst is the end-to-end for a 16-byte packet-field
+// key: ipv6[dst in @sids] matches the IPv6 destination (an SRv6 active
+// SID) against a pinned set keyed by an ipv6 field. It also locks the
+// byte-order contract via a differential check and covers runtime updates.
+func TestBpfDSLSetMatchIPv6Dst(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslsid_%d", os.Getpid())
+	if err := setmap.Create(pin, "sid:ipv6", "", 16); err != nil {
+		t.Skipf("creating pinned ipv6 set map: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	set, err := setmap.OpenSet(setmap.SpecRef{Name: "sids", Path: pin})
+	if err != nil {
+		t.Fatalf("OpenSet: %v", err)
+	}
+	t.Cleanup(set.Def.Close)
+
+	const memberSID = "fc00::1"
+
+	// Differential: the wire bytes of the member SID must equal the key
+	// BuildKey writes for it (extraction side vs add side agree, no swap).
+	key, err := set.Def.BuildKey(map[string]string{"sid": memberSID})
+	if err != nil {
+		t.Fatalf("BuildKey: %v", err)
+	}
+	if !bytes.Equal(key, net.ParseIP(memberSID).To16()) {
+		t.Fatalf("key %x != wire bytes %x (byte-order mismatch)", key, net.ParseIP(memberSID).To16())
+	}
+
+	if err := set.Def.Add(map[string]string{"sid": memberSID}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_set_e2e_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_set_e2e_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv6[dst in @sids]", nil, true, []*setmap.Set{set})
+	if err != nil {
+		t.Fatalf("LoadMultiEntry with ipv6 set: %v", err)
+	}
+	defer func() { _ = probe.Close() }()
+
+	// Membership gates capture: fc00::1 is a member, fc00::2 is not.
+	runIPv6(t, prog, 0x44, memberSID) // member, captured
+	runIPv6(t, prog, 0x55, "fc00::2") // non-member, dropped
+	markers := drainMarkers(t, probe, 1)
+	if markers[0x44] != 1 {
+		t.Fatalf("markers = %v, want one 0x44 (member SID captured)", markers)
+	}
+	if markers[0x55] != 0 {
+		t.Fatalf("markers = %v: non-member SID was captured", markers)
+	}
+
+	// Runtime add / delete without re-attach.
+	const addedSID = "2001:db8::9"
+	if err := set.Def.Add(map[string]string{"sid": addedSID}, 2); err != nil {
+		t.Fatalf("runtime Add: %v", err)
+	}
+	runIPv6(t, prog, 0x66, addedSID)
+	if markers = drainMarkers(t, probe, 1); markers[0x66] != 1 {
+		t.Fatalf("markers after runtime add = %v, want one 0x66", markers)
+	}
+	if err := set.Def.Delete(map[string]string{"sid": addedSID}); err != nil {
+		t.Fatalf("runtime Delete: %v", err)
+	}
+	runIPv6(t, prog, 0x77, addedSID)
+	if markers = drainMarkers(t, probe, 0); markers[0x77] != 0 {
+		t.Fatalf("markers after runtime delete = %v, want no 0x77", markers)
 	}
 }

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -182,7 +182,11 @@ func ipv6Packet(marker byte, dst net.IP) []byte {
 
 func runIPv6(t *testing.T, prog *ebpf.Program, marker byte, dst string) {
 	t.Helper()
-	if _, err := prog.Run(&ebpf.RunOptions{Data: ipv6Packet(marker, net.ParseIP(dst))}); err != nil {
+	ip := net.ParseIP(dst)
+	if ip == nil {
+		t.Fatalf("invalid test IPv6 %q", dst)
+	}
+	if _, err := prog.Run(&ebpf.RunOptions{Data: ipv6Packet(marker, ip)}); err != nil {
 		t.Fatalf("test-run: %v", err)
 	}
 }

--- a/internal/program/setfilter_test.go
+++ b/internal/program/setfilter_test.go
@@ -79,7 +79,7 @@ func TestBpfSetFilterLookupAndRuntimeUpdate(t *testing.T) {
 	}
 
 	const inImsi, inTeid = uint64(0x1111222233334444), uint32(0x3039)
-	if err := def.Add(map[string]uint64{"imsi": inImsi, "teid": uint64(inTeid)}, 1); err != nil {
+	if err := def.Add(map[string]string{"imsi": fmt.Sprintf("%d", inImsi), "teid": fmt.Sprintf("%d", inTeid)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestBpfSetFilterLookupAndRuntimeUpdate(t *testing.T) {
 
 	// (b) runtime add: no re-attach, next call is captured.
 	const newImsi = uint64(0x00000000000000aa)
-	if err := def.Add(map[string]uint64{"imsi": newImsi, "teid": uint64(inTeid)}, 2); err != nil {
+	if err := def.Add(map[string]string{"imsi": fmt.Sprintf("%d", newImsi), "teid": fmt.Sprintf("%d", inTeid)}, 2); err != nil {
 		t.Fatalf("runtime Add: %v", err)
 	}
 	runWithKey(t, prog, newImsi, inTeid)
@@ -126,7 +126,7 @@ func TestBpfSetFilterLookupAndRuntimeUpdate(t *testing.T) {
 	}
 
 	// (c) runtime delete: the same key stops matching.
-	if err := def.Delete(map[string]uint64{"imsi": newImsi, "teid": uint64(inTeid)}); err != nil {
+	if err := def.Delete(map[string]string{"imsi": fmt.Sprintf("%d", newImsi), "teid": fmt.Sprintf("%d", inTeid)}); err != nil {
 		t.Fatalf("runtime Delete: %v", err)
 	}
 	runWithKey(t, prog, newImsi, inTeid)
@@ -157,7 +157,7 @@ func TestBpfSetFilterScalarKey(t *testing.T) {
 	}
 
 	const member = uint64(0x00000000000000bb)
-	if err := def.Add(map[string]uint64{"imsi": member}, 1); err != nil {
+	if err := def.Add(map[string]string{"imsi": fmt.Sprintf("%d", member)}, 1); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -65,14 +65,21 @@ func newPktSetSlots(sets []*setmap.Set) *pktSetSlots {
 // can surface a clear message instead of a downstream codegen error.
 func (p *pktSetSlots) allocErr() error { return p.err }
 
-// keyAlign is the alignment a key buffer needs: its widest field width
-// (each field sits at a natural offset within the key, so an aligned base
-// keeps every field aligned). Fields are 1/2/4/8 bytes; defaults to 1.
+// keyAlign is the alignment a key buffer needs so every field's store is
+// naturally aligned: the widest field width, capped at 8. The cap matters
+// for a 16-byte field (an IPv6 SID), which kunai stores as two aligned
+// DWords — those need only 8-alignment, and pktSetKeyFloor (-40) is
+// 8-aligned but not 16-aligned, so aligning the base to 16 would push it
+// below the floor and spuriously overflow the 16-byte budget.
 func keyAlign(def *setmap.Definition) int16 {
 	align := int16(1)
 	for _, f := range def.Fields {
-		if int16(f.Size) > align {
-			align = int16(f.Size)
+		w := int16(f.Size)
+		if w > 8 {
+			w = 8
+		}
+		if w > align {
+			align = w
 		}
 	}
 	return align

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -65,21 +65,16 @@ func newPktSetSlots(sets []*setmap.Set) *pktSetSlots {
 // can surface a clear message instead of a downstream codegen error.
 func (p *pktSetSlots) allocErr() error { return p.err }
 
-// keyAlign is the alignment a key buffer needs so every field's store is
-// naturally aligned: the widest field width, capped at 8. The cap matters
-// for a 16-byte field (an IPv6 SID), which kunai stores as two aligned
-// DWords — those need only 8-alignment, and pktSetKeyFloor (-40) is
-// 8-aligned but not 16-aligned, so aligning the base to 16 would push it
-// below the floor and spuriously overflow the 16-byte budget.
+// keyAlign is the alignment a key buffer base needs so every field's store
+// is naturally aligned: the widest field store-alignment (KeyField.Align,
+// which is <= 8 for every field — a 16-byte ipv6 field aligns to 8, not
+// 16, since it is stored as two DWords). Aligning to 8 rather than 16
+// matters because pktSetKeyFloor (-40) is 8- but not 16-aligned.
 func keyAlign(def *setmap.Definition) int16 {
 	align := int16(1)
 	for _, f := range def.Fields {
-		w := int16(f.Size)
-		if w > 8 {
-			w = 8
-		}
-		if w > align {
-			align = w
+		if a := int16(f.Align()); a > align {
+			align = a
 		}
 	}
 	return align

--- a/internal/program/setslots.go
+++ b/internal/program/setslots.go
@@ -98,8 +98,16 @@ func (p *pktSetSlots) SlotFor(setName, fieldName string) (off int16, size int, o
 	if !ok {
 		return 0, 0, false
 	}
-	f, ok := s.def.Field(fieldName)
-	if !ok {
+	// A scalar set has a single key field whose name is just a label, so
+	// the DSL field it is matched against need not share that name (e.g.
+	// `ipv6[dst in @sids]` against a `sid:ipv6` scalar key). Mirrors the
+	// arg-based scalar-positional rule.
+	var f setmap.KeyField
+	if s.def.IsScalar {
+		f = s.def.Fields[0]
+	} else if kf, found := s.def.Field(fieldName); found {
+		f = kf
+	} else {
 		return 0, 0, false
 	}
 	if !s.allocated {

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -13,6 +13,34 @@ func setWithKey(name string, keySize uint32, fields []setmap.KeyField) *setmap.S
 	}
 }
 
+func TestPktSetSlotsSixteenByteKeyFits(t *testing.T) {
+	// A lone 16-byte SID key must allocate at base -40 (filling the whole
+	// [-40,-24) budget) and not overflow: keyAlign caps at 8, so the base
+	// is not rounded to a 16 boundary (which would land at -48, below the
+	// floor). The two DWord stores at -40/-32 are 8-aligned.
+	sets := []*setmap.Set{
+		setWithKey("sids", 16, []setmap.KeyField{{Name: "sid", Off: 0, Size: 16}}),
+	}
+	p := newPktSetSlots(sets)
+	off, size, ok := p.SlotFor("sids", "sid")
+	if !ok {
+		t.Fatalf("16-byte key should fit; allocErr=%v", p.allocErr())
+	}
+	if off != pktSetKeyFloor {
+		t.Errorf("base = %d, want %d", off, pktSetKeyFloor)
+	}
+	if size != 16 {
+		t.Errorf("size = %d, want 16", size)
+	}
+	if off%8 != 0 {
+		t.Errorf("base %d not 8-aligned (DWord stores would be rejected)", off)
+	}
+	// Zeroing covers the full 16-byte region (both dwords).
+	if got := len(p.emitPktSetKeyZeroing([]string{"sids"})); got != 3 { // Mov + 2 dword stores
+		t.Errorf("zeroing insns = %d, want 3 (mov + 2 dword stores)", got)
+	}
+}
+
 func TestPktSetSlotsAllocatesDistinctBuffersLazily(t *testing.T) {
 	sets := []*setmap.Set{
 		setWithKey("a", 8, []setmap.KeyField{{Name: "teid", Off: 0, Size: 4}, {Name: "mt", Off: 4, Size: 1}}),

--- a/internal/program/setslots_test.go
+++ b/internal/program/setslots_test.go
@@ -19,7 +19,7 @@ func TestPktSetSlotsSixteenByteKeyFits(t *testing.T) {
 	// is not rounded to a 16 boundary (which would land at -48, below the
 	// floor). The two DWord stores at -40/-32 are 8-aligned.
 	sets := []*setmap.Set{
-		setWithKey("sids", 16, []setmap.KeyField{{Name: "sid", Off: 0, Size: 16}}),
+		setWithKey("sids", 16, []setmap.KeyField{{Name: "sid", Off: 0, Size: 16, IsBytes: true}}),
 	}
 	p := newPktSetSlots(sets)
 	off, size, ok := p.SlotFor("sids", "sid")

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -252,11 +252,13 @@ func (d *Definition) BuildKey(values map[string]string) ([]byte, error) {
 		if f.IsBytes {
 			// ipv6: a network-order 16-byte address, copied verbatim so it
 			// matches the wire bytes kunai extracts (never endianness-flipped).
-			ip := net.ParseIP(raw).To16()
-			if ip == nil {
-				return nil, fmt.Errorf("key field %s: invalid IPv6 address %q", f.Name, raw)
+			// Reject an IPv4 literal (net.ParseIP would silently widen it to
+			// an IPv4-mapped ::ffff:a.b.c.d, an unexpected key).
+			parsed := net.ParseIP(raw)
+			if parsed == nil || parsed.To4() != nil {
+				return nil, fmt.Errorf("key field %s: %q is not an IPv6 address", f.Name, raw)
 			}
-			copy(key[f.Off:f.Off+f.Size], ip)
+			copy(key[f.Off:f.Off+f.Size], parsed.To16())
 		} else {
 			v, perr := parseUint(raw)
 			if perr != nil {

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -349,7 +349,11 @@ func (d *Definition) List(out io.Writer) error {
 	for iter.Next(&key, &val) {
 		var parts []string
 		for _, f := range d.Fields {
-			parts = append(parts, fmt.Sprintf("%s=%d", f.Name, getUint(key[f.Off:f.Off+f.Size])))
+			if f.IsBytes {
+				parts = append(parts, fmt.Sprintf("%s=%s", f.Name, net.IP(key[f.Off:f.Off+f.Size]).String()))
+			} else {
+				parts = append(parts, fmt.Sprintf("%s=%d", f.Name, getUint(key[f.Off:f.Off+f.Size])))
+			}
 		}
 		parts = append(parts, fmt.Sprintf("tag=%d", getUint(val)))
 		_, _ = fmt.Fprintln(out, strings.Join(parts, " "))
@@ -376,7 +380,7 @@ func (d *Definition) Schema(w io.Writer) {
 	_, _ = fmt.Fprintf(w, "hash map: key %d B, value %d B, max_entries %d\n",
 		d.KeySize, d.Map.ValueSize(), d.Map.MaxEntries())
 	for _, f := range d.Fields {
-		_, _ = fmt.Fprintf(w, "  %-20s u%-3d offset %d\n", f.Name, f.Size*8, f.Off)
+		_, _ = fmt.Fprintf(w, "  %-20s %-5s offset %d\n", f.Name, f.typeName(), f.Off)
 	}
 	_, _ = fmt.Fprintf(w, "note: entries must zero all padding bytes (hash covers the full key)\n")
 }

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -20,8 +20,18 @@ import (
 type FieldSpec struct {
 	Name    string
 	Size    uint32
-	Align   uint32 // natural alignment: Size for ints, 1 for the ipv6 byte array
-	IsBytes bool   // network-order byte string (ipv6): copied, never putUint'd
+	IsBytes bool // network-order byte string (ipv6): copied, never putUint'd
+}
+
+// fieldAlign is a field's layout/store alignment: its width for a numeric
+// field, but 8 for a 16-byte ipv6 field — kunai extracts it as two 8-byte
+// DWord stores, which require an 8-aligned offset. (This is the store
+// granularity, not the C `unsigned char[16]` type alignment of 1.)
+func fieldAlign(size uint32, isBytes bool) uint32 {
+	if isBytes {
+		return 8
+	}
+	return size
 }
 
 // ParseSchema parses "imsi:u64,teid:u32" into field specs.
@@ -42,11 +52,11 @@ func ParseSchema(s string) ([]FieldSpec, error) {
 			return nil, fmt.Errorf("duplicate field name %q in schema", name)
 		}
 		seen[name] = true
-		size, align, isBytes, err := typeKind(strings.TrimSpace(typ))
+		size, isBytes, err := typeKind(strings.TrimSpace(typ))
 		if err != nil {
 			return nil, fmt.Errorf("schema entry %q: %w", ent, err)
 		}
-		out = append(out, FieldSpec{Name: name, Size: size, Align: align, IsBytes: isBytes})
+		out = append(out, FieldSpec{Name: name, Size: size, IsBytes: isBytes})
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("empty schema")
@@ -54,25 +64,24 @@ func ParseSchema(s string) ([]FieldSpec, error) {
 	return out, nil
 }
 
-// typeKind resolves a schema type token to its width, natural alignment,
-// and whether it is a network-order byte string. `ipv6` is a 16-byte
-// address (an SRv6 SID): align 1, byte-string semantics, distinct from a
-// numeric u128 because it is copied verbatim in wire order, never
-// endianness-converted.
-func typeKind(t string) (size, align uint32, isBytes bool, err error) {
+// typeKind resolves a schema type token to its width and whether it is a
+// network-order byte string. `ipv6` is a 16-byte address (an SRv6 SID):
+// byte-string semantics, distinct from a numeric u128 because it is copied
+// verbatim in wire order, never endianness-converted.
+func typeKind(t string) (size uint32, isBytes bool, err error) {
 	switch t {
 	case "u8":
-		return 1, 1, false, nil
+		return 1, false, nil
 	case "u16":
-		return 2, 2, false, nil
+		return 2, false, nil
 	case "u32":
-		return 4, 4, false, nil
+		return 4, false, nil
 	case "u64":
-		return 8, 8, false, nil
+		return 8, false, nil
 	case "ipv6":
-		return 16, 1, true, nil
+		return 16, true, nil
 	}
-	return 0, 0, false, fmt.Errorf("unsupported type %q (u8/u16/u32/u64/ipv6)", t)
+	return 0, false, fmt.Errorf("unsupported type %q (u8/u16/u32/u64/ipv6)", t)
 }
 
 // layout assigns naturally-aligned offsets and returns the padded total
@@ -83,11 +92,12 @@ func layout(fields []FieldSpec) ([]KeyField, uint32) {
 	var cur, maxAlign uint32
 	maxAlign = 1
 	for _, f := range fields {
-		if f.Align > maxAlign {
-			maxAlign = f.Align
+		align := fieldAlign(f.Size, f.IsBytes)
+		if align > maxAlign {
+			maxAlign = align
 		}
-		cur = (cur + f.Align - 1) &^ (f.Align - 1)
-		out = append(out, KeyField{Name: f.Name, Off: cur, Size: f.Size, Align: f.Align, IsBytes: f.IsBytes})
+		cur = (cur + align - 1) &^ (align - 1)
+		out = append(out, KeyField{Name: f.Name, Off: cur, Size: f.Size, IsBytes: f.IsBytes})
 		cur += f.Size
 	}
 	total := (cur + maxAlign - 1) &^ (maxAlign - 1)
@@ -242,11 +252,11 @@ func (d *Definition) BuildKey(values map[string]string) ([]byte, error) {
 		if f.IsBytes {
 			// ipv6: a network-order 16-byte address, copied verbatim so it
 			// matches the wire bytes kunai extracts (never endianness-flipped).
-			ip := net.ParseIP(raw)
-			if ip == nil || ip.To16() == nil {
+			ip := net.ParseIP(raw).To16()
+			if ip == nil {
 				return nil, fmt.Errorf("key field %s: invalid IPv6 address %q", f.Name, raw)
 			}
-			copy(key[f.Off:f.Off+f.Size], ip.To16())
+			copy(key[f.Off:f.Off+f.Size], ip)
 		} else {
 			v, perr := parseUint(raw)
 			if perr != nil {

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"net"
 	"strconv"
 	"strings"
 
@@ -17,8 +18,10 @@ import (
 
 // FieldSpec is one `name:type` element of a --key/--value schema string.
 type FieldSpec struct {
-	Name string
-	Size uint32
+	Name    string
+	Size    uint32
+	Align   uint32 // natural alignment: Size for ints, 1 for the ipv6 byte array
+	IsBytes bool   // network-order byte string (ipv6): copied, never putUint'd
 }
 
 // ParseSchema parses "imsi:u64,teid:u32" into field specs.
@@ -39,11 +42,11 @@ func ParseSchema(s string) ([]FieldSpec, error) {
 			return nil, fmt.Errorf("duplicate field name %q in schema", name)
 		}
 		seen[name] = true
-		size, err := typeSize(strings.TrimSpace(typ))
+		size, align, isBytes, err := typeKind(strings.TrimSpace(typ))
 		if err != nil {
 			return nil, fmt.Errorf("schema entry %q: %w", ent, err)
 		}
-		out = append(out, FieldSpec{Name: name, Size: size})
+		out = append(out, FieldSpec{Name: name, Size: size, Align: align, IsBytes: isBytes})
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("empty schema")
@@ -51,18 +54,25 @@ func ParseSchema(s string) ([]FieldSpec, error) {
 	return out, nil
 }
 
-func typeSize(t string) (uint32, error) {
+// typeKind resolves a schema type token to its width, natural alignment,
+// and whether it is a network-order byte string. `ipv6` is a 16-byte
+// address (an SRv6 SID): align 1, byte-string semantics, distinct from a
+// numeric u128 because it is copied verbatim in wire order, never
+// endianness-converted.
+func typeKind(t string) (size, align uint32, isBytes bool, err error) {
 	switch t {
 	case "u8":
-		return 1, nil
+		return 1, 1, false, nil
 	case "u16":
-		return 2, nil
+		return 2, 2, false, nil
 	case "u32":
-		return 4, nil
+		return 4, 4, false, nil
 	case "u64":
-		return 8, nil
+		return 8, 8, false, nil
+	case "ipv6":
+		return 16, 1, true, nil
 	}
-	return 0, fmt.Errorf("unsupported type %q (u8/u16/u32/u64)", t)
+	return 0, 0, false, fmt.Errorf("unsupported type %q (u8/u16/u32/u64/ipv6)", t)
 }
 
 // layout assigns naturally-aligned offsets and returns the padded total
@@ -73,12 +83,11 @@ func layout(fields []FieldSpec) ([]KeyField, uint32) {
 	var cur, maxAlign uint32
 	maxAlign = 1
 	for _, f := range fields {
-		align := f.Size
-		if align > maxAlign {
-			maxAlign = align
+		if f.Align > maxAlign {
+			maxAlign = f.Align
 		}
-		cur = (cur + align - 1) &^ (align - 1)
-		out = append(out, KeyField{Name: f.Name, Off: cur, Size: f.Size})
+		cur = (cur + f.Align - 1) &^ (f.Align - 1)
+		out = append(out, KeyField{Name: f.Name, Off: cur, Size: f.Size, Align: f.Align, IsBytes: f.IsBytes})
 		cur += f.Size
 	}
 	total := (cur + maxAlign - 1) &^ (maxAlign - 1)
@@ -90,13 +99,25 @@ func intType(size uint32) *btf.Int {
 	return &btf.Int{Name: fmt.Sprintf("__u%d", size*8), Size: size, Encoding: btf.Unsigned}
 }
 
+// fieldType is the BTF type for one key field: an unsigned integer for
+// numeric fields, or a `__u8[N]` array for byte-string (ipv6) fields. The
+// array form is faithful to C's `struct in6_addr` (unsigned char[16]),
+// is alignment-1, and prints in memory (= network) order in bpftool,
+// unlike a __u128 integer which tools would render byte-reversed.
+func fieldType(f KeyField) btf.Type {
+	if f.IsBytes {
+		return &btf.Array{Index: intType(4), Type: intType(1), Nelems: f.Size}
+	}
+	return intType(f.Size)
+}
+
 // synthesizeStruct builds the BTF struct for a schema.
 func synthesizeStruct(name string, fields []KeyField, size uint32) *btf.Struct {
 	st := &btf.Struct{Name: name, Size: size}
 	for _, f := range fields {
 		st.Members = append(st.Members, btf.Member{
 			Name:   f.Name,
-			Type:   intType(f.Size),
+			Type:   fieldType(f),
 			Offset: btf.Bits(f.Off * 8),
 		})
 	}
@@ -108,7 +129,7 @@ func synthesizeStruct(name string, fields []KeyField, size uint32) *btf.Struct {
 // works); anything else becomes a struct named structName.
 func synthesizeType(structName string, fields []KeyField, size uint32) btf.Type {
 	if len(fields) == 1 && fields[0].Off == 0 && fields[0].Size == size {
-		return &btf.Typedef{Name: fields[0].Name, Type: intType(size)}
+		return &btf.Typedef{Name: fields[0].Name, Type: fieldType(fields[0])}
 	}
 	return synthesizeStruct(structName, fields, size)
 }
@@ -142,8 +163,9 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 	}
 	valFields, valSize := layout(valSpecs)
 	// The value is a single integer tag (add/list round-trip it as one
-	// number); a multi-field or odd-width value has no tag semantics.
-	if len(valFields) != 1 || !validFieldSize(valSize) {
+	// number); a multi-field, odd-width, or ipv6 value has no tag
+	// semantics. ipv6 is a key-only type.
+	if len(valFields) != 1 || valFields[0].IsBytes || !validValueFieldSize(valSize) {
 		return fmt.Errorf("--value must be a single u8/u16/u32/u64 tag field, got %q", valueSchema)
 	}
 
@@ -167,27 +189,29 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 // the entry value (tag) rather than a key field.
 const reservedTagName = "tag"
 
-// ParseFieldValues parses `field=value` CLI args (decimal or 0x hex) and
-// splits off the reserved `tag=` value assignment.
-func ParseFieldValues(args []string) (fields map[string]uint64, tag uint64, hasTag bool, err error) {
-	fields = map[string]uint64{}
+// ParseFieldValues splits `field=value` CLI args, keeping each key field's
+// value as a raw string (BuildKey parses it per the schema, since only the
+// schema knows whether a field is numeric or an IPv6 address). The
+// reserved `tag=` assignment is always numeric, so it is parsed here.
+func ParseFieldValues(args []string) (fields map[string]string, tag uint64, hasTag bool, err error) {
+	fields = map[string]string{}
 	for _, a := range args {
 		name, vs, ok := strings.Cut(a, "=")
 		if !ok || name == "" || vs == "" {
 			return nil, 0, false, fmt.Errorf("argument %q: want field=value", a)
 		}
-		v, perr := parseUint(vs)
-		if perr != nil {
-			return nil, 0, false, fmt.Errorf("argument %q: %w", a, perr)
-		}
 		if name == reservedTagName {
+			v, perr := parseUint(vs)
+			if perr != nil {
+				return nil, 0, false, fmt.Errorf("argument %q: %w", a, perr)
+			}
 			tag, hasTag = v, true
 			continue
 		}
 		if _, dup := fields[name]; dup {
 			return nil, 0, false, fmt.Errorf("field %q given twice", name)
 		}
-		fields[name] = v
+		fields[name] = vs
 	}
 	return fields, tag, hasTag, nil
 }
@@ -207,18 +231,32 @@ func parseUint(s string) (uint64, error) {
 // every provided name must be a key field; values must fit their field.
 // Padding is zeroed — hash maps hash all key_size bytes, so a non-zero
 // pad byte would make lookups silently miss.
-func (d *Definition) BuildKey(values map[string]uint64) ([]byte, error) {
+func (d *Definition) BuildKey(values map[string]string) ([]byte, error) {
 	key := make([]byte, int(d.KeySize))
 	used := map[string]bool{}
 	for _, f := range d.Fields {
-		v, ok := values[f.Name]
+		raw, ok := values[f.Name]
 		if !ok {
-			return nil, fmt.Errorf("missing key field %s (u%d at offset %d) — partial keys are not supported", f.Name, f.Size*8, f.Off)
+			return nil, fmt.Errorf("missing key field %s (%s at offset %d) — partial keys are not supported", f.Name, f.typeName(), f.Off)
 		}
-		if f.Size < 8 && v >= 1<<(8*f.Size) {
-			return nil, fmt.Errorf("value %d does not fit key field %s (u%d)", v, f.Name, f.Size*8)
+		if f.IsBytes {
+			// ipv6: a network-order 16-byte address, copied verbatim so it
+			// matches the wire bytes kunai extracts (never endianness-flipped).
+			ip := net.ParseIP(raw)
+			if ip == nil || ip.To16() == nil {
+				return nil, fmt.Errorf("key field %s: invalid IPv6 address %q", f.Name, raw)
+			}
+			copy(key[f.Off:f.Off+f.Size], ip.To16())
+		} else {
+			v, perr := parseUint(raw)
+			if perr != nil {
+				return nil, fmt.Errorf("key field %s: %w", f.Name, perr)
+			}
+			if f.Size < 8 && v >= 1<<(8*f.Size) {
+				return nil, fmt.Errorf("value %d does not fit key field %s (u%d)", v, f.Name, f.Size*8)
+			}
+			putUint(key[f.Off:f.Off+f.Size], v)
 		}
-		putUint(key[f.Off:f.Off+f.Size], v)
 		used[f.Name] = true
 	}
 	for name := range values {
@@ -229,10 +267,18 @@ func (d *Definition) BuildKey(values map[string]uint64) ([]byte, error) {
 	return key, nil
 }
 
+// typeName renders a key field's schema type token (u8/…/u64 or ipv6).
+func (f KeyField) typeName() string {
+	if f.IsBytes {
+		return "ipv6"
+	}
+	return fmt.Sprintf("u%d", f.Size*8)
+}
+
 func (d *Definition) fieldNames() string {
 	names := make([]string, len(d.Fields))
 	for i, f := range d.Fields {
-		names[i] = fmt.Sprintf("%s:u%d", f.Name, f.Size*8)
+		names[i] = f.Name + ":" + f.typeName()
 	}
 	return strings.Join(names, ", ")
 }
@@ -257,7 +303,7 @@ func putUint(buf []byte, v uint64) {
 // odd or multi-field value.
 func (d *Definition) tagWidth() (uint32, error) {
 	w := d.Map.ValueSize()
-	if !validFieldSize(w) {
+	if !validValueFieldSize(w) {
 		return 0, fmt.Errorf("map value is %d bytes; tag add/list needs a single u8/u16/u32/u64 value", w)
 	}
 	return w, nil
@@ -265,7 +311,7 @@ func (d *Definition) tagWidth() (uint32, error) {
 
 // Add inserts (or updates) one entry. The value is the tag zero-extended
 // to the map's value size (default tag 1 = plain presence).
-func (d *Definition) Add(values map[string]uint64, tag uint64) error {
+func (d *Definition) Add(values map[string]string, tag uint64) error {
 	key, err := d.BuildKey(values)
 	if err != nil {
 		return err
@@ -283,7 +329,7 @@ func (d *Definition) Add(values map[string]uint64, tag uint64) error {
 }
 
 // Delete removes one entry.
-func (d *Definition) Delete(values map[string]uint64) error {
+func (d *Definition) Delete(values map[string]string) error {
 	key, err := d.BuildKey(values)
 	if err != nil {
 		return err

--- a/internal/setmap/setmap.go
+++ b/internal/setmap/setmap.go
@@ -30,9 +30,13 @@ type KeyField struct {
 	Name    string
 	Off     uint32 // byte offset within the key
 	Size    uint32 // 1, 2, 4, 8, or 16 (ipv6)
-	Align   uint32 // natural alignment: Size for ints, 1 for the ipv6 array
 	IsBytes bool   // network-order byte string (ipv6): copied verbatim
 }
+
+// Align is the field's layout/store alignment: its width for numeric
+// fields, 8 for a 16-byte ipv6 field (extracted as two 8-byte DWord
+// stores, which need an 8-aligned offset).
+func (f KeyField) Align() uint32 { return fieldAlign(f.Size, f.IsBytes) }
 
 // Definition is an opened set map plus its resolved key schema.
 type Definition struct {
@@ -182,32 +186,33 @@ func describe(m *ebpf.Map) (*Definition, error) {
 	def := &Definition{Map: m, KeySize: m.KeySize()}
 	switch t := btf.UnderlyingType(keyType).(type) {
 	case *btf.Int, *btf.Array:
-		size, align, isBytes, ok := resolveFieldType(keyType)
+		size, isBytes, ok := resolveFieldType(keyType)
 		if !ok {
 			return nil, fmt.Errorf("scalar key BTF %s is not a supported key field (u8/u16/u32/u64 or __u8[16])", keyType)
 		}
-		def.Fields = []KeyField{{Name: scalarKeyName(keyType), Off: 0, Size: size, Align: align, IsBytes: isBytes}}
+		def.Fields = []KeyField{{Name: scalarKeyName(keyType), Off: 0, Size: size, IsBytes: isBytes}}
 		def.IsScalar = true
 	case *btf.Struct:
 		for _, mem := range t.Members {
 			if mem.BitfieldSize != 0 {
 				return nil, fmt.Errorf("key field %s: bitfields are not supported", mem.Name)
 			}
-			size, align, isBytes, ok := resolveFieldType(mem.Type)
+			size, isBytes, ok := resolveFieldType(mem.Type)
 			if !ok {
 				return nil, fmt.Errorf("key field %s: only u8/u16/u32/u64 or __u8[16] fields are supported (got %s)", mem.Name, mem.Type)
 			}
-			off := mem.Offset.Bytes()
+			f := KeyField{Name: mem.Name, Off: mem.Offset.Bytes(), Size: size, IsBytes: isBytes}
 			// The extraction stores each field with a naturally-aligned,
-			// in-bounds store; reject layouts (e.g. __attribute__((packed)))
-			// that would otherwise produce a misaligned or OOB stack write.
-			if off%align != 0 {
-				return nil, fmt.Errorf("key field %s: offset %d is not aligned to %d (packed keys are not supported)", mem.Name, off, align)
+			// in-bounds store; reject layouts (e.g. __attribute__((packed)),
+			// or an ipv6 member not at an 8-aligned offset) that would
+			// otherwise produce a misaligned or OOB stack write.
+			if f.Off%f.Align() != 0 {
+				return nil, fmt.Errorf("key field %s: offset %d is not aligned to %d (packed keys are not supported)", mem.Name, f.Off, f.Align())
 			}
-			if off+size > def.KeySize {
+			if f.Off+f.Size > def.KeySize {
 				return nil, fmt.Errorf("key field %s: extends past the %d-byte key", mem.Name, def.KeySize)
 			}
-			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: off, Size: size, Align: align, IsBytes: isBytes})
+			def.Fields = append(def.Fields, f)
 		}
 		if len(def.Fields) == 0 {
 			return nil, fmt.Errorf("key struct %s has no fields", t.Name)
@@ -222,18 +227,18 @@ func describe(m *ebpf.Map) (*Definition, error) {
 // unsigned integer, or a `__u8[16]` array (an IPv6 address / SRv6 SID,
 // treated as a network-order byte string). Must stay in lockstep with
 // fieldType (the synthesis side) — the round-trip test guards it.
-func resolveFieldType(t btf.Type) (size, align uint32, isBytes, ok bool) {
+func resolveFieldType(t btf.Type) (size uint32, isBytes, ok bool) {
 	switch u := btf.UnderlyingType(t).(type) {
 	case *btf.Int:
 		if validValueFieldSize(u.Size) { // 1/2/4/8 — a __u128 int is not a key field
-			return u.Size, u.Size, false, true
+			return u.Size, false, true
 		}
 	case *btf.Array:
 		if el, isInt := btf.UnderlyingType(u.Type).(*btf.Int); isInt && el.Size == 1 && u.Nelems == 16 {
-			return 16, 1, true, true
+			return 16, true, true
 		}
 	}
-	return 0, 0, false, false
+	return 0, false, false
 }
 
 // scalarUnnamed is the placeholder name for a bare-integer key with no

--- a/internal/setmap/setmap.go
+++ b/internal/setmap/setmap.go
@@ -27,9 +27,11 @@ const MaxKeySize = 64
 // KeyField is one member of the set's key schema, resolved from the
 // map's BTF key type.
 type KeyField struct {
-	Name string
-	Off  uint32 // byte offset within the key
-	Size uint32 // 1, 2, 4 or 8
+	Name    string
+	Off     uint32 // byte offset within the key
+	Size    uint32 // 1, 2, 4, 8, or 16 (ipv6)
+	Align   uint32 // natural alignment: Size for ints, 1 for the ipv6 array
+	IsBytes bool   // network-order byte string (ipv6): copied verbatim
 }
 
 // Definition is an opened set map plus its resolved key schema.
@@ -179,44 +181,59 @@ func describe(m *ebpf.Map) (*Definition, error) {
 
 	def := &Definition{Map: m, KeySize: m.KeySize()}
 	switch t := btf.UnderlyingType(keyType).(type) {
-	case *btf.Int:
-		if !validFieldSize(t.Size) {
-			return nil, fmt.Errorf("scalar key size %d is not 1/2/4/8", t.Size)
+	case *btf.Int, *btf.Array:
+		size, align, isBytes, ok := resolveFieldType(keyType)
+		if !ok {
+			return nil, fmt.Errorf("scalar key BTF %s is not a supported key field (u8/u16/u32/u64 or __u8[16])", keyType)
 		}
-		name := scalarKeyName(keyType)
-		def.Fields = []KeyField{{Name: name, Off: 0, Size: t.Size}}
+		def.Fields = []KeyField{{Name: scalarKeyName(keyType), Off: 0, Size: size, Align: align, IsBytes: isBytes}}
 		def.IsScalar = true
 	case *btf.Struct:
 		for _, mem := range t.Members {
 			if mem.BitfieldSize != 0 {
 				return nil, fmt.Errorf("key field %s: bitfields are not supported", mem.Name)
 			}
-			it, ok := btf.UnderlyingType(mem.Type).(*btf.Int)
+			size, align, isBytes, ok := resolveFieldType(mem.Type)
 			if !ok {
-				return nil, fmt.Errorf("key field %s: only integer fields are supported (got %s)", mem.Name, mem.Type)
-			}
-			if !validFieldSize(it.Size) {
-				return nil, fmt.Errorf("key field %s: size %d is not 1/2/4/8", mem.Name, it.Size)
+				return nil, fmt.Errorf("key field %s: only u8/u16/u32/u64 or __u8[16] fields are supported (got %s)", mem.Name, mem.Type)
 			}
 			off := mem.Offset.Bytes()
-			// emitSetFilters stores each field with a naturally-aligned,
+			// The extraction stores each field with a naturally-aligned,
 			// in-bounds store; reject layouts (e.g. __attribute__((packed)))
 			// that would otherwise produce a misaligned or OOB stack write.
-			if off%it.Size != 0 {
-				return nil, fmt.Errorf("key field %s: offset %d is not aligned to its %d-byte width (packed keys are not supported)", mem.Name, off, it.Size)
+			if off%align != 0 {
+				return nil, fmt.Errorf("key field %s: offset %d is not aligned to %d (packed keys are not supported)", mem.Name, off, align)
 			}
-			if off+it.Size > def.KeySize {
+			if off+size > def.KeySize {
 				return nil, fmt.Errorf("key field %s: extends past the %d-byte key", mem.Name, def.KeySize)
 			}
-			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: off, Size: it.Size})
+			def.Fields = append(def.Fields, KeyField{Name: mem.Name, Off: off, Size: size, Align: align, IsBytes: isBytes})
 		}
 		if len(def.Fields) == 0 {
 			return nil, fmt.Errorf("key struct %s has no fields", t.Name)
 		}
 	default:
-		return nil, fmt.Errorf("key BTF type %s is not a struct or integer", keyType)
+		return nil, fmt.Errorf("key BTF type %s is not a struct, integer, or byte array", keyType)
 	}
 	return def, nil
+}
+
+// resolveFieldType classifies a key field's BTF type: a 1/2/4/8-byte
+// unsigned integer, or a `__u8[16]` array (an IPv6 address / SRv6 SID,
+// treated as a network-order byte string). Must stay in lockstep with
+// fieldType (the synthesis side) — the round-trip test guards it.
+func resolveFieldType(t btf.Type) (size, align uint32, isBytes, ok bool) {
+	switch u := btf.UnderlyingType(t).(type) {
+	case *btf.Int:
+		if validValueFieldSize(u.Size) { // 1/2/4/8 — a __u128 int is not a key field
+			return u.Size, u.Size, false, true
+		}
+	case *btf.Array:
+		if el, isInt := btf.UnderlyingType(u.Type).(*btf.Int); isInt && el.Size == 1 && u.Nelems == 16 {
+			return 16, 1, true, true
+		}
+	}
+	return 0, 0, false, false
 }
 
 // scalarUnnamed is the placeholder name for a bare-integer key with no
@@ -233,7 +250,10 @@ func scalarKeyName(t btf.Type) string {
 	return scalarUnnamed
 }
 
-func validFieldSize(n uint32) bool {
+// validValueFieldSize gates a value (tag) field width: the tag round-trips
+// through putUint/getUint as a uint64, so only 1/2/4/8. The key side uses
+// resolveFieldType, which additionally admits the 16-byte ipv6 array.
+func validValueFieldSize(n uint32) bool {
 	return n == 1 || n == 2 || n == 4 || n == 8
 }
 

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -1,8 +1,12 @@
 package setmap
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf"
 )
 
 func TestParseSetSpec(t *testing.T) {
@@ -87,7 +91,7 @@ func TestBuildKeyPaddingAndErrors(t *testing.T) {
 		},
 	}
 
-	key, err := def.BuildKey(map[string]uint64{"imsi": 0x0102030405060708, "teid": 0x3039})
+	key, err := def.BuildKey(map[string]string{"imsi": "0x0102030405060708", "teid": "0x3039"})
 	if err != nil {
 		t.Fatalf("BuildKey: %v", err)
 	}
@@ -102,16 +106,58 @@ func TestBuildKeyPaddingAndErrors(t *testing.T) {
 	}
 
 	// partial key → error naming the missing field
-	if _, err := def.BuildKey(map[string]uint64{"imsi": 1}); err == nil || !strings.Contains(err.Error(), "teid") {
+	if _, err := def.BuildKey(map[string]string{"imsi": "1"}); err == nil || !strings.Contains(err.Error(), "teid") {
 		t.Errorf("partial key err = %v, want mention of teid", err)
 	}
 	// unknown field
-	if _, err := def.BuildKey(map[string]uint64{"imsi": 1, "teid": 2, "bogus": 3}); err == nil || !strings.Contains(err.Error(), "bogus") {
+	if _, err := def.BuildKey(map[string]string{"imsi": "1", "teid": "2", "bogus": "3"}); err == nil || !strings.Contains(err.Error(), "bogus") {
 		t.Errorf("unknown field err = %v, want mention of bogus", err)
 	}
 	// value too wide for field
-	if _, err := def.BuildKey(map[string]uint64{"imsi": 1, "teid": 1 << 40}); err == nil || !strings.Contains(err.Error(), "does not fit") {
+	if _, err := def.BuildKey(map[string]string{"imsi": "1", "teid": "1099511627776"}); err == nil || !strings.Contains(err.Error(), "does not fit") {
 		t.Errorf("overflow err = %v, want 'does not fit'", err)
+	}
+}
+
+func TestParseSchemaIPv6(t *testing.T) {
+	specs, err := ParseSchema("sid:ipv6")
+	if err != nil {
+		t.Fatalf("ParseSchema: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("specs = %+v", specs)
+	}
+	if f := specs[0]; f.Name != "sid" || f.Size != 16 || f.Align != 1 || !f.IsBytes {
+		t.Errorf("spec = %+v, want {sid 16 align1 bytes}", f)
+	}
+}
+
+func TestBuildKeyIPv6NetworkOrder(t *testing.T) {
+	def := &Definition{
+		KeySize: 16,
+		Fields:  []KeyField{{Name: "sid", Off: 0, Size: 16, Align: 1, IsBytes: true}},
+	}
+	key, err := def.BuildKey(map[string]string{"sid": "fc00::1"})
+	if err != nil {
+		t.Fatalf("BuildKey: %v", err)
+	}
+	// Network order, verbatim: fc 00 00 ... 00 01 (matches wire bytes).
+	want := make([]byte, 16)
+	want[0] = 0xfc
+	want[15] = 0x01
+	if !bytes.Equal(key, want) {
+		t.Errorf("key = %x, want %x", key, want)
+	}
+	// invalid literal
+	if _, err := def.BuildKey(map[string]string{"sid": "nope"}); err == nil || !strings.Contains(err.Error(), "invalid IPv6") {
+		t.Errorf("invalid-IP err = %v", err)
+	}
+}
+
+func TestCreateRejectsIPv6Value(t *testing.T) {
+	// ipv6 is a key-only type; the value guard runs before map creation.
+	if err := Create("/sys/fs/bpf/unused", "sid:ipv6", "tag:ipv6", 8); err == nil || !strings.Contains(err.Error(), "single u8/u16/u32/u64 tag") {
+		t.Errorf("ipv6 value err = %v", err)
 	}
 }
 
@@ -120,7 +166,7 @@ func TestParseFieldValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseFieldValues: %v", err)
 	}
-	if fields["imsi"] != 999990000000001 || fields["teid"] != 0x3039 {
+	if fields["imsi"] != "999990000000001" || fields["teid"] != "0x3039" {
 		t.Errorf("fields = %v", fields)
 	}
 	if !hasTag || tag != 7 {
@@ -170,5 +216,36 @@ func TestCreateRejectsMultiFieldValue(t *testing.T) {
 func TestParseSchemaRejectsDuplicateField(t *testing.T) {
 	if _, err := ParseSchema("imsi:u64,imsi:u32"); err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Errorf("dup field err = %v, want 'duplicate'", err)
+	}
+}
+
+// TestIPv6BTFRoundTrip pins that the synthesize side (fieldType, __u8[16]
+// array) and the describe side (resolveFieldType) agree: a map created
+// with an ipv6 key reads back as a 16-byte byte-string scalar field.
+func TestIPv6BTFRoundTrip(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to create a BPF map")
+	}
+	fields, size := layout([]FieldSpec{{Name: "sid", Size: 16, Align: 1, IsBytes: true}})
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name: "xdpninja_sidtest", Type: ebpf.Hash,
+		KeySize: size, ValueSize: 4, MaxEntries: 4,
+		Key:   synthesizeType("xdpninja_set_key", fields, size),
+		Value: intType(4),
+	})
+	if err != nil {
+		t.Fatalf("NewMap: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	def, err := describe(m)
+	if err != nil {
+		t.Fatalf("describe: %v", err)
+	}
+	if !def.IsScalar || len(def.Fields) != 1 {
+		t.Fatalf("def = %+v, want a single scalar field", def)
+	}
+	if f := def.Fields[0]; f.Name != "sid" || f.Size != 16 || f.Off != 0 || !f.IsBytes {
+		t.Errorf("field = %+v, want {sid 16 off0 bytes}", f)
 	}
 }

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -128,7 +128,7 @@ func TestParseSchemaIPv6(t *testing.T) {
 		t.Fatalf("specs = %+v", specs)
 	}
 	if f := specs[0]; f.Name != "sid" || f.Size != 16 || !f.IsBytes {
-		t.Errorf("spec = %+v, want {sid 16 align1 bytes}", f)
+		t.Errorf("spec = %+v, want {sid, size 16, bytes}", f)
 	}
 }
 

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -127,7 +127,7 @@ func TestParseSchemaIPv6(t *testing.T) {
 	if len(specs) != 1 {
 		t.Fatalf("specs = %+v", specs)
 	}
-	if f := specs[0]; f.Name != "sid" || f.Size != 16 || f.Align != 1 || !f.IsBytes {
+	if f := specs[0]; f.Name != "sid" || f.Size != 16 || !f.IsBytes {
 		t.Errorf("spec = %+v, want {sid 16 align1 bytes}", f)
 	}
 }
@@ -135,7 +135,7 @@ func TestParseSchemaIPv6(t *testing.T) {
 func TestBuildKeyIPv6NetworkOrder(t *testing.T) {
 	def := &Definition{
 		KeySize: 16,
-		Fields:  []KeyField{{Name: "sid", Off: 0, Size: 16, Align: 1, IsBytes: true}},
+		Fields:  []KeyField{{Name: "sid", Off: 0, Size: 16, IsBytes: true}},
 	}
 	key, err := def.BuildKey(map[string]string{"sid": "fc00::1"})
 	if err != nil {
@@ -225,7 +225,7 @@ func newIPv6SetMap(t *testing.T) *ebpf.Map {
 	if os.Geteuid() != 0 {
 		t.Skip("needs root to create a BPF map")
 	}
-	fields, size := layout([]FieldSpec{{Name: "sid", Size: 16, Align: 1, IsBytes: true}})
+	fields, size := layout([]FieldSpec{{Name: "sid", Size: 16, IsBytes: true}})
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Name: "xdpninja_sidtest", Type: ebpf.Hash,
 		KeySize: size, ValueSize: 4, MaxEntries: 4,

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -149,8 +149,12 @@ func TestBuildKeyIPv6NetworkOrder(t *testing.T) {
 		t.Errorf("key = %x, want %x", key, want)
 	}
 	// invalid literal
-	if _, err := def.BuildKey(map[string]string{"sid": "nope"}); err == nil || !strings.Contains(err.Error(), "invalid IPv6") {
+	if _, err := def.BuildKey(map[string]string{"sid": "nope"}); err == nil || !strings.Contains(err.Error(), "not an IPv6") {
 		t.Errorf("invalid-IP err = %v", err)
+	}
+	// an IPv4 literal must not be silently widened to ::ffff:a.b.c.d
+	if _, err := def.BuildKey(map[string]string{"sid": "1.2.3.4"}); err == nil || !strings.Contains(err.Error(), "not an IPv6") {
+		t.Errorf("IPv4-reject err = %v", err)
 	}
 }
 

--- a/internal/setmap/setmap_test.go
+++ b/internal/setmap/setmap_test.go
@@ -219,10 +219,9 @@ func TestParseSchemaRejectsDuplicateField(t *testing.T) {
 	}
 }
 
-// TestIPv6BTFRoundTrip pins that the synthesize side (fieldType, __u8[16]
-// array) and the describe side (resolveFieldType) agree: a map created
-// with an ipv6 key reads back as a 16-byte byte-string scalar field.
-func TestIPv6BTFRoundTrip(t *testing.T) {
+// newIPv6SetMap creates an in-memory hash map with a single ipv6 SID key.
+func newIPv6SetMap(t *testing.T) *ebpf.Map {
+	t.Helper()
 	if os.Geteuid() != 0 {
 		t.Skip("needs root to create a BPF map")
 	}
@@ -236,9 +235,15 @@ func TestIPv6BTFRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewMap: %v", err)
 	}
-	defer func() { _ = m.Close() }()
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
 
-	def, err := describe(m)
+// TestIPv6BTFRoundTrip pins that the synthesize side (fieldType, __u8[16]
+// array) and the describe side (resolveFieldType) agree: a map created
+// with an ipv6 key reads back as a 16-byte byte-string scalar field.
+func TestIPv6BTFRoundTrip(t *testing.T) {
+	def, err := describe(newIPv6SetMap(t))
 	if err != nil {
 		t.Fatalf("describe: %v", err)
 	}
@@ -247,5 +252,29 @@ func TestIPv6BTFRoundTrip(t *testing.T) {
 	}
 	if f := def.Fields[0]; f.Name != "sid" || f.Size != 16 || f.Off != 0 || !f.IsBytes {
 		t.Errorf("field = %+v, want {sid 16 off0 bytes}", f)
+	}
+}
+
+// TestIPv6AddListSchema round-trips an SRv6 SID through Add / List /
+// Schema and checks it renders as an IPv6 literal, not a number.
+func TestIPv6AddListSchema(t *testing.T) {
+	def, err := describe(newIPv6SetMap(t))
+	if err != nil {
+		t.Fatalf("describe: %v", err)
+	}
+	if err := def.Add(map[string]string{"sid": "fc00::1"}, 1); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	var list bytes.Buffer
+	if err := def.List(&list); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got := list.String(); !strings.Contains(got, "sid=fc00::1 tag=1") {
+		t.Errorf("List = %q, want to contain 'sid=fc00::1 tag=1'", got)
+	}
+	var schema bytes.Buffer
+	def.Schema(&schema)
+	if got := schema.String(); !strings.Contains(got, "sid") || !strings.Contains(got, "ipv6") {
+		t.Errorf("Schema = %q, want sid + ipv6", got)
 	}
 }

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -209,12 +209,23 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 		return nil, fmt.Errorf("codegen: set slot %d for @%s.%s is inside kunai's stack region (must be > %d)", slotOff, pred.SetName, fieldName, KunaiStackTop)
 	}
 
-	fieldOff, bytes, err := fieldRefByteOffset(pred.Field)
+	// A bare 128-bit primary field (ipv6.src / ipv6.dst = an SRv6 SID) is
+	// 16 bytes, which fieldRefByteOffset rejects (single-load only). Use
+	// the width-relaxed 128-bit helper and take the two-DWord store path.
+	is128 := pred.Field.Aux == nil && pred.Field.Slice == nil &&
+		pred.Field.Field != nil && pred.Field.Field.Bits == 128
+	var fieldOff, bytes int
+	var err error
+	if is128 {
+		fieldOff, bytes, err = findFieldByteOffset128(pred.Field.Layer.Spec, pred.Field.Field.Name)
+	} else {
+		fieldOff, bytes, err = fieldRefByteOffset(pred.Field)
+	}
 	if err != nil {
 		return nil, err
 	}
-	if bytes > 8 {
-		return nil, fmt.Errorf("%w: set key field %q is %d bytes; packet-field extraction supports up to 8 (16-byte keys such as SRv6 SID are a follow-up)", ErrNotImplemented, fieldName, bytes)
+	if bytes != 16 && bytes > 8 {
+		return nil, fmt.Errorf("%w: set key field %q is %d bytes; packet-field extraction supports 1/2/4/8 (numeric) or 16 (ipv6)", ErrNotImplemented, fieldName, bytes)
 	}
 	// Require an exact width match: a narrower packet field would only
 	// write a prefix of the key (relying on zero-fill), which silently
@@ -223,12 +234,35 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 	if bytes != slotSize {
 		return nil, fmt.Errorf("packet field %q is %d bytes but set @%s key field %q is %d bytes; widths must match (create the set with a matching field type)", fieldName, bytes, pred.SetName, fieldName, slotSize)
 	}
+
+	var insns asm.Instructions
+
+	// 16-byte (IPv6 address / SID): store the raw network-order bytes.
+	// Unlike the <=8 numeric path below, this is an identity byte copy —
+	// emitBoundedLoad (LE load) then StoreMem (LE store) preserves wire
+	// byte order, so NO HostTo is applied. `set add sid=fc00::1` writes
+	// the same net.ParseIP().To16() bytes verbatim (setmap copies, not
+	// putUint), so the key matches. Do not add a byte-swap here in any
+	// later "unify the store path" refactor — it would reverse the SID on
+	// a little-endian host and silently break every IPv6 match.
+	if bytes == 16 {
+		insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff), asm.DWord, dslReject)...)
+		insns = append(insns, asm.StoreMem(asm.R10, slotOff, asm.R3, asm.DWord))
+		insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff+8), asm.DWord, dslReject)...)
+		insns = append(insns, asm.StoreMem(asm.R10, slotOff+8, asm.R3, asm.DWord))
+		if pc.out != nil {
+			*pc.out = append(*pc.out, ExtractSlot{
+				SetName: pred.SetName, FieldName: fieldName,
+				StackOff: slotOff, StoreSize: 16,
+			})
+		}
+		return insns, nil
+	}
+
 	size, err := asmSizeFor(bytes)
 	if err != nil {
 		return nil, err
 	}
-
-	var insns asm.Instructions
 	// Single-aux fields gate on presence just like emitIntPredicate;
 	// iterator-stack (dynamic) aux fields are rejected at resolve time.
 	if pred.Field.Aux != nil {

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -224,9 +224,8 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 	if err != nil {
 		return nil, err
 	}
-	if bytes != 16 && bytes > 8 {
-		return nil, fmt.Errorf("%w: set key field %q is %d bytes; packet-field extraction supports 1/2/4/8 (numeric) or 16 (ipv6)", ErrNotImplemented, fieldName, bytes)
-	}
+	// bytes is 1/2/4/8 (the fieldRefByteOffset path rejects wider) or 16
+	// (the is128 path), so no explicit 9..15 guard is needed here.
 	// Require an exact width match: a narrower packet field would only
 	// write a prefix of the key (relying on zero-fill), which silently
 	// matches just zero-extended entries — a mis-configuration trap.

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -220,6 +220,63 @@ type badSlot struct{}
 func (badSlot) HasSet(name string) bool                            { return name == "teids" }
 func (badSlot) SlotFor(_, _ string) (off int16, size int, ok bool) { return -200, 4, true }
 
+// sidSlot is a 16-byte set key field at -40 for the ipv6.dst SID path.
+type sidSlot struct{}
+
+func (sidSlot) HasSet(name string) bool { return name == "sids" }
+func (sidSlot) SlotFor(set, field string) (off int16, size int, ok bool) {
+	if set == "sids" && field == "dst" {
+		return -40, 16, true
+	}
+	return 0, 0, false
+}
+
+func TestCompileInSetIPv6DstRawByteStore(t *testing.T) {
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: sidSlot{}}}
+	out, err := Compile("eth/ipv6[dst in @sids]", caps)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(out.Extractions) != 1 {
+		t.Fatalf("extractions = %+v, want 1", out.Extractions)
+	}
+	if ex := out.Extractions[0]; ex.SetName != "sids" || ex.FieldName != "dst" || ex.StackOff != -40 || ex.StoreSize != 16 {
+		t.Errorf("extraction = %+v", ex)
+	}
+
+	insns := out.Instructions()
+	// Both 8-byte halves are stored to the host slot: R10-40 and R10-32.
+	var loAt40, hiAt32 bool
+	for _, ins := range insns {
+		if ins.Dst == asm.R10 && ins.OpCode.Class().IsStore() && ins.OpCode.Size() == asm.DWord {
+			switch int16(ins.Offset) {
+			case -40:
+				loAt40 = true
+			case -32:
+				hiAt32 = true
+			}
+		}
+	}
+	if !loAt40 || !hiAt32 {
+		t.Errorf("want DWord stores at -40 and -32, got lo=%v hi=%v", loAt40, hiAt32)
+	}
+	// Byte-order: a 16-byte address is a raw wire-byte copy — NO HostTo.
+	for _, sz := range []asm.Size{asm.Word, asm.DWord, asm.Half} {
+		swapOp := asm.HostTo(asm.BE, asm.R3, sz).OpCode
+		for _, ins := range insns {
+			if ins.OpCode == swapOp {
+				t.Fatal("16-byte extraction emitted HostTo(BE); it must copy raw network-order bytes")
+			}
+		}
+	}
+	// Map-agnostic invariant still holds.
+	for _, ins := range insns {
+		if ins.OpCode.JumpOp() == asm.Call && ins.Src != asm.PseudoCall && ins.Constant == int64(asm.FnMapLookupElem) {
+			t.Fatal("codegen emitted FnMapLookupElem; kunai must stay map-agnostic")
+		}
+	}
+}
+
 func TestCompileVlanOptionalSucceeds(t *testing.T) {
 	// `?` quantifier + real vlan vocab — verifies end-to-end path.
 	insns, err := compileForTest("eth/vlan?/ipv4/tcp")


### PR DESCRIPTION
## 概要

v2 の DSL パケットフィールド集合照合は 1 フィールド 8 バイトまで。**SRv6 SID は 128bit = 16 バイト**(IPv6 宛先に載る active SID)なので照合できませんでした。本 PR で 16 バイトフィールドを集合キーにできるようにし、`ipv6[dst in @sids]` で SID を pinned map 照合できます。

```bash
xdp-ninja set create /sys/fs/bpf/sids --key "dst:ipv6"
xdp-ninja set add    /sys/fs/bpf/sids dst=fc00::1
xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" 'eth/ipv6[dst in @sids]'
```

## 設計の核心: byte-order

数値フィールド(u8-u64)は host-order 数値を NativeEndian で書き、パケットの BE 値を kunai が `HostTo(BE)` で正規化して一致させます。**IPv6 アドレス / SID は network-order のバイト列そのものが値**なので扱いが違い、両側とも raw 16 バイトをそのまま置きます。

- **kunai 抽出**: 8 バイト×2 の DWord load + store を **`HostTo` 抜き**で(LE-load→LE-store の恒等コピーでバイト順保存)。
- **`set add`**: `net.ParseIP().To16()` を **`copy`** で(`putUint`/NativeEndian を通さない)。

両者が同じ wire バイト列を書くので一致。**LE で `putUint` に通すと反転して全 miss** するのが最大の落とし穴。差分テストで固定。

## 実装 (6 コミット)

1. `fix(program)`: host `keyAlign` を 16 バイトフィールド向けに調整(8-align)
2. `feat(kunai)`: `emitInSetPredicate` の 128bit 分岐(`findFieldByteOffset128` + 2×DWord raw store、HostTo 抜き)
3. `feat(setmap)`: `ipv6` 型追加(`__u8[16]` BTF array、値表現を schema-aware に refactor、`net.ParseIP` copy、value に ipv6 拒否)
4. `feat(setmap)`: `set list`/`schema` を IPv6 リテラル表示
5. `feat(program)`: `ipv6[dst in @sids]` e2e + byte-order 差分 + scalar-name relax + docs
6. `refactor(setmap)`: `/simplify` 適用(アライメント導出化で store 8-align 正当化・冗長状態除去)

## テスト
- **unit**: setmap(ParseSchema/BuildKey network-order/BTF round-trip synth↔describe/表示)、kunai(2×DWord raw store・HostTo 非出・FnMapLookupElem 非混入の不変条件)、host(16B keyAlign)。
- **root BPF e2e**: `ipv6[dst in @sids]` member/non-member、**byte-order 差分**(SID の wire バイト == BuildKey 出力)、runtime add/delete、**vimto 6.6 検証**。v2 numeric / composite / arg-set 回帰 green。

## スコープ外
- `srv6.segments[N].addr`(bracket 参照不可)、32 桁 hex 入力、複合キー内の 16 バイト(16B 予算で不可)、arg 由来 set の 16 バイト(fentry 引数は 8 バイト register)
