### PR TITLE
test(scripts): add a capture-point program + arg-filter integration test

### DIFF
--- a/scripts/test/cleanup_argcap.sh
+++ b/scripts/test/cleanup_argcap.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo ip link delete va0 2>/dev/null || true
+sudo ip netns delete xdpargtest 2>/dev/null || true

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -261,10 +261,17 @@ test_argfilter() {
     kill $pn 2>/dev/null; wait $pn 2>/dev/null || true
     local cnomatch=$(capture_count "$errn")
 
-    echo "argfilter match=$cmatch nomatch=$cnomatch stderr_m=$(cat "$errm") stderr_n=$(cat "$errn")" >&2
+    # Both runs must reach the normal shutdown ("N packets captured");
+    # otherwise a crash/parse error before capture would leave cnomatch=0 and
+    # false-pass the nomatch half.
+    local ranm=0 rann=0
+    grep -q "packets captured" "$errm" && ranm=1
+    grep -q "packets captured" "$errn" && rann=1
+
+    echo "argfilter match=$cmatch nomatch=$cnomatch ranm=$ranm rann=$rann stderr_m=$(cat "$errm") stderr_n=$(cat "$errn")" >&2
     rm -f "$errm" "$errn"
     "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
-    [[ "$cmatch" -ge 3 && "$cnomatch" -eq 0 ]]
+    [[ "$ranm" -eq 1 && "$rann" -eq 1 && "$cmatch" -ge 3 && "$cnomatch" -eq 0 ]]
 }
 
 test_graceful_shutdown() {

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -230,6 +230,42 @@ test_dsl_tc_exit_action() {
     run_count_test 3 --mode tc-exit -p "$pid_t" -c 3 "eth/ipv4/icmp where action == TC_ACT_OK"
 }
 
+# Exercises --func subfunction attach + --arg-filter argument reading against
+# xdp_argcap, whose capture_point(ctx, pkt_len) uses KEEP_ARGS to keep pkt_len
+# on the ABI. A real ping frame (~98 B) satisfies pkt_len>=60 (match) but none
+# is >=200 (nomatch); requiring both proves the argument value is actually read
+# rather than always/never matching.
+test_argfilter() {
+    "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
+    if ! "$SCRIPT_DIR/setup_argcap.sh" >/dev/null 2>&1; then
+        echo "setup_argcap failed" >&2
+        "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
+        return 1
+    fi
+
+    local errm=$(mktemp)
+    timeout 10 "$BINARY" -i va0 --func capture_point --arg-filter "pkt_len>=60" -c 3 > /dev/null 2>"$errm" &
+    local pm=$!
+    sleep 2
+    ip netns exec xdpargtest ping -c 5 -W 1 10.99.0.1 >/dev/null 2>&1 || true
+    wait $pm 2>/dev/null || true
+    local cmatch=$(capture_count "$errm")
+
+    local errn=$(mktemp)
+    timeout 6 "$BINARY" -i va0 --func capture_point --arg-filter "pkt_len>=200" > /dev/null 2>"$errn" &
+    local pn=$!
+    sleep 1
+    ip netns exec xdpargtest ping -c 3 -W 1 10.99.0.1 >/dev/null 2>&1 || true
+    sleep 2
+    kill $pn 2>/dev/null; wait $pn 2>/dev/null || true
+    local cnomatch=$(capture_count "$errn")
+
+    echo "argfilter match=$cmatch nomatch=$cnomatch stderr_m=$(cat "$errm") stderr_n=$(cat "$errn")" >&2
+    rm -f "$errm" "$errn"
+    "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
+    [[ "$cmatch" -ge 3 && "$cnomatch" -eq 0 ]]
+}
+
 test_graceful_shutdown() {
     require_bpftool || return 1
     local prog_id_before=$(bpftool prog show name xdp_pass 2>/dev/null | head -1 | awk '{print $1}' | tr -d ':')
@@ -275,6 +311,7 @@ run_test "dsl_capture_headers"     test_dsl_capture_headers
 run_test "dsl_exit_action"         test_dsl_exit_action
 run_test "dsl_tc_entry"            test_dsl_tc_entry
 run_test "dsl_tc_exit_action"      test_dsl_tc_exit_action
+run_test "argfilter"               test_argfilter
 run_test "graceful_shutdown"       test_graceful_shutdown
 
 echo ""

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -237,8 +237,9 @@ test_dsl_tc_exit_action() {
 # rather than always/never matching.
 test_argfilter() {
     "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
-    if ! "$SCRIPT_DIR/setup_argcap.sh" >/dev/null 2>&1; then
-        echo "setup_argcap failed" >&2
+    local setup_out
+    if ! setup_out=$("$SCRIPT_DIR/setup_argcap.sh" 2>&1); then
+        echo "setup_argcap failed: $setup_out" >&2
         "$SCRIPT_DIR/cleanup_argcap.sh" 2>/dev/null || true
         return 1
     fi

--- a/scripts/test/setup_argcap.sh
+++ b/scripts/test/setup_argcap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Sets up an XDP program with a __noinline capture point on va0, for testing
 # xdp-ninja --func + --arg-filter. Traffic sent to 10.99.0.1 runs the program,
-# which calls capture_point(pkt_len).
+# which calls capture_point(ctx, pkt_len).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/test/setup_argcap.sh
+++ b/scripts/test/setup_argcap.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Sets up an XDP program with a __noinline capture point on va0, for testing
+# xdp-ninja --func + --arg-filter. Traffic sent to 10.99.0.1 runs the program,
+# which calls capture_point(pkt_len).
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OBJ="$SCRIPT_DIR/xdp_argcap.o"
+
+# Compile (needs sudo because the test dir may be root-owned). -I so the
+# program's #include "keep_args.h" resolves; -g so BTF carries the
+# capture_point func_info and its pkt_len parameter name.
+clang -O2 -g -target bpf -I "$SCRIPT_DIR" -c "$SCRIPT_DIR/xdp_argcap.c" -o "$OBJ" 2>/dev/null || \
+    sudo clang -O2 -g -target bpf -I "$SCRIPT_DIR" -c "$SCRIPT_DIR/xdp_argcap.c" -o "$OBJ"
+
+# Create netns + veth
+sudo ip netns add xdpargtest
+sudo ip link add va0 type veth peer name va1
+sudo ip link set va1 netns xdpargtest
+sudo ip addr add 10.99.0.1/24 dev va0
+sudo ip netns exec xdpargtest ip addr add 10.99.0.2/24 dev va1
+sudo ip link set va0 up
+sudo ip netns exec xdpargtest ip link set va1 up
+
+# Attach the program to va0 so it runs on ingress traffic.
+sudo ip link set dev va0 xdp obj "$OBJ" sec xdp
+
+echo "argcap loaded on va0 (capture_point subfunction)" >&2

--- a/scripts/test/xdp_argcap.c
+++ b/scripts/test/xdp_argcap.c
@@ -1,0 +1,30 @@
+// XDP program with a __noinline capture point, used to test xdp-ninja's
+// --func subfunction attach + --arg-filter argument reading.
+//
+// capture_point(ctx, pkt_len) mirrors a real datapath capture point: the
+// first argument is the context pointer (which xdp-ninja treats as the
+// implicit ctx and does not expose), and pkt_len is the filterable arg that
+// --arg-filter reads. pkt_len is otherwise unused, so KEEP_ARGS (keep_args.h)
+// is what keeps it on the ABI — without it the compiler would drop the dead
+// argument and xdp-ninja could not read it.
+
+#include <linux/bpf.h>
+
+#include "keep_args.h"
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+__attribute__((noinline)) int capture_point(struct xdp_md *ctx, __u32 pkt_len) {
+  KEEP_ARGS(ctx, pkt_len);
+  return 0;
+}
+
+SEC("xdp")
+int xdp_argcap(struct xdp_md *ctx) {
+  void *data = (void *)(long)ctx->data;
+  void *data_end = (void *)(long)ctx->data_end;
+  capture_point(ctx, (__u32)(data_end - data));
+  return 2; /* XDP_PASS */
+}
+
+char _license[] SEC("license") = "GPL";

--- a/scripts/test/xdp_argcap.c
+++ b/scripts/test/xdp_argcap.c
@@ -24,7 +24,7 @@ int xdp_argcap(struct xdp_md *ctx) {
   void *data = (void *)(long)ctx->data;
   void *data_end = (void *)(long)ctx->data_end;
   capture_point(ctx, (__u32)(data_end - data));
-  return 2; /* XDP_PASS */
+  return XDP_PASS;
 }
 
 char _license[] SEC("license") = "GPL";

--- a/scripts/test/xdp_argcap.c
+++ b/scripts/test/xdp_argcap.c
@@ -23,7 +23,9 @@ SEC("xdp")
 int xdp_argcap(struct xdp_md *ctx) {
   void *data = (void *)(long)ctx->data;
   void *data_end = (void *)(long)ctx->data_end;
-  capture_point(ctx, (__u32)(data_end - data));
+  // char* (not void*) subtraction: a byte-sized ptrdiff in standard C,
+  // avoiding the void*-arithmetic GNU extension (-Wpointer-arith).
+  capture_point(ctx, (__u32)((char *)data_end - (char *)data));
   return XDP_PASS;
 }
 


### PR DESCRIPTION
## 概要

`keep_args.h`(#76)を使うサンプルの capture-point プログラムと、`--func` サブ関数アタッチ + `--arg-filter` の引数読み出しを検証する統合テストを追加する。

## 追加物

- `scripts/test/xdp_argcap.c` — `__noinline` な `capture_point(struct xdp_md *ctx, __u32 pkt_len)` を持つ XDP プログラム。先頭の `ctx` は xdp-ninja が暗黙の context として扱い露出しない引数、`pkt_len` が `--arg-filter` の対象(arg index 1)。`pkt_len` は本体で未使用なので `KEEP_ARGS(ctx, pkt_len)` が ABI に残す(無ければコンパイラが落として読めなくなる)。
- `scripts/test/setup_argcap.sh` / `cleanup_argcap.sh` — 専用 veth `va0` にプログラムをロード/破棄(tailcall テストと同じ分離セットアップ方式)。
- `run_tests.sh` に `test_argfilter` を追加。`-i va0 --func capture_point` で、`--arg-filter "pkt_len>=60"` は実 ping フレーム(~98 B)を捕捉、`"pkt_len>=200"` は捕捉ゼロ。両方を要求することで、引数値が実際に読まれている(常に一致/不一致ではない)ことを保証する。

## 検証

- `--list-params` が `pkt_len [4 bytes, unsigned, arg index 1]` を表示。
- match(≥60)=3、nomatch(≥200)=0 を実機確認。
- フル統合スイート(`make test-integration` 相当)17 passed / 0 failed。生成 `.o` は gitignore 済み。