### PR TITLE
fix(cli): stop comma-splitting root slice flags so --set key(...) works

### DIFF
--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -250,7 +250,18 @@ func ensureAsyncPreemptDisabled() {
 
 func main() {
 	ensureAsyncPreemptDisabled()
-	app := &cli.Command{
+	app := newRootCommand()
+
+	if err := app.Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// newRootCommand builds the top-level CLI. Extracted from main so tests can
+// assert its parsing behaviour (see TestSetFlagNotCommaSplit).
+func newRootCommand() *cli.Command {
+	return &cli.Command{
 		Name:      "xdp-ninja",
 		Version:   fmt.Sprintf("%s, commit %s, built at %s, built by %s", version, commit, date, builtBy),
 		Usage:     "capture packets at XDP time (fentry/fexit observer or standalone XDP)",
@@ -277,16 +288,13 @@ Examples:
 		Commands:              []*cli.Command{convertCommand, setCommand, mergeCommand},
 		EnableShellCompletion: true,
 		// Do not split slice-flag values on commas. --set carries a key
-		// mapping whose own syntax uses commas (NAME=/path,key(f1=arg:p1,f2)),
-		// which the default separator would tear apart. Repeatable flags
-		// (--set, --func, --prog-name, --arg-filter) still take one value per
-		// occurrence; pass them multiple times instead of comma-joining.
+		// mapping whose own syntax uses commas
+		// (NAME=/path,key(f1=arg:p1,f2=arg:p2)), which the default separator
+		// would tear apart. Every root slice flag (--set, --func,
+		// --prog-name, --arg-filter, --prog-id/-p) therefore takes one value
+		// per occurrence; pass them multiple times instead of comma-joining.
+		// Subcommands keep the default separator.
 		DisableSliceFlagSeparator: true,
-	}
-
-	if err := app.Run(context.Background(), os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
 	}
 }
 

--- a/cmd/xdp-ninja/main.go
+++ b/cmd/xdp-ninja/main.go
@@ -276,6 +276,12 @@ Examples:
 		Action:                run,
 		Commands:              []*cli.Command{convertCommand, setCommand, mergeCommand},
 		EnableShellCompletion: true,
+		// Do not split slice-flag values on commas. --set carries a key
+		// mapping whose own syntax uses commas (NAME=/path,key(f1=arg:p1,f2)),
+		// which the default separator would tear apart. Repeatable flags
+		// (--set, --func, --prog-name, --arg-filter) still take one value per
+		// occurrence; pass them multiple times instead of comma-joining.
+		DisableSliceFlagSeparator: true,
 	}
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/cmd/xdp-ninja/setflag_test.go
+++ b/cmd/xdp-ninja/setflag_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+// parseSetFlags runs the real root command (with its Action swapped for a
+// capture) over the given args and returns the parsed --set slice.
+func parseSetFlags(t *testing.T, args ...string) []string {
+	t.Helper()
+	app := newRootCommand()
+	var got []string
+	app.Action = func(_ context.Context, c *cli.Command) error {
+		got = c.StringSlice("set")
+		return nil
+	}
+	if err := app.Run(context.Background(), append([]string{"xdp-ninja"}, args...)); err != nil {
+		t.Fatalf("run %v: %v", args, err)
+	}
+	return got
+}
+
+// TestSetFlagNotCommaSplit guards the DisableSliceFlagSeparator wiring: a
+// single --set value carrying a comma-bearing key(...) mapping must reach the
+// action as one element, and repeated --set must still accumulate.
+func TestSetFlagNotCommaSplit(t *testing.T) {
+	if !newRootCommand().DisableSliceFlagSeparator {
+		t.Fatal("root command must set DisableSliceFlagSeparator so --set key(...) is not comma-split")
+	}
+
+	const spec = "NAME=/sys/fs/bpf/flows,key(imsi=arg:subscriber,teid=arg:teid)"
+	if got := parseSetFlags(t, "--set", spec); len(got) != 1 || got[0] != spec {
+		t.Fatalf("--set with commas parsed as %q, want single element %q", got, spec)
+	}
+
+	if got := parseSetFlags(t, "--set", "A=/a", "--set", "B=/b"); len(got) != 2 {
+		t.Fatalf("repeated --set gave %q, want 2 elements", got)
+	}
+}


### PR DESCRIPTION
## 概要

`--set NAME=/path,key(field=arg:param,...)` の明示キー対応付けが CLI で使えなかった不具合を直す。

## 原因

`--set` は `StringSliceFlag` で、urfave/cli v3 は単一値をカンマで分割する。そのため

```
--set "WATCH=/sys/fs/bpf/imsi_watch,key(imsi=arg:imsi)"
  → ["WATCH=/sys/fs/bpf/imsi_watch", "key(imsi=arg:imsi)"]
```

と割れ、2つ目 `key(imsi=arg:imsi)` が壊れた set spec として解釈され `opening pinned map arg:imsi): no such file or directory` になっていた。`ParseSetSpec` 自体はカンマ構文を正しく解釈できるのに、その手前で値が壊されていた(docs/ja/dsl-usage.md にも載っている構文が実際には使えなかった)。

## 修正

root コマンドに `DisableSliceFlagSeparator: true` を設定し、スライスフラグのカンマ分割を無効化する。

- 効果: `--set`/`--func`/`--prog-name`/`--arg-filter` は1回の指定で1値になり、`key(...)` のカンマがそのまま渡る。
- スコープ: root フラグのみ。サブコマンド(例 `convert --read`)はカンマ分割を維持(実機で伝播しないことを確認)。
- 繰り返し指定(`--func a --func b` 等)は従来どおり。カンマ結合は非対応になるが、繰り返しが元々の推奨イディオム。

## 検証

- 実機: `--set "WATCH=/x,key(imsi=arg:imsi)"` が set-parse を通過して attach 段階まで到達(修正前は set-parse で失敗)。繰り返し `--prog-name`/`--func` も正常。`convert -r a,b` は依然分割される(サブコマンド無変更)。
- `go build` + `make test`(unit)+ `golangci-lint` all green。カンマ複数値に依存するテスト/docs は無し。