### PR TITLE
feat: static [N] aux-stack index in bracket predicates (srv6[segments[0].addr in @sids])

### DIFF
--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -504,11 +504,16 @@ sudo xdp-ninja set create /sys/fs/bpf/sids --key "dst:ipv6"
 sudo xdp-ninja set add    /sys/fs/bpf/sids dst=fc00::1
 sudo xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
   'eth/ipv6[dst in @sids]'
+
+# SRH の segment list の N 番目の SID を照合する。segments[0] は最終宛先
+sudo xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
+  'eth/ipv6/srv6[segments[0].addr in @sids]'
 ```
 
 - 同名一致します。DSL のフィールド名がそのまま集合キーのフィールド名になり、`gtp[teid in @teids]` は集合キー `teid` を引きます。ただしスカラ集合、つまりフィールドが 1 個のキーは名前がラベルにすぎないので、`ipv6[dst in @sids]` を `sid:ipv6` のようにフィールド名が違うキーへ当てても照合できます。
 - エンディアンはツールが吸収します。数値フィールドはパケットが network order、`set add` は host order で書きますが変換をツールが合わせるので、利用者は普段どおりの数値で `set add` するだけで済みます。`ipv6` フィールドは IPv6 アドレスのバイト列そのものが値なので、パケットも `set add fc00::1` も同じ network order のまま照合します。
 - キー幅には上限があります。パケット由来キーはホストスタックの空き領域を使うため、合計 16 バイトまでです。TEID の 4 バイト、IMSI の 8 バイト、TEID と IMSI を合わせた 12 バイト、SRv6 SID の 16 バイトはいずれも収まります。数値フィールドは 1 個 8 バイトまで、`ipv6` フィールドは 16 バイトで、16 バイトのキーはそれ 1 個で予算を使い切ります。
+- 定数インデックスの aux フィールドを bracket で参照できます。`srv6[segments[0].addr in @sids]` は SRH の segment list の 0 番目を引きます。bracket に書けるのは `[N]` の定数インデックスだけで、`segments[srv6.last_entry]` のような動的インデックスや添字なしの `any()/all()` は `where` 句を使います。
 - `@NAME` は他の bracket 条件やレイヤ条件と AND で合成します。`in @NAME` は bracket predicate 専用で、`where` 句の中では使えません。
 - `in @NAME` は必ず通るレイヤ、すなわち quantifier のない `QuantOne` のレイヤにのみ書けます。`vlan[...]?` のような optional や繰り返しのレイヤ、`(vlan[...]|qinq)` のような alternation の枝は、そのレイヤが不在でもフィルタが成立しうるため、抽出が走らずキーが未書き込みになる可能性があり、reject されます。
 - 引数由来の `--arg-filter @NAME` は entry/exit 専用のままです。パケット由来の DSL `@NAME` は entry/exit と `--mode xdp` の両方で動きます。

--- a/internal/program/setfilter_dsl_test.go
+++ b/internal/program/setfilter_dsl_test.go
@@ -262,3 +262,47 @@ func TestBpfDSLSetMatchIPv6Dst(t *testing.T) {
 		t.Fatalf("markers after runtime delete = %v, want no 0x77", markers)
 	}
 }
+
+// TestBpfDSLSetMatchSRv6SegmentLoads verifier-loads the srv6 segment set
+// filter. Unlike ipv6[dst] (a primary-header field), srv6[segments[N].addr]
+// runs the SRH segment walk, a parser-machine self-loop that does not
+// execute in the fentry scratch-buffer path (the same limitation the gtp
+// note above calls out), so this asserts the extraction VERIFIES on the CI
+// kernel matrix rather than capturing. The packet-level match is proven by
+// TestAuxStackSrv6SegmentsStaticIndexBracket in pkg/kunai/dsltest (native
+// XDP), and the raw-byte store shape by the codegen unit tests.
+func TestBpfDSLSetMatchSRv6SegmentLoads(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_dslseg_%d", os.Getpid())
+	if err := setmap.Create(pin, "sid:ipv6", "", 16); err != nil {
+		t.Skipf("creating pinned ipv6 set map: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	set, err := setmap.OpenSet(setmap.SpecRef{Name: "sids", Path: pin})
+	if err != nil {
+		t.Fatalf("OpenSet: %v", err)
+	}
+	t.Cleanup(set.Def.Close)
+
+	// Byte-order differential (host side, no BPF): the SID wire bytes equal
+	// the key BuildKey writes, so the raw extraction store and `set add`
+	// agree with no swap.
+	const memberSID = "fc00::1"
+	key, err := set.Def.BuildKey(map[string]string{"sid": memberSID})
+	if err != nil {
+		t.Fatalf("BuildKey: %v", err)
+	}
+	if !bytes.Equal(key, net.ParseIP(memberSID).To16()) {
+		t.Fatalf("key %x != wire bytes %x (byte-order mismatch)", key, net.ParseIP(memberSID).To16())
+	}
+
+	prog := loadXDPByName(t, dslSetTargetSrc, "xdp_set_e2e_target")
+	targets := []attach.Target{{Program: prog, FuncName: "xdp_set_e2e_target", Type: ebpf.XDP}}
+	probe, err := LoadMultiEntry(targets, "eth/ipv6/srv6[segments[0].addr in @sids]", nil, true, []*setmap.Set{set})
+	if err != nil {
+		t.Fatalf("LoadMultiEntry with srv6 segment set: %v", err)
+	}
+	_ = probe.Close()
+}

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -209,21 +209,32 @@ func field128RawOffset(ref *ir.FieldRef) (off int, ok bool, err error) {
 	if ref.Aux.FieldBitWidth != 128 {
 		return 0, false, nil
 	}
-	if ref.Aux.FieldBitOff%8 != 0 {
-		return 0, false, fmt.Errorf("%w: aux field %s.%s starts at bit %d (not byte-aligned)", ErrNotImplemented, ref.Aux.OutParam, ref.Field.Name, ref.Aux.FieldBitOff)
-	}
-	// Same fold as fieldRefByteOffset's aux branch: aux base + field window
-	// + Static*ElemSize. A dynamic index needs a runtime address compute
-	// (R5), which the raw-copy store path does not do, so it is rejected
-	// (resolve already blocks it inside a bracket).
-	o := ref.Aux.OffsetInLayer + ref.Aux.FieldBitOff/8
-	if ref.Aux.Stack != nil {
-		if !ref.Aux.Stack.IsStatic {
-			return 0, false, fmt.Errorf("%w: dynamic aux stack index in set extraction (use a constant index)", ErrNotImplemented)
-		}
-		o += int(ref.Aux.Stack.Static) * ref.Aux.HeaderSize
+	o, err := auxStaticByteOffset(ref.Aux)
+	if err != nil {
+		return 0, false, err
 	}
 	return o, true, nil
+}
+
+// auxStaticByteOffset folds an aux field's constant byte offset within its
+// layer: OffsetInLayer + FieldBitOff/8, plus Static*HeaderSize for a static
+// aux-stack element (srv6.segments[N]). It errors on a non-byte-aligned
+// field or a dynamic stack index, which needs a runtime address compute
+// (R5) that a constant-offset caller cannot express. This is the same fold
+// fieldRefByteOffset (codegen.go) and auxLoadEmitter apply inline; kept as a
+// helper so the 128-bit raw-copy path shares one definition of the formula.
+func auxStaticByteOffset(aux *ir.AuxRef) (int, error) {
+	if aux.FieldBitOff%8 != 0 {
+		return 0, fmt.Errorf("%w: aux field %s starts at bit %d (not byte-aligned)", ErrNotImplemented, aux.OutParam, aux.FieldBitOff)
+	}
+	off := aux.OffsetInLayer + aux.FieldBitOff/8
+	if aux.Stack != nil {
+		if !aux.Stack.IsStatic {
+			return 0, fmt.Errorf("%w: dynamic aux stack index needs a runtime offset (use a constant index)", ErrNotImplemented)
+		}
+		off += int(aux.Stack.Static) * aux.HeaderSize
+	}
+	return off, nil
 }
 
 func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, error) {
@@ -254,13 +265,11 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 	// (ipv6.dst = the active SRv6 SID) and a static aux-stack element
 	// (srv6.segments[N].addr = a specific SID in the SRH list).
 	fieldOff, is128, err := field128RawOffset(pred.Field)
-	var bytes int
 	if err != nil {
 		return nil, err
 	}
-	if is128 {
-		bytes = 16
-	} else {
+	bytes := 16
+	if !is128 {
 		fieldOff, bytes, err = fieldRefByteOffset(pred.Field)
 		if err != nil {
 			return nil, err

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -225,7 +225,7 @@ func field128RawOffset(ref *ir.FieldRef) (off int, ok bool, err error) {
 // helper so the 128-bit raw-copy path shares one definition of the formula.
 func auxStaticByteOffset(aux *ir.AuxRef) (int, error) {
 	if aux.FieldBitOff%8 != 0 {
-		return 0, fmt.Errorf("%w: aux field %s starts at bit %d (not byte-aligned)", ErrNotImplemented, aux.OutParam, aux.FieldBitOff)
+		return 0, fmt.Errorf("%w: aux field %s (%s) starts at bit %d (not byte-aligned)", ErrNotImplemented, aux.OutParam, aux.HeaderName, aux.FieldBitOff)
 	}
 	off := aux.OffsetInLayer + aux.FieldBitOff/8
 	if aux.Stack != nil {

--- a/pkg/kunai/codegen/predicate.go
+++ b/pkg/kunai/codegen/predicate.go
@@ -187,6 +187,45 @@ type predCtx struct {
 // integer, so a multi-byte field is byte-reversed relative to its
 // numeric value. HostTo(BE) brings R3 to the numeric value in host
 // order; StoreMem then writes it native-endian, matching the map key.
+// field128RawOffset returns the byte offset of a 16-byte (128-bit) field
+// to be extracted as raw wire bytes, and ok=true when the field is one:
+// a primary-header field (ipv6.dst) or a static aux-stack element
+// (srv6.segments[N].addr). It is the width-relaxed 128-bit sibling of
+// fieldRefByteOffset (which caps aux/primary fields at 8 bytes). ok=false
+// means "not a 16-byte field" (the caller falls back to the <=8 path); a
+// non-nil error means a 16-byte field that cannot be extracted (a
+// non-byte-aligned or dynamic-index aux stack).
+func field128RawOffset(ref *ir.FieldRef) (off int, ok bool, err error) {
+	if ref.Slice != nil {
+		return 0, false, nil
+	}
+	if ref.Aux == nil {
+		if ref.Field == nil || ref.Field.Bits != 128 {
+			return 0, false, nil
+		}
+		o, _, e := findFieldByteOffset128(ref.Layer.Spec, ref.Field.Name)
+		return o, true, e
+	}
+	if ref.Aux.FieldBitWidth != 128 {
+		return 0, false, nil
+	}
+	if ref.Aux.FieldBitOff%8 != 0 {
+		return 0, false, fmt.Errorf("%w: aux field %s.%s starts at bit %d (not byte-aligned)", ErrNotImplemented, ref.Aux.OutParam, ref.Field.Name, ref.Aux.FieldBitOff)
+	}
+	// Same fold as fieldRefByteOffset's aux branch: aux base + field window
+	// + Static*ElemSize. A dynamic index needs a runtime address compute
+	// (R5), which the raw-copy store path does not do, so it is rejected
+	// (resolve already blocks it inside a bracket).
+	o := ref.Aux.OffsetInLayer + ref.Aux.FieldBitOff/8
+	if ref.Aux.Stack != nil {
+		if !ref.Aux.Stack.IsStatic {
+			return 0, false, fmt.Errorf("%w: dynamic aux stack index in set extraction (use a constant index)", ErrNotImplemented)
+		}
+		o += int(ref.Aux.Stack.Static) * ref.Aux.HeaderSize
+	}
+	return o, true, nil
+}
+
 func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, error) {
 	if pc == nil || pc.sets == nil {
 		return nil, fmt.Errorf("%w: `in @%s` needs a host that supports set matching", ErrNotImplemented, pred.SetName)
@@ -209,20 +248,23 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 		return nil, fmt.Errorf("codegen: set slot %d for @%s.%s is inside kunai's stack region (must be > %d)", slotOff, pred.SetName, fieldName, KunaiStackTop)
 	}
 
-	// A bare 128-bit primary field (ipv6.src / ipv6.dst = an SRv6 SID) is
-	// 16 bytes, which fieldRefByteOffset rejects (single-load only). Use
-	// the width-relaxed 128-bit helper and take the two-DWord store path.
-	is128 := pred.Field.Aux == nil && pred.Field.Slice == nil &&
-		pred.Field.Field != nil && pred.Field.Field.Bits == 128
-	var fieldOff, bytes int
-	var err error
-	if is128 {
-		fieldOff, bytes, err = findFieldByteOffset128(pred.Field.Layer.Spec, pred.Field.Field.Name)
-	} else {
-		fieldOff, bytes, err = fieldRefByteOffset(pred.Field)
-	}
+	// A 16-byte (128-bit) field is rejected by fieldRefByteOffset (which
+	// caps at a single <=8-byte load), so resolve its offset separately and
+	// take the two-DWord store path. This covers a primary field
+	// (ipv6.dst = the active SRv6 SID) and a static aux-stack element
+	// (srv6.segments[N].addr = a specific SID in the SRH list).
+	fieldOff, is128, err := field128RawOffset(pred.Field)
+	var bytes int
 	if err != nil {
 		return nil, err
+	}
+	if is128 {
+		bytes = 16
+	} else {
+		fieldOff, bytes, err = fieldRefByteOffset(pred.Field)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// bytes is 1/2/4/8 (the fieldRefByteOffset path rejects wider) or 16
 	// (the is128 path), so no explicit 9..15 guard is needed here.
@@ -245,6 +287,13 @@ func emitInSetPredicate(pred *ir.Predicate, pc *predCtx) (asm.Instructions, erro
 	// later "unify the store path" refactor — it would reverse the SID on
 	// a little-endian host and silently break every IPv6 match.
 	if bytes == 16 {
+		// A static aux-stack element (srv6.segments[N].addr) gates on
+		// presence just like the <=8 aux path; a primary field has no aux
+		// and emitAuxGating is skipped. Dynamic/iterator stacks are rejected
+		// at resolve time and in field128RawOffset.
+		if pred.Field.Aux != nil {
+			insns = append(insns, emitAuxGating(pred.Field.Aux.Gating, r4Anchor(), dslReject)...)
+		}
 		insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff), asm.DWord, dslReject)...)
 		insns = append(insns, asm.StoreMem(asm.R10, slotOff, asm.R3, asm.DWord))
 		insns = append(insns, emitBoundedLoad(asm.R3, int16(fieldOff+8), asm.DWord, dslReject)...)

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -220,12 +220,14 @@ type badSlot struct{}
 func (badSlot) HasSet(name string) bool                            { return name == "teids" }
 func (badSlot) SlotFor(_, _ string) (off int16, size int, ok bool) { return -200, 4, true }
 
-// sidSlot is a 16-byte set key field at -40 for the ipv6.dst SID path.
+// sidSlot is a scalar 16-byte ipv6 set at -40 (a SID set). Like a real
+// scalar set, its lone key field is name-agnostic, so it matches any DSL
+// field (ipv6.dst, srv6.segments[N].addr) referencing @sids.
 type sidSlot struct{}
 
 func (sidSlot) HasSet(name string) bool { return name == "sids" }
-func (sidSlot) SlotFor(set, field string) (off int16, size int, ok bool) {
-	if set == "sids" && field == "dst" {
+func (sidSlot) SlotFor(set, _ string) (off int16, size int, ok bool) {
+	if set == "sids" {
 		return -40, 16, true
 	}
 	return 0, 0, false
@@ -274,6 +276,64 @@ func TestCompileInSetIPv6DstRawByteStore(t *testing.T) {
 		if ins.OpCode.JumpOp() == asm.Call && ins.Src != asm.PseudoCall && ins.Constant == int64(asm.FnMapLookupElem) {
 			t.Fatal("codegen emitted FnMapLookupElem; kunai must stay map-agnostic")
 		}
+	}
+}
+
+func TestCompileInSetSRv6SegmentRawByteStore(t *testing.T) {
+	// A static aux-stack element (a specific SID in the SRH list) extracts
+	// as raw wire bytes too — same 16-byte path as ipv6.dst, only the
+	// offset resolves through the aux fold instead of the primary header.
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: sidSlot{}}}
+	out, err := Compile("eth/ipv6/srv6[segments[0].addr in @sids]", caps)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(out.Extractions) != 1 {
+		t.Fatalf("extractions = %+v, want 1", out.Extractions)
+	}
+	if ex := out.Extractions[0]; ex.SetName != "sids" || ex.StackOff != -40 || ex.StoreSize != 16 {
+		t.Errorf("extraction = %+v", ex)
+	}
+
+	insns := out.Instructions()
+	var loAt40, hiAt32 bool
+	for _, ins := range insns {
+		if ins.Dst == asm.R10 && ins.OpCode.Class().IsStore() && ins.OpCode.Size() == asm.DWord {
+			switch int16(ins.Offset) {
+			case -40:
+				loAt40 = true
+			case -32:
+				hiAt32 = true
+			}
+		}
+	}
+	if !loAt40 || !hiAt32 {
+		t.Errorf("want DWord stores at -40 and -32, got lo=%v hi=%v", loAt40, hiAt32)
+	}
+	// Raw wire-byte copy: no HostTo on the extracted SID.
+	for _, sz := range []asm.Size{asm.Word, asm.DWord, asm.Half} {
+		swapOp := asm.HostTo(asm.BE, asm.R3, sz).OpCode
+		for _, ins := range insns {
+			if ins.OpCode == swapOp {
+				t.Fatal("segment SID extraction emitted HostTo(BE); it must copy raw network-order bytes")
+			}
+		}
+	}
+	// Map-agnostic: still no lookup in kunai.
+	for _, ins := range insns {
+		if ins.OpCode.JumpOp() == asm.Call && ins.Src != asm.PseudoCall && ins.Constant == int64(asm.FnMapLookupElem) {
+			t.Fatal("codegen emitted FnMapLookupElem; kunai must stay map-agnostic")
+		}
+	}
+}
+
+func TestCompileInSetRejectsDynamicSegmentIndex(t *testing.T) {
+	// A dynamic stack index cannot be extracted (no runtime address
+	// compute in the raw-copy path); resolve rejects it inside a bracket.
+	caps := codegen.Capabilities{Lang: codegen.LangCaps{SetSlots: sidSlot{}}}
+	_, err := Compile("eth/ipv6/srv6[segments[srv6.last_entry].addr in @sids]", caps)
+	if err == nil || !strings.Contains(err.Error(), "constant index") {
+		t.Fatalf("expected dynamic-index rejection, got %v", err)
 	}
 }
 

--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -281,6 +281,26 @@ func TestAuxStackSrv6SegmentsStaticIndex(t *testing.T) {
 	r.MustReject(t, mismatch, "first segment != fc00::1 (= fc00::beef)")
 }
 
+// TestAuxStackSrv6SegmentsStaticIndexBracket pins the same static-index
+// segment access written as a bracket predicate,
+// `srv6[segments[0].addr == fc00::1]`, which now resolves the same way the
+// where form does. Proves the bracket path lands on the right packet
+// bytes at the packet level (the offset fold is correct).
+func TestAuxStackSrv6SegmentsStaticIndexBracket(t *testing.T) {
+	r := New(t, "eth/ipv6/srv6[segments[0].addr == fc00::1]/tcp")
+	matchPkt := BuildSRv6(t, SRv6Opts{
+		Segments:        []net.IP{net.ParseIP("fc00::1")},
+		InnerNextHeader: 6,
+	})
+	r.MustMatch(t, matchPkt, "first segment == fc00::1 (bracket form)")
+
+	mismatch := BuildSRv6(t, SRv6Opts{
+		Segments:        []net.IP{net.ParseIP("fc00::beef")},
+		InnerNextHeader: 6,
+	})
+	r.MustReject(t, mismatch, "first segment != fc00::1 (= fc00::beef)")
+}
+
 // TestAuxStackSrv6SegmentsStaticCIDRMatch pins the static-stack +
 // IPv6 CIDR aux combination — `srv6.segments[0].addr == fc00::/16`
 // emits the same R5 = layer_anchor + OffsetInLayer + Static*ElemSize

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -10,12 +10,19 @@ import (
 // two-part `<aux>.<field>` / `<aux>.exists` for auxiliary access,
 // always scoped to the owning layer.
 func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerInstance) (*ir.Predicate, error) {
-	field, err := resolveUnqualifiedField(ap.Field, layer)
+	field, err := r.resolveUnqualifiedField(ap.Field, layer)
 	if err != nil {
 		return nil, err
 	}
 	if field.Aux != nil && field.Aux.Stack != nil && field.Aux.Stack.IsIterator {
 		return nil, errorf(ap.Pos, "auxiliary header stack %q needs an index inside a bracket predicate (use `[N]` or wrap in `any(...)` / `all(...)`)", field.Aux.OutParam)
+	}
+	// A bracket predicate reads a single field at a compile-time-constant
+	// offset, so only a static `[N]` index is addressable. A dynamic index
+	// (`segments[srv6.last_entry]`) needs a runtime offset computation that
+	// only the `where` clause emits.
+	if field.Aux != nil && field.Aux.Stack != nil && !field.Aux.Stack.IsStatic {
+		return nil, errorf(ap.Pos, "auxiliary header stack %q takes a constant index inside a bracket predicate (a dynamic index needs a `where` clause)", field.Aux.OutParam)
 	}
 	// `in @set` extracts the field into a host key buffer that the host
 	// looks up unconditionally after the filter. That is only correct if
@@ -92,9 +99,11 @@ func rejectBareIdentValue(v *ast.Value) error {
 // layer's headers. Single-segment paths bind to the primary header
 // (the existing `tcp[dport == 443]` shape). Two-segment paths
 // `<aux>.<field>` or `<aux>.exists` bind to one of the layer's
-// auxiliary headers (e.g. `gtp[opt.next_ext == 0]`). Anything
-// deeper belongs in a `where` clause and is rejected here.
-func resolveUnqualifiedField(fp *ast.FieldPath, layer *ir.LayerInstance) (*ir.FieldRef, error) {
+// auxiliary headers (e.g. `gtp[opt.next_ext == 0]`); a static index
+// `<stack>[N].<field>` (e.g. `srv6[segments[0].addr in @sids]`) binds
+// to a fixed element of an aux header stack, mirroring the `where`
+// clause. Anything deeper belongs in a `where` clause and is rejected.
+func (r *resolver) resolveUnqualifiedField(fp *ast.FieldPath, layer *ir.LayerInstance) (*ir.FieldRef, error) {
 	if fp == nil || len(fp.Parts) == 0 {
 		return nil, errorf(ast.Position{}, "empty field path")
 	}
@@ -115,7 +124,14 @@ func resolveUnqualifiedField(fp *ast.FieldPath, layer *ir.LayerInstance) (*ir.Fi
 		}
 		ref = &ir.FieldRef{Layer: layer, Field: f}
 	case 2:
-		ref, err = resolveAuxField(layer, fp.Parts[0], fp.Parts[1], fp)
+		// `<stack>[N].<field>` binds a fixed stack element; the bare
+		// `<aux>.<field>` (no index) routes to the single-aux / iterator
+		// resolver as before.
+		if hasIndexAt(fp, 0) {
+			ref, err = r.resolveAuxStackField(layer, fp.Parts[0], indexAt(fp, 0), fp.Parts[1], fp)
+		} else {
+			ref, err = resolveAuxField(layer, fp.Parts[0], fp.Parts[1], fp)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -14,15 +14,16 @@ func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerIns
 	if err != nil {
 		return nil, err
 	}
-	if field.Aux != nil && field.Aux.Stack != nil && field.Aux.Stack.IsIterator {
-		return nil, errorf(ap.Pos, "auxiliary header stack %q needs an index inside a bracket predicate (use `[N]` or wrap in `any(...)` / `all(...)`)", field.Aux.OutParam)
-	}
 	// A bracket predicate reads a single field at a compile-time-constant
-	// offset, so only a static `[N]` index is addressable. A dynamic index
-	// (`segments[srv6.last_entry]`) needs a runtime offset computation that
-	// only the `where` clause emits.
-	if field.Aux != nil && field.Aux.Stack != nil && !field.Aux.Stack.IsStatic {
-		return nil, errorf(ap.Pos, "auxiliary header stack %q takes a constant index inside a bracket predicate (a dynamic index needs a `where` clause)", field.Aux.OutParam)
+	// offset, so a stack access must carry a static `[N]` index. The
+	// index-less iterator form (`any()/all()`) and a dynamic index
+	// (`segments[srv6.last_entry]`, a runtime offset only `where` emits) are
+	// both non-static; branch only for the more specific diagnostic.
+	if stk := field.Aux; stk != nil && stk.Stack != nil && !stk.Stack.IsStatic {
+		if stk.Stack.IsIterator {
+			return nil, errorf(ap.Pos, "auxiliary header stack %q needs an index inside a bracket predicate (use `[N]` or wrap in `any(...)` / `all(...)`)", stk.OutParam)
+		}
+		return nil, errorf(ap.Pos, "auxiliary header stack %q takes a constant index inside a bracket predicate (a dynamic index needs a `where` clause)", stk.OutParam)
 	}
 	// `in @set` extracts the field into a host key buffer that the host
 	// looks up unconditionally after the filter. That is only correct if

--- a/pkg/kunai/resolve/predicate.go
+++ b/pkg/kunai/resolve/predicate.go
@@ -23,7 +23,7 @@ func (r *resolver) resolveBracketPredicate(ap *ast.Predicate, layer *ir.LayerIns
 		if stk.Stack.IsIterator {
 			return nil, errorf(ap.Pos, "auxiliary header stack %q needs an index inside a bracket predicate (use `[N]` or wrap in `any(...)` / `all(...)`)", stk.OutParam)
 		}
-		return nil, errorf(ap.Pos, "auxiliary header stack %q takes a constant index inside a bracket predicate (a dynamic index needs a `where` clause)", stk.OutParam)
+		return nil, errorf(ap.Pos, "auxiliary header stack %q requires a constant index inside a bracket predicate (a dynamic index needs a `where` clause)", stk.OutParam)
 	}
 	// `in @set` extracts the field into a host key buffer that the host
 	// looks up unconditionally after the filter. That is only correct if

--- a/pkg/kunai/resolve/resolve_test.go
+++ b/pkg/kunai/resolve/resolve_test.go
@@ -284,6 +284,32 @@ func TestResolveAuxStackRejectsSinglePath(t *testing.T) {
 	resolveErr(t, "eth/ipv4/udp/gtp[exts.next_ext==0]/ipv4/tcp", nil, "needs an index")
 }
 
+func TestResolveBracketStaticStackIndex(t *testing.T) {
+	// `srv6[segments[0].addr == ...]`: a constant index binds a fixed
+	// stack element, mirroring `where srv6.segments[0].addr == ...`.
+	p := resolveOK(t, "eth/ipv6/srv6[segments[0].addr==fc00::1]", nil)
+	srv6 := p.Layers[2]
+	if len(srv6.Predicates) != 1 {
+		t.Fatalf("expected 1 predicate on srv6, got %d", len(srv6.Predicates))
+	}
+	aux := srv6.Predicates[0].Field.Aux
+	if aux == nil || aux.Stack == nil {
+		t.Fatalf("expected an aux-stack field ref, got %+v", srv6.Predicates[0].Field)
+	}
+	if !aux.Stack.IsStatic || aux.Stack.Static != 0 || aux.Stack.IsIterator {
+		t.Errorf("stack index = %+v, want IsStatic=true Static=0", aux.Stack)
+	}
+	if aux.OutParam != "segments" || aux.FieldBitWidth != 128 {
+		t.Errorf("aux = %+v, want segments/128", aux)
+	}
+}
+
+func TestResolveBracketRejectsDynamicStackIndex(t *testing.T) {
+	// A dynamic index needs a runtime offset compute that only the
+	// where clause emits; inside a bracket it is rejected.
+	resolveErr(t, "eth/ipv6/srv6[segments[srv6.last_entry].addr==fc00::1]", nil, "constant index")
+}
+
 func TestResolveQuantSameStackMultipleRefs(t *testing.T) {
 	// any()/all() require exactly one iteration *target* stack, not
 	// exactly one textual reference. The same stack may appear more


### PR DESCRIPTION
## 概要

v3 の `ipv6[dst in @sids]`(primary header の 128bit = active SID)に続き、SRH の segment list の N 番目の SID `srv6.segments[N].addr` を集合照合できるようにする。実運用では `segments[0]`(SRH は逆順なので最終宛先)が効く。

```bash
xdp-ninja set create /sys/fs/bpf/sids --key "dst:ipv6"
xdp-ninja set add    /sys/fs/bpf/sids dst=fc00::1
xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
  'eth/ipv6/srv6[segments[0].addr in @sids]'
```

## これは原理的な壁ではなく未配線だった

`segments[0]` の `[0]` はパーサが where 句と同一の `parseFieldPath` で正しく解析し `FieldPath.Indices` に格納していた。だが bracket 側の `resolveUnqualifiedField` が `len(Parts)` だけで分岐し index を見ずに iterator へ流していたため reject されていた。where 句は `hasIndexAt` を見て静的 `[N]` を `StackIndex{IsStatic:true}` に解決するので、`where srv6.segments[0].addr == ...` は元から通っていた。

## 実装 (3 コミット + /simplify)

1. `feat(resolve)`: bracket の case 2 で `hasIndexAt` を見て where と同じ `resolveAuxStackField` へ配線。動的インデックスは bracket で reject(静的固定オフセットのみ)。srv6 に限らず任意の静的 `[N]` aux stack を bracket で使える一般化。比較側 codegen は既に aux 128bit 対応済みなので、これだけで `srv6[segments[0].addr == fc00::1]` の比較も通る。
2. `feat(kunai)`: 集合抽出の 16バイト分岐を静的 aux stack へ拡張。`field128RawOffset`(primary + static-aux の 128bit offset 解決)を追加、aux のとき gating を出す。byte-order は v3 と同一(raw wire コピー、HostTo 抜き)。
3. `test(program)`: dsltest で bracket 形の packet match(native XDP)、program で verifier load + byte-order 差分、docs。
4. `refactor`: /simplify(offset fold を `auxStaticByteOffset` に集約、reject 節統合)。

## テストと harness 制約

- **dsltest**(native XDP): `srv6[segments[0].addr == fc00::1]` が BuildSRv6 パケットを match/reject。static-index の offset fold が正しい packet バイトに当たることを証明。
- **codegen unit**: `srv6[segments[0].addr in @sids]` が StoreSize 16・2×DWord store・HostTo 非出・FnMapLookupElem 非混入で compile、動的インデックスは reject。
- **program**: `in @sids` の verifier load(vimto 6.6 確認)+ byte-order 差分。**capture は assert しない** — SRH の segment walk は parser-machine self-loop で fentry scratch 経路では実行されない(gtp と同じ既知制約)。match は dsltest が packet-level で担保。`auxLoadEmitter` の static 分岐と `field128RawOffset` は同一 offset 式なので、`==` テストが `in @sids` の offset を transitively に検証する。

## スコープ外

- 動的インデックス `segments[srv6.last_entry]` の bracket 集合照合(R5 ランタイムアドレス計算が要る)
- `any()/all()` の集合照合(bpf_loop 走査で固定 load モデルに乗らない)
- `in @set` を where 句へ開放
