### PR TITLE
feat(cli): --prog-name, --json for list-*, and combined list-progs/list-funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo xdp-ninja -i eth0 --func process_packet | tcpdump -n -r -
 # has it. All attach points share one ringbuf and merge into one pcap.
 # (e.g. UL + DL capture points living in separate per-direction programs)
 sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
-  --func pgwu_capture_point_ul --func pgwu_capture_point_dl -w all.pcap
+  --func upf_capture_point_ul --func upf_capture_point_dl -w all.pcap
 
 # Match against a runtime-updatable set (pinned BPF hash map): the map
 # key IS the value to match; entries added/removed while capturing take
@@ -78,7 +78,7 @@ sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
 # `xdp-ninja set` (schema comes from the map's BTF).
 sudo xdp-ninja set create /sys/fs/bpf/subs --key "imsi:u64"
 sudo xdp-ninja set add /sys/fs/bpf/subs imsi=999990000000001
-sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul \
+sudo xdp-ninja -p 1661 --func upf_capture_point_ul \
   --set "subs=/sys/fs/bpf/subs" --arg-filter "@subs" -w subs.pcap
 
 # Key the set off a PACKET field instead of a function arg — for values

--- a/cmd/xdp-ninja/listjson.go
+++ b/cmd/xdp-ninja/listjson.go
@@ -1,0 +1,80 @@
+// JSON shapes for the --list-progs / --list-funcs / --list-params commands,
+// emitted on stdout when --json is set so the discovery output can be piped
+// into jq or another tool instead of scraping the human-readable text.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/takehaya/xdp-ninja/internal/attach"
+)
+
+// funcJSON is one BTF function of a program.
+type funcJSON struct {
+	Name    string `json:"name"`
+	Linkage string `json:"linkage"`
+}
+
+// progNodeJSON is one node of a program's reachable tree. Funcs is populated
+// only when --list-funcs is combined with --list-progs.
+type progNodeJSON struct {
+	ID     uint32     `json:"id"`
+	Name   string     `json:"name,omitempty"`
+	Via    string     `json:"via,omitempty"`
+	Keys   []uint32   `json:"keys,omitempty"`
+	Depth  int        `json:"depth,omitempty"`
+	Parent uint32     `json:"parent,omitempty"`
+	Funcs  []funcJSON `json:"funcs,omitempty"`
+}
+
+// progsTargetJSON is one -p / -i target: its entry (root) plus the reachable
+// tree. Funcs is the root's functions when --list-funcs is combined.
+type progsTargetJSON struct {
+	ID        uint32         `json:"id"`
+	Func      string         `json:"func"`
+	Funcs     []funcJSON     `json:"funcs,omitempty"`
+	Reachable []progNodeJSON `json:"reachable"`
+}
+
+// funcsTargetJSON is one target's BTF function list (--list-funcs alone).
+type funcsTargetJSON struct {
+	ID    uint32     `json:"id"`
+	Funcs []funcJSON `json:"funcs"`
+}
+
+// paramJSON is one filterable function parameter.
+type paramJSON struct {
+	Name   string `json:"name"`
+	Index  int    `json:"index"`
+	Size   uint32 `json:"size"`
+	Signed bool   `json:"signed"`
+}
+
+// paramsTargetJSON is one attach pair's filterable parameters.
+type paramsTargetJSON struct {
+	Func   string      `json:"func"`
+	ID     uint32      `json:"id"`
+	Params []paramJSON `json:"params"`
+}
+
+// funcsToJSON converts resolved BTF functions to their JSON shape.
+func funcsToJSON(funcs []attach.FuncInfo) []funcJSON {
+	out := make([]funcJSON, len(funcs))
+	for i, f := range funcs {
+		out[i] = funcJSON{Name: f.Name, Linkage: f.Linkage}
+	}
+	return out
+}
+
+// emitJSON writes v to stdout as indented JSON. list output is a deliberate
+// program result, so it goes to stdout (not the stderr the text form uses).
+func emitJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encoding JSON: %w", err)
+	}
+	return nil
+}

--- a/cmd/xdp-ninja/listjson.go
+++ b/cmd/xdp-ninja/listjson.go
@@ -17,24 +17,26 @@ type funcJSON struct {
 	Linkage string `json:"linkage"`
 }
 
-// progNodeJSON is one node of a program's reachable tree. Funcs is populated
-// only when --list-funcs is combined with --list-progs.
+// progNodeJSON is one node of a program's reachable tree. Funcs is a pointer
+// so the combined --list-funcs view can emit "funcs": [] (requested, none
+// found) distinctly from omitting the key (funcs not requested at all).
 type progNodeJSON struct {
-	ID     uint32     `json:"id"`
-	Name   string     `json:"name,omitempty"`
-	Via    string     `json:"via,omitempty"`
-	Keys   []uint32   `json:"keys,omitempty"`
-	Depth  int        `json:"depth,omitempty"`
-	Parent uint32     `json:"parent,omitempty"`
-	Funcs  []funcJSON `json:"funcs,omitempty"`
+	ID     uint32      `json:"id"`
+	Name   string      `json:"name,omitempty"`
+	Via    string      `json:"via,omitempty"`
+	Keys   []uint32    `json:"keys,omitempty"`
+	Depth  int         `json:"depth,omitempty"`
+	Parent uint32      `json:"parent,omitempty"`
+	Funcs  *[]funcJSON `json:"funcs,omitempty"`
 }
 
 // progsTargetJSON is one -p / -i target: its entry (root) plus the reachable
-// tree. Funcs is the root's functions when --list-funcs is combined.
+// tree. Funcs is the root's functions when --list-funcs is combined; a
+// pointer for the same present-but-empty vs absent distinction as the nodes.
 type progsTargetJSON struct {
 	ID        uint32         `json:"id"`
 	Func      string         `json:"func"`
-	Funcs     []funcJSON     `json:"funcs,omitempty"`
+	Funcs     *[]funcJSON    `json:"funcs,omitempty"`
 	Reachable []progNodeJSON `json:"reachable"`
 }
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -44,6 +44,10 @@ var flags = []cli.Flag{
 		Name: "prog-id", Aliases: []string{"p"},
 		Usage: "BPF program ID to attach to (use instead of -i for multi-prog setups); repeatable to attach several programs in one run",
 	},
+	&cli.StringSliceFlag{
+		Name:  "prog-name",
+		Usage: "select target program(s) by name instead of ID (requires -i); resolved against the interface's reachable program tree, so you skip looking up numeric IDs. Repeatable. Kernel program names are truncated to 15 chars; a full name matches by prefix",
+	},
 	&cli.StringFlag{
 		Name: "write", Aliases: []string{"w"},
 		Usage: "write packets to pcap file instead of stdout",
@@ -1204,6 +1208,9 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	if len(cmd.IntSlice("prog-id")) > 0 {
 		return fmt.Errorf("--mode xdp does not accept -p (the program is xdp-ninja itself, not an existing one)")
 	}
+	if len(cmd.StringSlice("prog-name")) > 0 {
+		return fmt.Errorf("--mode xdp does not accept --prog-name (the program is xdp-ninja itself, not an existing one)")
+	}
 	if len(cmd.StringSlice("func")) > 0 {
 		return fmt.Errorf("--func is only valid with --mode entry/exit (no BTF subfunction concept in xdp-native)")
 	}
@@ -1225,12 +1232,21 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	ifaceName := cmd.String("interface")
 	progIDs := cmd.IntSlice("prog-id")
+	progNames := cmd.StringSlice("prog-name")
 
 	if ifaceName != "" && len(progIDs) > 0 {
 		return nil, fmt.Errorf("specify either -i or -p, not both")
 	}
 	if ifaceName == "" && len(progIDs) == 0 {
 		return nil, fmt.Errorf("specify -i <interface> or -p <prog-id>")
+	}
+	if len(progNames) > 0 {
+		if ifaceName == "" {
+			return nil, fmt.Errorf("--prog-name requires -i <interface> (names resolve against the interface's reachable program tree)")
+		}
+		if isTC {
+			return nil, fmt.Errorf("--prog-name is XDP-only; select tc clsact targets with -p <prog-id>")
+		}
 	}
 
 	if ifaceName != "" {
@@ -1239,11 +1255,21 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 			// interface-based clsact qdisc walk wired up yet.
 			return nil, fmt.Errorf("--mode tc-* requires -p <prog-id>; interface-based tc target lookup is not implemented")
 		}
-		info, err := attach.FindXDPProgram(ifaceName)
+		root, err := attach.FindXDPProgram(ifaceName)
 		if err != nil {
 			return nil, err
 		}
-		return []*attach.ProgInfo{info}, nil
+		if len(progNames) == 0 {
+			return []*attach.ProgInfo{root}, nil
+		}
+		// Resolve names against the root plus its reachable tree, then open
+		// the matched programs by ID (the root handle is reused if it matches).
+		ids, err := resolveProgNames(root, progNames)
+		if err != nil {
+			_ = root.Program.Close()
+			return nil, err
+		}
+		return openXDPByIDs(root, ids)
 	}
 
 	var infos []*attach.ProgInfo
@@ -1271,6 +1297,50 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 			return nil, err
 		}
 		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+// resolveProgNames maps --prog-name values to program IDs against the root
+// program and its reachable tree. The root's kernel name comes from its
+// program info; reachable node names come from the tree walk.
+func resolveProgNames(root *attach.ProgInfo, names []string) ([]uint32, error) {
+	pi, err := root.Program.Info()
+	if err != nil {
+		return nil, fmt.Errorf("getting root program info: %w", err)
+	}
+	reachable, err := attach.WalkReachablePrograms(root.Program, root.ProgID)
+	if err != nil {
+		return nil, err
+	}
+	return attach.MatchProgramsByName(root.ProgID, pi.Name, reachable, names)
+}
+
+// openXDPByIDs opens each program ID as an attach target, reusing the
+// already-open root handle when its ID is in the set. On error every handle
+// opened here is closed; the caller owns root.
+func openXDPByIDs(root *attach.ProgInfo, ids []uint32) ([]*attach.ProgInfo, error) {
+	var infos []*attach.ProgInfo
+	rootUsed := false
+	for _, id := range ids {
+		if id == root.ProgID {
+			infos = append(infos, root)
+			rootUsed = true
+			continue
+		}
+		info, err := attach.FindXDPProgramByID(id)
+		if err != nil {
+			for _, prev := range infos {
+				if prev != root {
+					_ = prev.Program.Close()
+				}
+			}
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	if !rootUsed {
+		_ = root.Program.Close()
 	}
 	return infos, nil
 }

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -408,12 +408,12 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			if asJSON {
 				jt := progsTargetJSON{ID: info.ProgID, Func: info.FuncName, Reachable: []progNodeJSON{}}
 				if withFuncs {
-					jt.Funcs = listNodeFuncs(info.ProgID, info)
+					jt.Funcs = funcsToJSON(fetchNodeFuncs(info.ProgID, info))
 				}
 				for _, p := range progs {
 					n := progNodeJSON{ID: p.ProgID, Name: p.ProgName, Via: p.Via, Keys: p.Keys, Depth: p.Depth, Parent: p.ParentID}
 					if withFuncs {
-						n.Funcs = listNodeFuncs(p.ProgID, nil)
+						n.Funcs = funcsToJSON(fetchNodeFuncs(p.ProgID, nil))
 					}
 					jt.Reachable = append(jt.Reachable, n)
 				}
@@ -1309,21 +1309,14 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 			// interface-based clsact qdisc walk wired up yet.
 			return nil, fmt.Errorf("--mode tc-* requires -p <prog-id>; interface-based tc target lookup is not implemented")
 		}
-		root, err := attach.FindXDPProgram(ifaceName)
+		if len(progNames) > 0 {
+			return attach.ResolveXDPTargetsByName(ifaceName, progNames)
+		}
+		info, err := attach.FindXDPProgram(ifaceName)
 		if err != nil {
 			return nil, err
 		}
-		if len(progNames) == 0 {
-			return []*attach.ProgInfo{root}, nil
-		}
-		// Resolve names against the root plus its reachable tree, then open
-		// the matched programs by ID (the root handle is reused if it matches).
-		ids, err := resolveProgNames(root, progNames)
-		if err != nil {
-			_ = root.Program.Close()
-			return nil, err
-		}
-		return openXDPByIDs(root, ids)
+		return []*attach.ProgInfo{info}, nil
 	}
 
 	var infos []*attach.ProgInfo
@@ -1361,29 +1354,29 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 // node without BTF (or that fails to open) yields no funcs rather than an
 // error, so one unreadable node does not abort the whole listing.
 func fetchNodeFuncs(progID uint32, root *attach.ProgInfo) []attach.FuncInfo {
-	info := root
-	if info == nil {
-		opened, err := attach.FindXDPProgramByID(progID)
+	if root != nil {
+		// Borrowed handle: reuse its cached BTF spec (loaded during
+		// ResolveTargets) instead of reopening.
+		spec, err := root.BTFSpecCached()
 		if err != nil {
 			return nil
 		}
-		defer func() { _ = opened.Program.Close() }()
-		info = opened
+		funcs, err := attach.ListFuncsFromSpec(spec)
+		if err != nil {
+			return nil
+		}
+		return funcs
 	}
-	spec, err := info.BTFSpecCached()
+	opened, err := attach.FindXDPProgramByID(progID)
 	if err != nil {
 		return nil
 	}
-	funcs, err := attach.ListFuncsFromSpec(spec)
+	defer func() { _ = opened.Program.Close() }()
+	funcs, err := attach.ListFuncs(opened.Program)
 	if err != nil {
 		return nil
 	}
 	return funcs
-}
-
-// listNodeFuncs is fetchNodeFuncs in the JSON shape.
-func listNodeFuncs(progID uint32, root *attach.ProgInfo) []funcJSON {
-	return funcsToJSON(fetchNodeFuncs(progID, root))
 }
 
 // printNodeFuncs prints a node's BTF functions indented under it (text mode).
@@ -1391,50 +1384,6 @@ func printNodeFuncs(progID uint32, root *attach.ProgInfo, indent string) {
 	for _, f := range fetchNodeFuncs(progID, root) {
 		fmt.Fprintf(os.Stderr, "%s%-40s [%s]\n", indent, f.Name, f.Linkage)
 	}
-}
-
-// resolveProgNames maps --prog-name values to program IDs against the root
-// program and its reachable tree. The root's kernel name comes from its
-// program info; reachable node names come from the tree walk.
-func resolveProgNames(root *attach.ProgInfo, names []string) ([]uint32, error) {
-	pi, err := root.Program.Info()
-	if err != nil {
-		return nil, fmt.Errorf("getting root program info: %w", err)
-	}
-	reachable, err := attach.WalkReachablePrograms(root.Program, root.ProgID)
-	if err != nil {
-		return nil, err
-	}
-	return attach.MatchProgramsByName(root.ProgID, pi.Name, reachable, names)
-}
-
-// openXDPByIDs opens each program ID as an attach target, reusing the
-// already-open root handle when its ID is in the set. On error every handle
-// opened here is closed; the caller owns root.
-func openXDPByIDs(root *attach.ProgInfo, ids []uint32) ([]*attach.ProgInfo, error) {
-	var infos []*attach.ProgInfo
-	rootUsed := false
-	for _, id := range ids {
-		if id == root.ProgID {
-			infos = append(infos, root)
-			rootUsed = true
-			continue
-		}
-		info, err := attach.FindXDPProgramByID(id)
-		if err != nil {
-			for _, prev := range infos {
-				if prev != root {
-					_ = prev.Program.Close()
-				}
-			}
-			return nil, err
-		}
-		infos = append(infos, info)
-	}
-	if !rootUsed {
-		_ = root.Program.Close()
-	}
-	return infos, nil
 }
 
 // formatKeyRanges renders a sorted key list compactly, collapsing runs of

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -72,6 +72,10 @@ var flags = []cli.Flag{
 		Name:  "list-progs",
 		Usage: "list programs reachable from the target: tail calls + CPUMAP/DEVMAP/DEVMAP_HASH redirect targets (followed transitively), then exit",
 	},
+	&cli.BoolFlag{
+		Name:  "json",
+		Usage: "emit --list-progs / --list-funcs / --list-params output as JSON on stdout instead of human-readable text on stderr",
+	},
 	&cli.StringSliceFlag{
 		Name:  "arg-filter",
 		Usage: "filter by function argument value (requires --func); format: param=value, param>=val, param<=val, param=min..max, or @NAME to match against a --set pinned-map set",
@@ -393,12 +397,32 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	// CPUMAP/DEVMAP/DEVMAP_HASH redirect targets, followed
 	// transitively) for each target, then exit
 	if cmd.Bool("list-progs") {
+		asJSON := cmd.Bool("json")
+		withFuncs := cmd.Bool("list-funcs")
+		var jsonOut []progsTargetJSON
 		for _, info := range infos {
-			fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
-
 			progs, err := attach.WalkReachablePrograms(info.Program, info.ProgID)
 			if err != nil {
 				return err
+			}
+			if asJSON {
+				jt := progsTargetJSON{ID: info.ProgID, Func: info.FuncName, Reachable: []progNodeJSON{}}
+				if withFuncs {
+					jt.Funcs = listNodeFuncs(info.ProgID, info)
+				}
+				for _, p := range progs {
+					n := progNodeJSON{ID: p.ProgID, Name: p.ProgName, Via: p.Via, Keys: p.Keys, Depth: p.Depth, Parent: p.ParentID}
+					if withFuncs {
+						n.Funcs = listNodeFuncs(p.ProgID, nil)
+					}
+					jt.Reachable = append(jt.Reachable, n)
+				}
+				jsonOut = append(jsonOut, jt)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "id=%-6d %s\n", info.ProgID, info.FuncName)
+			if withFuncs {
+				printNodeFuncs(info.ProgID, info, "    ")
 			}
 			byParent := map[uint32][]attach.ReachableProgram{}
 			for _, p := range progs {
@@ -409,16 +433,26 @@ func run(ctx context.Context, cmd *cli.Command) error {
 				for _, c := range byParent[parent] {
 					fmt.Fprintf(os.Stderr, "%sid=%-6d %s (%s[%s])\n",
 						indent, c.ProgID, c.ProgName, c.Via, formatKeyRanges(c.Keys))
+					if withFuncs {
+						printNodeFuncs(c.ProgID, nil, indent+"    ")
+					}
 					printTree(c.ProgID, indent+"  ")
 				}
 			}
 			printTree(info.ProgID, "  ")
 		}
+		if asJSON {
+			return emitJSON(jsonOut)
+		}
 		return nil
 	}
 
-	// --list-funcs: print available BTF functions per target and exit
+	// --list-funcs: print available BTF functions per target and exit.
+	// (When combined with --list-progs, the funcs are printed per reachable
+	// node in the list-progs handler above, which returns first.)
 	if cmd.Bool("list-funcs") {
+		asJSON := cmd.Bool("json")
+		var jsonOut []funcsTargetJSON
 		for _, info := range infos {
 			spec, err := info.BTFSpecCached()
 			if err != nil {
@@ -428,10 +462,17 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			if err != nil {
 				return err
 			}
+			if asJSON {
+				jsonOut = append(jsonOut, funcsTargetJSON{ID: info.ProgID, Funcs: funcsToJSON(funcs)})
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "BTF functions in program (id=%d):\n", info.ProgID)
 			for _, f := range funcs {
 				fmt.Fprintf(os.Stderr, "  %-40s [%s]\n", f.Name, f.Linkage)
 			}
+		}
+		if asJSON {
+			return emitJSON(jsonOut)
 		}
 		return nil
 	}
@@ -464,7 +505,17 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	// Params were resolved once from each program's cached BTF during
 	// ResolveTargets.
 	if cmd.Bool("list-params") {
+		asJSON := cmd.Bool("json")
+		var jsonOut []paramsTargetJSON
 		for _, t := range targets {
+			if asJSON {
+				jt := paramsTargetJSON{Func: t.FuncName, ID: t.ProgID}
+				for _, p := range t.Params {
+					jt.Params = append(jt.Params, paramJSON{Name: p.Name, Index: p.Index, Size: p.Size, Signed: p.Signed})
+				}
+				jsonOut = append(jsonOut, jt)
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "Filterable parameters for %s (id=%d):\n", t.FuncName, t.ProgID)
 			if len(t.Params) == 0 {
 				fmt.Fprintf(os.Stderr, "  (none - only integer parameters after the first argument are supported)\n")
@@ -476,6 +527,9 @@ func run(ctx context.Context, cmd *cli.Command) error {
 				}
 				fmt.Fprintf(os.Stderr, "  %-20s [%d bytes, %s, arg index %d]\n", p.Name, p.Size, signStr, p.Index)
 			}
+		}
+		if asJSON {
+			return emitJSON(jsonOut)
 		}
 		return nil
 	}
@@ -1299,6 +1353,44 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 		infos = append(infos, info)
 	}
 	return infos, nil
+}
+
+// fetchNodeFuncs resolves the BTF functions of one reachable-tree node for
+// the combined --list-progs --list-funcs view. root is non-nil only for the
+// already-open root program; other nodes are opened by ID and closed here. A
+// node without BTF (or that fails to open) yields no funcs rather than an
+// error, so one unreadable node does not abort the whole listing.
+func fetchNodeFuncs(progID uint32, root *attach.ProgInfo) []attach.FuncInfo {
+	info := root
+	if info == nil {
+		opened, err := attach.FindXDPProgramByID(progID)
+		if err != nil {
+			return nil
+		}
+		defer func() { _ = opened.Program.Close() }()
+		info = opened
+	}
+	spec, err := info.BTFSpecCached()
+	if err != nil {
+		return nil
+	}
+	funcs, err := attach.ListFuncsFromSpec(spec)
+	if err != nil {
+		return nil
+	}
+	return funcs
+}
+
+// listNodeFuncs is fetchNodeFuncs in the JSON shape.
+func listNodeFuncs(progID uint32, root *attach.ProgInfo) []funcJSON {
+	return funcsToJSON(fetchNodeFuncs(progID, root))
+}
+
+// printNodeFuncs prints a node's BTF functions indented under it (text mode).
+func printNodeFuncs(progID uint32, root *attach.ProgInfo, indent string) {
+	for _, f := range fetchNodeFuncs(progID, root) {
+		fmt.Fprintf(os.Stderr, "%s%-40s [%s]\n", indent, f.Name, f.Linkage)
+	}
 }
 
 // resolveProgNames maps --prog-name values to program IDs against the root

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -393,6 +393,13 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 	}()
 
+	// --json only shapes the --list-* output; on a normal capture run it
+	// would silently do nothing while pcap still streamed to stdout. Reject
+	// it early so a JSON-consuming pipeline fails loudly instead.
+	if cmd.Bool("json") && !cmd.Bool("list-progs") && !cmd.Bool("list-funcs") && !cmd.Bool("list-params") {
+		return fmt.Errorf("--json only applies to --list-progs / --list-funcs / --list-params")
+	}
+
 	// --list-progs: show reachable programs (tail calls +
 	// CPUMAP/DEVMAP/DEVMAP_HASH redirect targets, followed
 	// transitively) for each target, then exit
@@ -408,12 +415,14 @@ func run(ctx context.Context, cmd *cli.Command) error {
 			if asJSON {
 				jt := progsTargetJSON{ID: info.ProgID, Func: info.FuncName, Reachable: []progNodeJSON{}}
 				if withFuncs {
-					jt.Funcs = funcsToJSON(fetchNodeFuncs(info.ProgID, info))
+					f := funcsToJSON(fetchNodeFuncs(info.ProgID, info))
+					jt.Funcs = &f
 				}
 				for _, p := range progs {
 					n := progNodeJSON{ID: p.ProgID, Name: p.ProgName, Via: p.Via, Keys: p.Keys, Depth: p.Depth, Parent: p.ParentID}
 					if withFuncs {
-						n.Funcs = funcsToJSON(fetchNodeFuncs(p.ProgID, nil))
+						f := funcsToJSON(fetchNodeFuncs(p.ProgID, nil))
+						n.Funcs = &f
 					}
 					jt.Reachable = append(jt.Reachable, n)
 				}

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -509,7 +509,7 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		var jsonOut []paramsTargetJSON
 		for _, t := range targets {
 			if asJSON {
-				jt := paramsTargetJSON{Func: t.FuncName, ID: t.ProgID}
+				jt := paramsTargetJSON{Func: t.FuncName, ID: t.ProgID, Params: []paramJSON{}}
 				for _, p := range t.Params {
 					jt.Params = append(jt.Params, paramJSON{Name: p.Name, Index: p.Index, Size: p.Size, Signed: p.Signed})
 				}
@@ -1349,30 +1349,28 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 }
 
 // fetchNodeFuncs resolves the BTF functions of one reachable-tree node for
-// the combined --list-progs --list-funcs view. root is non-nil only for the
-// already-open root program; other nodes are opened by ID and closed here. A
-// node without BTF (or that fails to open) yields no funcs rather than an
-// error, so one unreadable node does not abort the whole listing.
+// the combined --list-progs --list-funcs view. root is the already-open node
+// (its handle is borrowed); a nil root means open the program by ID and close
+// it here. A node without BTF (or that fails to open) yields no funcs rather
+// than an error, so one unreadable node does not abort the whole listing.
 func fetchNodeFuncs(progID uint32, root *attach.ProgInfo) []attach.FuncInfo {
-	if root != nil {
-		// Borrowed handle: reuse its cached BTF spec (loaded during
-		// ResolveTargets) instead of reopening.
-		spec, err := root.BTFSpecCached()
+	info := root
+	if info == nil {
+		opened, err := attach.FindXDPProgramByID(progID)
 		if err != nil {
 			return nil
 		}
-		funcs, err := attach.ListFuncsFromSpec(spec)
-		if err != nil {
-			return nil
-		}
-		return funcs
+		defer func() { _ = opened.Program.Close() }()
+		info = opened
 	}
-	opened, err := attach.FindXDPProgramByID(progID)
+	// Both the borrowed root and a fresh FindXDPProgramByID cache their
+	// parsed BTF, so BTFSpecCached reuses it rather than re-parsing (which a
+	// bare attach.ListFuncs(prog) would do).
+	spec, err := info.BTFSpecCached()
 	if err != nil {
 		return nil
 	}
-	defer func() { _ = opened.Program.Close() }()
-	funcs, err := attach.ListFuncs(opened.Program)
+	funcs, err := attach.ListFuncsFromSpec(spec)
 	if err != nil {
 		return nil
 	}

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -1280,9 +1280,10 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	return nil
 }
 
-// findTargets resolves `-p` (repeatable) or `-i` (single) into the target
-// programs. Multiple programs come only from repeated -p; an interface
-// still resolves to the single XDP program attached to it.
+// findTargets resolves `-p` (repeatable) or `-i` into the target programs.
+// Several programs come from repeated -p, or from -i with --prog-name (which
+// picks named programs out of the interface's reachable tree); a bare -i
+// resolves to just the single XDP program attached to the interface.
 func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	ifaceName := cmd.String("interface")
 	progIDs := cmd.IntSlice("prog-id")
@@ -1356,16 +1357,19 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 func fetchNodeFuncs(progID uint32, root *attach.ProgInfo) []attach.FuncInfo {
 	info := root
 	if info == nil {
-		opened, err := attach.FindXDPProgramByID(progID)
+		// Open by generic program ID, not XDP-specific: BTF is type-agnostic,
+		// and a reachable node may be a tc (or other) program whose functions
+		// should still be listed.
+		opened, err := attach.FindBPFProgramByID(progID)
 		if err != nil {
 			return nil
 		}
 		defer func() { _ = opened.Program.Close() }()
 		info = opened
 	}
-	// Both the borrowed root and a fresh FindXDPProgramByID cache their
-	// parsed BTF, so BTFSpecCached reuses it rather than re-parsing (which a
-	// bare attach.ListFuncs(prog) would do).
+	// Both the borrowed root and a fresh Find* cache their parsed BTF, so
+	// BTFSpecCached reuses it rather than re-parsing (which a bare
+	// attach.ListFuncs(prog) would do).
 	spec, err := info.BTFSpecCached()
 	if err != nil {
 		return nil

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -467,8 +467,8 @@ sudo xdp-ninja -i ens2f0 --prog-name upf_dl_v4 --prog-name upf_dl_v6 \
 # 到達ツリーを JSON で
 sudo xdp-ninja -i ens2f0 --list-progs --json | jq '.[].reachable[].name'
 
-# 到達ツリー + 各プログラムの BTF 関数を一括で
-sudo xdp-ninja -i ens2f0 --list-progs --list-funcs
+# 到達ツリー + 各プログラムの BTF 関数を JSON で一括取得
+sudo xdp-ninja -i ens2f0 --list-progs --list-funcs --json | jq '.[].reachable[] | {name, funcs}'
 ```
 
 - 全アタッチポイントが 1本の共有 ringbuf に emit するので、出力は通常どおり 1 つの pcap に時刻順で入ります (`-w` なら終了時マージ、stdout なら直列化ストリーム)。

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -424,7 +424,7 @@ mergecap -w merged.pcap path.pcap.cpu*
 
 `-p` と `--func` はどちらも繰り返し指定できます。各 `--func` は、指定した全プログラムのうち BTF にその関数を持つものすべてにアタッチされます。関数を持たないプログラムはスキップされ、どのプログラムにも無い関数名はエラーになります。`--func` を省略した場合は各プログラムの entry 関数が対象です。
 
-多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) では capture point が方向ごとに別プログラムへ散り、さらに noinline サブ関数は呼び出し元プログラムごとに実体を持ちます。たとえば `pgwu_capture_point_dl` は v4/v6 ハンドラ両方に入ります。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で張れます。
+モバイルコアの UPF を例にすると、上り (UL) と下り (DL) の capture point が別プログラムに分かれ、さらに多段 dispatcher (cpu_dispatch → CPUMAP → 方向別ハンドラ) を通ります。ここで `--func upf_capture_point_dl` が複数プログラムに当たる理由は、noinline サブ関数が呼び出し元プログラムごとに 1 コピーずつコンパイルされるからです。DL の実体が IPv4 ハンドラ (id 1610) と IPv6 ハンドラ (id 1611) の両方にあれば、関数名 1 つで両方へ張れます。UL + DL v4 + DL v6 の全網羅は従来3回の起動が必要でしたが、1回で済みます。
 
 ### `--list-progs` で到達可能プログラムを洗い出す
 
@@ -433,17 +433,42 @@ mergecap -w merged.pcap path.pcap.cpu*
 - tail call は、`bpf_tail_call` が使う `PROG_ARRAY` のエントリ先です。
 - redirect は、`CPUMAP` / `DEVMAP` / `DEVMAP_HASH` のエントリに attach された XDP プログラム、すなわち `bpf_redirect_map()` の飛び先です。
 
-さらにその先も同様に辿るので、`cpu_dispatch → CPUMAP[0..N] → 方向別ハンドラ` から別の redirect へ続くような多段構成でも、末端の実プログラム ID までまとめて出ます。出力された prog ID を `-p` に渡してアタッチします。
+さらにその先も同様に辿るので、`cpu_dispatch → CPUMAP[0..N] → 方向別ハンドラ` から別の redirect へ続くような多段構成でも、末端の実プログラム ID までまとめて出ます。
 
 ```bash
 # --list-progs で dispatcher から末端の prog ID を推移的に洗い出し
 sudo xdp-ninja -i ens2f0 --list-progs
 
-# UL + DL (v4/v6 両実体) を1回でアタッチ。--func pgwu_capture_point_dl は
+# UL + DL (v4/v6 両実体) を1回でアタッチ。--func upf_capture_point_dl は
 # 1610/1611 の両方に、_ul は 1614 だけにマッチする
 sudo xdp-ninja -p 1610 -p 1611 -p 1614 \
-  --func pgwu_capture_point_ul --func pgwu_capture_point_dl \
+  --func upf_capture_point_ul --func upf_capture_point_dl \
   --arg-filter "imsi=999990000000001" -w all.pcap
+```
+
+### ID の代わりに名前で選ぶ (`--prog-name`)
+
+`--list-progs` の出力から prog ID を控えてコピペするのが面倒なときは、`--prog-name` で名前から選べます。`-i` の到達ツリーに対して名前解決するので、ID を調べずに済みます。func 側は従来どおり `--func` を使います。
+
+```bash
+# ID の代わりに名前で選ぶ (-i の到達ツリーから解決)
+sudo xdp-ninja -i ens2f0 --prog-name upf_dl_v4 --prog-name upf_dl_v6 \
+  --func upf_capture_point_dl --arg-filter "imsi=999990000000001" -w dl.pcap
+```
+
+- カーネル上のプログラム名は 15 文字までに切り詰められるので、長い名前は前方一致で解決します。同じ切り詰め名のプログラムが複数あると曖昧としてエラーになるので、その場合は `-p <id>` を使います。
+- `--prog-name` は `-i` 専用です。`--mode xdp` や tc 系では使えません。
+
+### list 出力を JSON で得る (`--json`)
+
+`--json` を付けると、`--list-progs` / `--list-funcs` / `--list-params` の結果をテキストではなく JSON で stdout に出せます。jq などに渡して自動処理したいときに便利です。`--list-progs` と `--list-funcs` を同時に渡すと、到達ツリーの各プログラムにその BTF 関数一覧もぶら下がります。
+
+```bash
+# 到達ツリーを JSON で
+sudo xdp-ninja -i ens2f0 --list-progs --json | jq '.[].reachable[].name'
+
+# 到達ツリー + 各プログラムの BTF 関数を一括で
+sudo xdp-ninja -i ens2f0 --list-progs --list-funcs
 ```
 
 - 全アタッチポイントが 1本の共有 ringbuf に emit するので、出力は通常どおり 1 つの pcap に時刻順で入ります (`-w` なら終了時マージ、stdout なら直列化ストリーム)。
@@ -464,7 +489,7 @@ sudo xdp-ninja set create /sys/fs/bpf/flows --key "imsi:u64,teid:u32" --max-entr
 sudo xdp-ninja set add /sys/fs/bpf/flows imsi=999990000000001 teid=0x3039 tag=1
 
 # 3) キャプチャ (--set で名前を付け、@NAME で参照)
-sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul \
+sudo xdp-ninja -p 1661 --func upf_capture_point_ul \
   --set "flows=/sys/fs/bpf/flows" --arg-filter "@flows" -w out.pcap
 
 # 4) キャプチャ中でも出し入れできる
@@ -524,13 +549,13 @@ sudo xdp-ninja -i eth0 --mode xdp --set "sids=/sys/fs/bpf/sids" \
 
 ```bash
 # 対象関数の絞り込み可能な整数引数を確認
-sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --list-params
+sudo xdp-ninja -p 1661 --func upf_capture_point_ul --list-params
 #   imsi  [8 bytes, unsigned, arg index 1]
 #   teid  [4 bytes, unsigned, arg index 2]
 
 # 1 回だけ観測して終了 (-c 1)
-sudo xdp-ninja -p 1661 --func pgwu_capture_point_ul --arg-echo -c 1
-#   pgwu_capture_point_ul: imsi=999990000000001 (0x38d7c50ba9c01) teid=12345 (0x3039)
+sudo xdp-ninja -p 1661 --func upf_capture_point_ul --arg-echo -c 1
+#   upf_capture_point_ul: imsi=999990000000001 (0x38d7c50ba9c01) teid=12345 (0x3039)
 ```
 
 - `--func` は必須です。表示対象は `--list-params` が挙げる整数引数で、10 進と 16 進を併記します。

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -294,9 +294,11 @@ func WalkReachablePrograms(root *ebpf.Program, rootID uint32) ([]ReachableProgra
 // name instead of a numeric ID. The candidate pool is the root plus every
 // reachable node; rootName/reachable names come from the kernel, which
 // truncates program names to 15 chars (BPF_OBJ_NAME_LEN-1). A requested
-// name matches a candidate when the candidate name is a prefix of it (so a
+// name matches a candidate when they are equal, or when the candidate is at
+// the truncation length (>=15) and is a prefix of the requested name (so a
 // full name like "upf_capture_point_dl" matches the truncated
-// "upf_capture_poi"), or when they are equal.
+// "upf_capture_poi"). A shorter candidate must match exactly, so an
+// untruncated short name cannot falsely prefix a different program's name.
 //
 // Each requested name must resolve to exactly one program. An ambiguous
 // name (several candidates) or an unknown one returns an error naming the

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -315,7 +315,12 @@ func MatchProgramsByName(rootID uint32, rootName string, reachable []ReachablePr
 			if c.name == "" {
 				continue
 			}
-			if c.name == want || strings.HasPrefix(want, c.name) {
+			// Exact match, or a prefix match only when the candidate is at
+			// the kernel truncation limit (>=15). Gating the prefix branch on
+			// length mirrors the BTF-func matcher below and avoids a genuinely
+			// short name (e.g. "xdp_pass") falsely matching a longer requested
+			// name for a different program.
+			if c.name == want || (len(c.name) >= 15 && strings.HasPrefix(want, c.name)) {
 				hits = append(hits, c)
 			}
 		}
@@ -336,6 +341,59 @@ func MatchProgramsByName(rootID uint32, rootName string, reachable []ReachablePr
 		}
 	}
 	return out, nil
+}
+
+// ResolveXDPTargetsByName resolves --prog-name values into attach targets:
+// it finds the interface's root XDP program, walks its reachable tree, maps
+// the names to program IDs, and opens each matched program. It owns the
+// whole transaction so callers never juggle program handles on a partial
+// failure — on any error every handle opened here (including the root) is
+// closed. The returned ProgInfos are the caller's to close on success.
+func ResolveXDPTargetsByName(ifaceName string, names []string) ([]*ProgInfo, error) {
+	root, err := FindXDPProgram(ifaceName)
+	if err != nil {
+		return nil, err
+	}
+	pi, err := root.Program.Info()
+	if err != nil {
+		_ = root.Program.Close()
+		return nil, fmt.Errorf("getting root program info: %w", err)
+	}
+	reachable, err := WalkReachablePrograms(root.Program, root.ProgID)
+	if err != nil {
+		_ = root.Program.Close()
+		return nil, err
+	}
+	ids, err := MatchProgramsByName(root.ProgID, pi.Name, reachable, names)
+	if err != nil {
+		_ = root.Program.Close()
+		return nil, err
+	}
+
+	var infos []*ProgInfo
+	rootUsed := false
+	for _, id := range ids {
+		if id == root.ProgID {
+			infos = append(infos, root)
+			rootUsed = true
+			continue
+		}
+		info, err := FindXDPProgramByID(id)
+		if err != nil {
+			for _, prev := range infos {
+				if prev != root {
+					_ = prev.Program.Close()
+				}
+			}
+			_ = root.Program.Close()
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	if !rootUsed {
+		_ = root.Program.Close()
+	}
+	return infos, nil
 }
 
 // progCand is one (id, name) candidate for name-based program matching.

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -289,6 +289,74 @@ func WalkReachablePrograms(root *ebpf.Program, rootID uint32) ([]ReachableProgra
 	return out, nil
 }
 
+// MatchProgramsByName resolves human-readable program names to program IDs
+// against the reachable set of a root program, so a target can be picked by
+// name instead of a numeric ID. The candidate pool is the root plus every
+// reachable node; rootName/reachable names come from the kernel, which
+// truncates program names to 15 chars (BPF_OBJ_NAME_LEN-1). A requested
+// name matches a candidate when the candidate name is a prefix of it (so a
+// full name like "upf_capture_point_dl" matches the truncated
+// "upf_capture_poi"), or when they are equal.
+//
+// Each requested name must resolve to exactly one program. An ambiguous
+// name (several candidates) or an unknown one returns an error naming the
+// candidates / the available names, so the caller can disambiguate.
+func MatchProgramsByName(rootID uint32, rootName string, reachable []ReachableProgram, names []string) ([]uint32, error) {
+	cands := []progCand{{rootID, rootName}}
+	for _, r := range reachable {
+		cands = append(cands, progCand{r.ProgID, r.ProgName})
+	}
+
+	var out []uint32
+	seen := map[uint32]bool{}
+	for _, want := range names {
+		var hits []progCand
+		for _, c := range cands {
+			if c.name == "" {
+				continue
+			}
+			if c.name == want || strings.HasPrefix(want, c.name) {
+				hits = append(hits, c)
+			}
+		}
+		switch len(hits) {
+		case 0:
+			return nil, fmt.Errorf("no reachable program matches name %q; available: %s", want, availableNames(cands))
+		case 1:
+			if !seen[hits[0].id] {
+				seen[hits[0].id] = true
+				out = append(out, hits[0].id)
+			}
+		default:
+			var ids []string
+			for _, h := range hits {
+				ids = append(ids, fmt.Sprintf("%q(id=%d)", h.name, h.id))
+			}
+			return nil, fmt.Errorf("program name %q is ambiguous, matches: %s (select by -p <id>)", want, strings.Join(ids, ", "))
+		}
+	}
+	return out, nil
+}
+
+// progCand is one (id, name) candidate for name-based program matching.
+type progCand struct {
+	id   uint32
+	name string
+}
+
+// availableNames lists the distinct non-empty candidate names for an error.
+func availableNames(cands []progCand) string {
+	seen := map[string]bool{}
+	var names []string
+	for _, c := range cands {
+		if c.name != "" && !seen[c.name] {
+			seen[c.name] = true
+			names = append(names, c.name)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
 // groupTargets collapses one program's direct targets by (via, program id),
 // merging the map keys so a program reached through many slots (e.g. a
 // per-CPU CPUMAP) becomes a single entry with all keys.

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -658,3 +658,46 @@ func TestWalkReachableProgramsDeepChain(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchProgramsByName(t *testing.T) {
+	// Root plus a reachable tree; names are kernel-truncated (<=15 chars).
+	root := "cpu_dispatch"
+	reach := []ReachableProgram{
+		{ProgID: 1610, ProgName: "upf_dl_v4"},
+		{ProgID: 1611, ProgName: "upf_dl_v6"},
+		{ProgID: 1614, ProgName: "upf_ul_v4"},
+		{ProgID: 99, ProgName: "upf_capture_poi"}, // truncated form of upf_capture_point_dl
+		{ProgID: 88, ProgName: "dup_name"},
+		{ProgID: 89, ProgName: "dup_name"}, // same name -> ambiguous
+		{ProgID: 42, ProgName: ""},         // nameless, never matches
+	}
+
+	// Exact match on the root and a leaf.
+	got, err := MatchProgramsByName(1600, root, reach, []string{"cpu_dispatch", "upf_ul_v4"})
+	if err != nil {
+		t.Fatalf("exact: %v", err)
+	}
+	if len(got) != 2 || got[0] != 1600 || got[1] != 1614 {
+		t.Errorf("exact got %v, want [1600 1614]", got)
+	}
+
+	// A full (untruncated) name matches its truncated candidate by prefix.
+	got, err = MatchProgramsByName(1600, root, reach, []string{"upf_capture_point_dl"})
+	if err != nil {
+		t.Fatalf("prefix: %v", err)
+	}
+	if len(got) != 1 || got[0] != 99 {
+		t.Errorf("prefix got %v, want [99]", got)
+	}
+
+	// Unknown name errors and lists the available names.
+	if _, err := MatchProgramsByName(1600, root, reach, []string{"nope"}); err == nil || !strings.Contains(err.Error(), "no reachable program") {
+		t.Errorf("unknown: %v", err)
+	}
+
+	// Two programs share a (truncated) name, so the name is ambiguous and
+	// the error lists both ids for the user to disambiguate with -p.
+	if _, err := MatchProgramsByName(1600, root, reach, []string{"dup_name"}); err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("ambiguous: %v", err)
+	}
+}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -690,6 +690,12 @@ func TestMatchProgramsByName(t *testing.T) {
 		t.Errorf("prefix got %v, want [99]", got)
 	}
 
+	// A genuinely short name (not truncated) must NOT falsely match a longer
+	// requested name for a different program.
+	if _, err := MatchProgramsByName(1600, root, reach, []string{"upf_ul_v4_extra"}); err == nil || !strings.Contains(err.Error(), "no reachable program") {
+		t.Errorf("short-name false match: %v", err)
+	}
+
 	// Unknown name errors and lists the available names.
 	if _, err := MatchProgramsByName(1600, root, reach, []string{"nope"}); err == nil || !strings.Contains(err.Error(), "no reachable program") {
 		t.Errorf("unknown: %v", err)

--- a/internal/attach/targets.go
+++ b/internal/attach/targets.go
@@ -3,7 +3,7 @@
 // fentry/fexit probe can attach to. Multi-stage dispatchers (cpu_dispatch →
 // CPUMAP → per-direction handlers) put capture points in separate programs,
 // and noinline subfunctions get one copy per calling program (e.g. a
-// `pgwu_capture_point_dl` in both the v4 and the v6 handler), so covering
+// `upf_capture_point_dl` in both the v4 and the v6 handler), so covering
 // UL+DL takes several attaches in one run.
 package attach
 


### PR DESCRIPTION
## 概要

prog/func 発見まわりの CLI UX を改善します。`-p <ID>` を使うのに毎回 `--list-progs` で ID を調べてコピペする手間を減らし、list 系を機械処理しやすくします。

## 追加した機能

### 1. `--prog-name` で名前から選ぶ
`--list-progs` の到達ツリーに対して名前解決し、ID を調べずにターゲットを選べます。`-i` 必須。func 側は従来どおり `--func`。

```bash
sudo xdp-ninja -i ens2f0 --prog-name upf_dl_v4 --prog-name upf_dl_v6 \
  --func upf_capture_point_dl --arg-filter "imsi=..." -w dl.pcap
```

- カーネル上の prog 名は 15 文字に切り詰められるので、フル名は前方一致で解決(切り詰め=候補が 15 文字のときだけ prefix 一致を許可し、短い名前の誤マッチを防止)。
- 同じ切り詰め名が複数あると曖昧エラーで候補 ID を列挙、`-p <id>` にフォールバック。
- 名前マッチは純関数 `attach.MatchProgramsByName`(unit test)、解決トランザクションは `attach.ResolveXDPTargetsByName`(ハンドルの open/close を attach 側に閉じる)。

### 2. `--json` で list 系を JSON 出力
`--list-progs` / `--list-funcs` / `--list-params` を stdout に JSON で出せます。jq 連携用。

```bash
sudo xdp-ninja -i ens2f0 --list-progs --json | jq '.[].reachable[].name'
```

### 3. `--list-progs` + `--list-funcs` 同時
到達ツリーの各プログラムに BTF 関数一覧もぶら下げます(テキストはインデント、JSON は funcs 配列)。BTF 無しノードは funcs 空で skip。

## docs

- `--func` が 1 つの関数名で複数プログラムに当たる理由(noinline サブ関数が呼び出し元ごとに実体を持つ = v4/v6 ハンドラ両方に入る)を明記。
- `pgwu_*` を `upf_*` に中立化し、モバイルコア UPF の例として枠組み直し(特定デプロイに寄らない読み物に)。
- `--prog-name` / `--json` を利用ガイドに追記。

## テスト
- unit: `MatchProgramsByName`(exact / 切り詰め prefix / 短名誤マッチ防止 / 曖昧 / 不一致)。
- 手動 e2e: veth に tail-call scratch XDP を load し、`--prog-name` 解決、`--list-progs`(text/`--json`)、combined view を確認。
- `/simplify` 適用済み(prefix gate の correctness 修正、ハンドル lifecycle を attach へ、`ListFuncs` 再利用、ラッパ削除)。

## スコープ外
- `-i` 無しの全システム走査、正規表現マッチ、JSON schema の後方互換保証。
