### PR TITLE
test(output): microbench the --split-by-tag write-path overhead

### DIFF
--- a/internal/output/split_bench_test.go
+++ b/internal/output/split_bench_test.go
@@ -15,7 +15,7 @@ import (
 // pcapng buffers), not disk — the total bytes written are identical between
 // plain and split, so disk cost is not the delta.
 //
-// Run: go test -bench=BenchmarkSplit -benchmem ./internal/output/
+// Run: go test -run '^$' -bench 'BenchmarkPlain|BenchmarkSplit' -benchmem ./internal/output/
 //
 // Naming: BenchmarkPlain is the flag OFF baseline (one writer). BenchmarkSplit*
 // is the flag ON; the TagsN suffix is the number of DISTINCT tags (1/4/16),
@@ -61,6 +61,7 @@ func interleaved(numTags int) func(i int) uint32 {
 }
 
 func reportPerPkt(b *testing.B) {
+	b.StopTimer() // exclude this reporting from the measured duration
 	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*benchBatch), "ns/pkt")
 }
 
@@ -98,6 +99,11 @@ func benchmarkSplit(b *testing.B, tag func(i int) uint32) {
 		return w
 	}
 	pkts := benchPackets(benchBatch, tag)
+	// Warm up every tag's writer before timing so the one-time os.Create +
+	// pcapng-header init is not charged to the measured write loop.
+	for i := range pkts {
+		writerFor(pkts[i].Tag)
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {

--- a/internal/output/split_bench_test.go
+++ b/internal/output/split_bench_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -21,6 +22,9 @@ import (
 // is the flag ON; the TagsN suffix is the number of DISTINCT tags (1/4/16),
 // not a batch count, and Clustered/Interleaved is how those tags are ordered
 // within a batch (contiguous same-tag runs vs per-packet round-robin).
+//
+// Each benchmark pins XDP_NINJA_FAST_PCAPNG off so it measures the default
+// pcapng writer regardless of the caller's environment.
 
 const benchBatch = 256
 
@@ -40,12 +44,16 @@ func benchPackets(n int, tag func(i int) uint32) []capture.Packet {
 
 func nullWriter(b *testing.B) *Writer {
 	b.Helper()
-	w, err := NewWriter("/dev/null", false)
+	w, err := NewWriter(os.DevNull, false)
 	if err != nil {
 		b.Fatalf("NewWriter: %v", err)
 	}
 	return w
 }
+
+// pinStdWriter forces the default pcapng writer so the measurement does not
+// depend on whether the caller exported XDP_NINJA_FAST_PCAPNG.
+func pinStdWriter(b *testing.B) { b.Setenv("XDP_NINJA_FAST_PCAPNG", "") }
 
 // clustered: same-tag packets arrive contiguously (the common case — one
 // set-map value's flows batch together). numTags contiguous runs per batch.
@@ -69,6 +77,7 @@ func reportPerPkt(b *testing.B) {
 // BenchmarkPlain is the non-split baseline: one writer, one WriteBatch per
 // batch.
 func BenchmarkPlain(b *testing.B) {
+	pinStdWriter(b)
 	w := nullWriter(b)
 	defer func() { _ = w.Close() }()
 	pkts := benchPackets(benchBatch, func(int) uint32 { return 0 })
@@ -85,6 +94,7 @@ func BenchmarkPlain(b *testing.B) {
 // benchmarkSplit mirrors captureLoopShardedSplit.writeShard: run-length group
 // the batch by tag and WriteBatch each run into its per-tag writer.
 func benchmarkSplit(b *testing.B, tag func(i int) uint32) {
+	pinStdWriter(b)
 	writers := map[uint32]*Writer{}
 	defer func() {
 		for _, w := range writers {

--- a/internal/output/split_bench_test.go
+++ b/internal/output/split_bench_test.go
@@ -49,9 +49,10 @@ func nullWriter(b *testing.B) *Writer {
 
 // clustered: same-tag packets arrive contiguously (the common case — one
 // set-map value's flows batch together). numTags contiguous runs per batch.
+// Scale-based so tags stay in [0, numTags) for any numTags in [1, benchBatch]
+// (an even divisor is not required, and there is no division by numTags).
 func clustered(numTags int) func(i int) uint32 {
-	run := benchBatch / numTags
-	return func(i int) uint32 { return uint32(i / run) }
+	return func(i int) uint32 { return uint32(i * numTags / benchBatch) }
 }
 
 // interleaved: tags round-robin per packet (worst case — every packet is its
@@ -95,6 +96,10 @@ func benchmarkSplit(b *testing.B, tag func(i int) uint32) {
 			return w
 		}
 		w := nullWriter(b)
+		// Mirror captureLoopShardedSplit: each live file gets a periodic
+		// flusher, so its ~1 Hz flushMu contention is part of the measurement
+		// (the per-WriteBatch flushMu lock is already on every write).
+		w.EnablePeriodicFlush(time.Second)
 		writers[t] = w
 		return w
 	}

--- a/internal/output/split_bench_test.go
+++ b/internal/output/split_bench_test.go
@@ -1,0 +1,123 @@
+package output
+
+import (
+	"testing"
+	"time"
+
+	"github.com/takehaya/xdp-ninja/internal/capture"
+)
+
+// Benchmarks isolating the userspace overhead that --split-by-tag adds over
+// a plain single-file capture. The in-kernel tag machinery (20B metadata,
+// tag read) is always on regardless of the flag, so the flag's incremental
+// cost is purely this write-path routing + per-tag writers. All writers are
+// backed by /dev/null so the measurement is CPU (routing, lock, per-writer
+// pcapng buffers), not disk — the total bytes written are identical between
+// plain and split, so disk cost is not the delta.
+//
+// Run: go test -bench=BenchmarkSplit -benchmem ./internal/output/
+//
+// Naming: BenchmarkPlain is the flag OFF baseline (one writer). BenchmarkSplit*
+// is the flag ON; the TagsN suffix is the number of DISTINCT tags (1/4/16),
+// not a batch count, and Clustered/Interleaved is how those tags are ordered
+// within a batch (contiguous same-tag runs vs per-packet round-robin).
+
+const benchBatch = 256
+
+func benchPackets(n int, tag func(i int) uint32) []capture.Packet {
+	base := time.Unix(1700000000, 0).UTC()
+	payload := make([]byte, 64) // shared: WritePacket serializes immediately
+	pkts := make([]capture.Packet, n)
+	for i := range pkts {
+		pkts[i] = capture.Packet{
+			Timestamp: base.Add(time.Duration(i) * time.Microsecond),
+			Data:      payload,
+			Tag:       tag(i),
+		}
+	}
+	return pkts
+}
+
+func nullWriter(b *testing.B) *Writer {
+	b.Helper()
+	w, err := NewWriter("/dev/null", false)
+	if err != nil {
+		b.Fatalf("NewWriter: %v", err)
+	}
+	return w
+}
+
+// clustered: same-tag packets arrive contiguously (the common case — one
+// set-map value's flows batch together). numTags contiguous runs per batch.
+func clustered(numTags int) func(i int) uint32 {
+	run := benchBatch / numTags
+	return func(i int) uint32 { return uint32(i / run) }
+}
+
+// interleaved: tags round-robin per packet (worst case — every packet is its
+// own run, so one WriteBatch + one lock per packet).
+func interleaved(numTags int) func(i int) uint32 {
+	return func(i int) uint32 { return uint32(i % numTags) }
+}
+
+func reportPerPkt(b *testing.B) {
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*benchBatch), "ns/pkt")
+}
+
+// BenchmarkPlain is the non-split baseline: one writer, one WriteBatch per
+// batch.
+func BenchmarkPlain(b *testing.B) {
+	w := nullWriter(b)
+	defer func() { _ = w.Close() }()
+	pkts := benchPackets(benchBatch, func(int) uint32 { return 0 })
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := w.WriteBatch(pkts); err != nil {
+			b.Fatal(err)
+		}
+	}
+	reportPerPkt(b)
+}
+
+// benchmarkSplit mirrors captureLoopShardedSplit.writeShard: run-length group
+// the batch by tag and WriteBatch each run into its per-tag writer.
+func benchmarkSplit(b *testing.B, tag func(i int) uint32) {
+	writers := map[uint32]*Writer{}
+	defer func() {
+		for _, w := range writers {
+			_ = w.Close()
+		}
+	}()
+	writerFor := func(t uint32) *Writer {
+		if w := writers[t]; w != nil {
+			return w
+		}
+		w := nullWriter(b)
+		writers[t] = w
+		return w
+	}
+	pkts := benchPackets(benchBatch, tag)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		for i := 0; i < len(pkts); {
+			t := pkts[i].Tag
+			j := i + 1
+			for j < len(pkts) && pkts[j].Tag == t {
+				j++
+			}
+			if err := writerFor(t).WriteBatch(pkts[i:j]); err != nil {
+				b.Fatal(err)
+			}
+			i = j
+		}
+	}
+	reportPerPkt(b)
+}
+
+func BenchmarkSplitTags1(b *testing.B)             { benchmarkSplit(b, func(int) uint32 { return 0 }) }
+func BenchmarkSplitTags4Clustered(b *testing.B)    { benchmarkSplit(b, clustered(4)) }
+func BenchmarkSplitTags16Clustered(b *testing.B)   { benchmarkSplit(b, clustered(16)) }
+func BenchmarkSplitTags4Interleaved(b *testing.B)  { benchmarkSplit(b, interleaved(4)) }
+func BenchmarkSplitTags16Interleaved(b *testing.B) { benchmarkSplit(b, interleaved(16)) }


### PR DESCRIPTION
## 概要

`--split-by-tag`(#72)がユーザー空間の書き込み経路に足す overhead を分離測定する microbench を追加する。カーネル側の tag 機構(20B メタデータ・tag 読み出し)はフラグ非依存で常時 ON なので、フラグ固有の増分コストはこの書き込み経路のみ。全 writer を `/dev/null` backing にして、routing + lock + tag ごとの pcapng バッファの CPU コストだけを見る(総書き込みバイト数は plain/split で同じなのでディスクは差にならない)。

## 命名

- `Plain` = フラグ OFF(単一 writer、baseline)。
- `SplitTagsN...` = フラグ ON。`Split` は機能有効の意味、`TagsN` の N が tag の種類数(1/4/16)。`Clustered`/`Interleaved` は tag の並び(同一 tag 連続 vs パケットごと交互)。

## 実行

```bash
go test -run '^$' -bench 'BenchmarkPlain|BenchmarkSplit' -benchmem ./internal/output/
```

## 参考値(本マシン: 64 並列, Linux 6.15, 256 パケット/バッチ, 64B ペイロード, 3 回計測で安定)

| ケース | ns/pkt | baseline 比 |
|---|---:|---:|
| Plain | 24.6 | — |
| Split 1 tag | 25.0 | +1.6% |
| Split 4 tags clustered | 26.0 | +5.7% |
| Split 16 tags clustered | 27.9 | +13% |
| Split 4 tags interleaved | 45.3 | +84% |
| Split 16 tags interleaved | 53.9 | +119% |

いずれも 0 allocs/pkt。現実的な clustered で +0.4〜3.3 ns/pkt、最悪の interleaved でも +20〜29 ns/pkt。過去実測の observer 天井(~583〜722 ns/pkt)に対し、split の増分は clustered で予算の <0.5%、最悪でも ~5% で、キャプチャ全体のスループットにはほぼ影響しない。