### PR TITLE
feat(setmap): add `set resize` to change a pinned set's capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ sudo xdp-ninja set create /sys/fs/bpf/subs --key "imsi:u64"
 sudo xdp-ninja set add /sys/fs/bpf/subs imsi=999990000000001
 sudo xdp-ninja -p 1661 --func upf_capture_point_ul \
   --set "subs=/sys/fs/bpf/subs" --arg-filter "@subs" -w subs.pcap
+# Capacity defaults to 1024 (set create --max-entries); grow it later
+# with `set resize` (entries and schema are preserved, takes effect
+# from the next attach)
+sudo xdp-ninja set resize /sys/fs/bpf/subs --max-entries 4096
 
 # Key the set off a PACKET field instead of a function arg — for values
 # that live in the packet (GTP TEID, SRv6 SID). Works on fentry and xdp.

--- a/cmd/xdp-ninja/set.go
+++ b/cmd/xdp-ninja/set.go
@@ -27,8 +27,9 @@ Examples:
   xdp-ninja set add    /sys/fs/bpf/flows imsi=999990000000001 teid=0x3039 tag=1
   xdp-ninja set del    /sys/fs/bpf/flows imsi=999990000000001 teid=0x3039
   xdp-ninja set list   /sys/fs/bpf/flows
-  xdp-ninja set schema /sys/fs/bpf/flows`,
-	Commands: []*cli.Command{setCreateCmd, setAddCmd, setDelCmd, setListCmd, setSchemaCmd},
+  xdp-ninja set schema /sys/fs/bpf/flows
+  xdp-ninja set resize /sys/fs/bpf/flows --max-entries 4096`,
+	Commands: []*cli.Command{setCreateCmd, setAddCmd, setDelCmd, setListCmd, setSchemaCmd, setResizeCmd},
 }
 
 var setCreateCmd = &cli.Command{
@@ -63,6 +64,45 @@ var setCreateCmd = &cli.Command{
 		}
 		fmt.Fprintf(os.Stderr, "created %s (key: %s, value: %s, max_entries: %d)\n",
 			path, cmd.String("key"), cmd.String("value"), cmd.Int("max-entries"))
+		return nil
+	},
+}
+
+var setResizeCmd = &cli.Command{
+	Name:      "resize",
+	Usage:     "change a set's capacity (copies entries into a new map, swaps the pin)",
+	ArgsUsage: "<pin-path>",
+	Description: `BPF maps cannot change max_entries in place, so resize creates a new
+map with the same key/value BTF, copies every entry, and atomically
+replaces the pin. A running capture keeps the old map from attach time;
+the new capacity takes effect from the next attach. Entries added
+between the copy and the swap are lost, so resize while no writer is
+active.`,
+	Flags: []cli.Flag{
+		&cli.IntFlag{
+			Name: "max-entries", Required: true,
+			Usage: "new map capacity",
+		},
+	},
+	Action: func(_ context.Context, cmd *cli.Command) error {
+		path, err := setPathArg(cmd)
+		if err != nil {
+			return err
+		}
+		maxEntries := cmd.Int("max-entries")
+		if maxEntries <= 0 || maxEntries > math.MaxUint32 {
+			return fmt.Errorf("--max-entries must be in 1..%d, got %d", math.MaxUint32, maxEntries)
+		}
+		oldMax, copied, err := setmap.Resize(path, uint32(maxEntries))
+		if err != nil {
+			return err
+		}
+		if oldMax == uint32(maxEntries) {
+			fmt.Fprintf(os.Stderr, "%s already has max_entries %d, nothing to do\n", path, oldMax)
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "resized %s (max_entries: %d -> %d, copied %d entries)\n",
+			path, oldMax, maxEntries, copied)
 		return nil
 	},
 }

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -482,7 +482,8 @@ sudo xdp-ninja -i ens2f0 --list-progs --list-funcs --json | jq '.[].reachable[] 
 map のキーが照合する値そのもので、スカラまたは struct 複合キーになります。value は小さな tag です。複合キーのフィールド間は AND で 1 lookup し、OR はエントリを複数入れて表現します。すなわち集合は直和です。部分キーは不可です。
 
 ```bash
-# 1) 集合を作る (BTF 付き hash map を pin)
+# 1) 集合を作る (BTF 付き hash map を pin)。--max-entries は省略可で既定 1024、
+#    1〜2^32-1 で指定できる
 sudo xdp-ninja set create /sys/fs/bpf/flows --key "imsi:u64,teid:u32" --max-entries 1024
 
 # 2) エントリ投入 (フィールド名で指定。幅・パディングはツールが保証)
@@ -497,7 +498,12 @@ sudo xdp-ninja set add /sys/fs/bpf/flows imsi=999990000000777 teid=100
 sudo xdp-ninja set del /sys/fs/bpf/flows imsi=999990000000001 teid=0x3039
 sudo xdp-ninja set list /sys/fs/bpf/flows
 sudo xdp-ninja set schema /sys/fs/bpf/flows
+
+# 5) 容量が足りなくなったら resize (エントリと BTF スキーマは保たれる)
+sudo xdp-ninja set resize /sys/fs/bpf/flows --max-entries 4096
 ```
+
+`set resize` は BPF map の容量を後から変えられない制約を、同じスキーマの新 map を作ってエントリを全コピーし pin を差し替えることで回避します。実行中のキャプチャは attach 時の旧 map を掴んだままなので、新しい容量は次回 attach から有効です。コピーと差し替えの間に旧 map へ入れたエントリは失われるため、resize は `set add` を止めてから行ってください。
 
 - キーの対応付けは、既定ではキーの BTF フィールド名と fentry 引数名を同名で一致させます。名前が違うときは `--set "flows=/sys/fs/bpf/flows,key(imsi=arg:subscriber,teid=arg:teid)"` と明示します。`()` は bash のメタ文字なのでクオートが必須です。
 - `@NAME` は他の `--arg-filter` と AND で合成されます。`--set` は複数定義できます。

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -6,8 +6,10 @@ package setmap
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"strconv"
@@ -240,6 +242,8 @@ func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
 	tmp := path + "_resize_tmp"
 	if _, serr := os.Stat(tmp); serr == nil {
 		return 0, 0, fmt.Errorf("%s exists (crashed or concurrent resize?); remove it and retry", tmp)
+	} else if !errors.Is(serr, fs.ErrNotExist) {
+		return 0, 0, fmt.Errorf("checking %s: %w", tmp, serr)
 	}
 
 	keyBTF, valueBTF, err := mapBTFTypes(m)
@@ -268,8 +272,11 @@ func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
 		return 0, 0, fmt.Errorf("pinning at %s: %w", tmp, err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
-		_ = next.Unpin()
-		return 0, 0, fmt.Errorf("replacing pin %s: %w", path, err)
+		err = fmt.Errorf("replacing pin %s: %w", path, err)
+		if uerr := next.Unpin(); uerr != nil {
+			err = errors.Join(err, fmt.Errorf("cleaning up %s (remove it before retrying): %w", tmp, uerr))
+		}
+		return 0, 0, err
 	}
 	return oldMax, copied, nil
 }

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -222,13 +222,24 @@ func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
 	}
 
 	// Count first so a shrink below the live entry count fails up front
-	// instead of erroring out mid-copy with a half-populated new map.
-	entries, err := dumpEntries(m)
+	// instead of erroring out mid-copy with a half-populated new map. A
+	// separate counting pass (rather than snapshotting the entries) keeps
+	// memory flat for large sets; the copy below streams a second pass.
+	count, err := countEntries(m)
 	if err != nil {
 		return 0, 0, fmt.Errorf("%s: reading entries: %w", path, err)
 	}
-	if uint64(len(entries)) > uint64(newMax) {
-		return 0, 0, fmt.Errorf("%s holds %d entries; cannot shrink to %d", path, len(entries), newMax)
+	if count > uint64(newMax) {
+		return 0, 0, fmt.Errorf("%s holds %d entries; cannot shrink to %d", path, count, newMax)
+	}
+
+	// The temporary pin name avoids '.' — bpffs rejects dotted pin names
+	// with EPERM (bpf_lookup reserves the dot). It is deterministic, so a
+	// leftover from a crashed resize (or a concurrent one) would fail the
+	// Pin below with a bare EEXIST; surface it with a recovery hint.
+	tmp := path + "_resize_tmp"
+	if _, serr := os.Stat(tmp); serr == nil {
+		return 0, 0, fmt.Errorf("%s exists (crashed or concurrent resize?); remove it and retry", tmp)
 	}
 
 	keyBTF, valueBTF, err := mapBTFTypes(m)
@@ -248,15 +259,11 @@ func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
 		return 0, 0, fmt.Errorf("creating resized map: %w", err)
 	}
 	defer func() { _ = next.Close() }()
-	for _, ent := range entries {
-		if perr := next.Put(ent.key, ent.value); perr != nil {
-			return 0, 0, fmt.Errorf("copying entry: %w", perr)
-		}
+	copied, err = copyEntries(m, next)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: copying entries: %w", path, err)
 	}
 
-	// bpffs rejects pin names containing '.' with EPERM (bpf_lookup
-	// reserves the dot), so the temporary name uses an underscore suffix.
-	tmp := path + "_resize_tmp"
 	if err := next.Pin(tmp); err != nil {
 		return 0, 0, fmt.Errorf("pinning at %s: %w", tmp, err)
 	}
@@ -264,25 +271,35 @@ func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
 		_ = next.Unpin()
 		return 0, 0, fmt.Errorf("replacing pin %s: %w", path, err)
 	}
-	return oldMax, len(entries), nil
+	return oldMax, copied, nil
 }
 
-// rawEntry is one key/value pair captured verbatim (no schema decoding).
-type rawEntry struct{ key, value []byte }
-
-// dumpEntries snapshots every entry of the map as raw bytes.
-func dumpEntries(m *ebpf.Map) ([]rawEntry, error) {
-	var out []rawEntry
+// countEntries walks the map without retaining anything.
+func countEntries(m *ebpf.Map) (uint64, error) {
+	var n uint64
 	key := make([]byte, int(m.KeySize()))
 	val := make([]byte, int(m.ValueSize()))
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
-		out = append(out, rawEntry{
-			key:   append([]byte(nil), key...),
-			value: append([]byte(nil), val...),
-		})
+		n++
 	}
-	return out, iter.Err()
+	return n, iter.Err()
+}
+
+// copyEntries streams every entry of src into dst as raw bytes (no schema
+// decoding), one at a time so memory stays flat for large sets.
+func copyEntries(src, dst *ebpf.Map) (int, error) {
+	var n int
+	key := make([]byte, int(src.KeySize()))
+	val := make([]byte, int(src.ValueSize()))
+	iter := src.Iterate()
+	for iter.Next(&key, &val) {
+		if err := dst.Put(key, val); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, iter.Err()
 }
 
 // reservedTagName is the field=value key that `set add`/`del` treat as

--- a/internal/setmap/ops.go
+++ b/internal/setmap/ops.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -193,6 +194,95 @@ func Create(path, keySchema, valueSchema string, maxEntries uint32) error {
 		return fmt.Errorf("pinning at %s: %w", path, err)
 	}
 	return nil
+}
+
+// Resize changes a pinned set map's capacity. BPF maps cannot change
+// max_entries in place, so this creates a new map with the same key/value
+// BTF (reused from the old map, so externally-created maps keep their
+// names and types), copies every entry, and atomically replaces the pin
+// via rename(2) on bpffs. Returns the old capacity and the entry count.
+//
+// Two caveats, by construction:
+//   - A running capture holds the old map's fd from attach time; the new
+//     capacity takes effect from the next attach, not for live sessions.
+//   - Entries added to the old map between the copy and the pin swap are
+//     lost. Resize while no writer is active.
+func Resize(path string, newMax uint32) (oldMax uint32, copied int, err error) {
+	m, err := ebpf.LoadPinnedMap(path, nil)
+	if err != nil {
+		return 0, 0, fmt.Errorf("opening pinned map %s: %w", path, err)
+	}
+	defer func() { _ = m.Close() }()
+	if m.Type() != ebpf.Hash {
+		return 0, 0, fmt.Errorf("%s: map type %s is not supported (need hash)", path, m.Type())
+	}
+	oldMax = m.MaxEntries()
+	if oldMax == newMax {
+		return oldMax, 0, nil
+	}
+
+	// Count first so a shrink below the live entry count fails up front
+	// instead of erroring out mid-copy with a half-populated new map.
+	entries, err := dumpEntries(m)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: reading entries: %w", path, err)
+	}
+	if uint64(len(entries)) > uint64(newMax) {
+		return 0, 0, fmt.Errorf("%s holds %d entries; cannot shrink to %d", path, len(entries), newMax)
+	}
+
+	keyBTF, valueBTF, err := mapBTFTypes(m)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: %w", path, err)
+	}
+	info, err := m.Info()
+	if err != nil {
+		return 0, 0, fmt.Errorf("%s: map info: %w", path, err)
+	}
+	next, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name: info.Name, Type: m.Type(), Flags: m.Flags(),
+		KeySize: m.KeySize(), ValueSize: m.ValueSize(), MaxEntries: newMax,
+		Key: keyBTF, Value: valueBTF,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("creating resized map: %w", err)
+	}
+	defer func() { _ = next.Close() }()
+	for _, ent := range entries {
+		if perr := next.Put(ent.key, ent.value); perr != nil {
+			return 0, 0, fmt.Errorf("copying entry: %w", perr)
+		}
+	}
+
+	// bpffs rejects pin names containing '.' with EPERM (bpf_lookup
+	// reserves the dot), so the temporary name uses an underscore suffix.
+	tmp := path + "_resize_tmp"
+	if err := next.Pin(tmp); err != nil {
+		return 0, 0, fmt.Errorf("pinning at %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = next.Unpin()
+		return 0, 0, fmt.Errorf("replacing pin %s: %w", path, err)
+	}
+	return oldMax, len(entries), nil
+}
+
+// rawEntry is one key/value pair captured verbatim (no schema decoding).
+type rawEntry struct{ key, value []byte }
+
+// dumpEntries snapshots every entry of the map as raw bytes.
+func dumpEntries(m *ebpf.Map) ([]rawEntry, error) {
+	var out []rawEntry
+	key := make([]byte, int(m.KeySize()))
+	val := make([]byte, int(m.ValueSize()))
+	iter := m.Iterate()
+	for iter.Next(&key, &val) {
+		out = append(out, rawEntry{
+			key:   append([]byte(nil), key...),
+			value: append([]byte(nil), val...),
+		})
+	}
+	return out, iter.Err()
 }
 
 // reservedTagName is the field=value key that `set add`/`del` treat as

--- a/internal/setmap/ops_test.go
+++ b/internal/setmap/ops_test.go
@@ -113,6 +113,27 @@ func TestResizeShrinkBelowCountFails(t *testing.T) {
 	}
 }
 
+// TestResizeLeftoverTmpPinFails verifies a leftover temporary pin (from a
+// crashed or concurrent resize) is reported with a recovery hint instead
+// of a bare EEXIST from the pin syscall.
+func TestResizeLeftoverTmpPinFails(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_tmppin_%d", os.Getpid())
+	if err := Create(pin, "teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+	if err := Create(pin+"_resize_tmp", "teid:u32", "", 16); err != nil {
+		t.Fatalf("creating leftover tmp pin: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin + "_resize_tmp") })
+
+	if _, _, err := Resize(pin, 32); err == nil || !strings.Contains(err.Error(), "remove it and retry") {
+		t.Fatalf("Resize = %v, want a leftover-tmp error with a recovery hint", err)
+	}
+}
+
 // TestResizeSameCapacityNoop verifies a same-capacity resize succeeds
 // without touching the map.
 func TestResizeSameCapacityNoop(t *testing.T) {

--- a/internal/setmap/ops_test.go
+++ b/internal/setmap/ops_test.go
@@ -1,0 +1,142 @@
+package setmap
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/takehaya/xdp-ninja/internal/testutil"
+)
+
+// TestResizeGrowPreservesEntriesAndSchema is the end-to-end for `set
+// resize`: create a composite-key set, add entries, grow it, and verify
+// the replacement pin keeps the capacity, every entry, and the BTF key
+// schema (field names, offsets, widths).
+func TestResizeGrowPreservesEntriesAndSchema(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_resize_%d", os.Getpid())
+	if err := Create(pin, "imsi:u64,teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	def, err := Open(pin)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	for i := range 3 {
+		err := def.Add(map[string]string{
+			"imsi": fmt.Sprintf("%d", 999990000000001+i),
+			"teid": fmt.Sprintf("%d", 0x1000+i),
+		}, uint64(i+1))
+		if err != nil {
+			def.Close()
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	wantFields := def.Fields
+	var wantList strings.Builder
+	if err := def.List(&wantList); err != nil {
+		def.Close()
+		t.Fatalf("List: %v", err)
+	}
+	def.Close()
+
+	oldMax, copied, err := Resize(pin, 4096)
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if oldMax != 16 || copied != 3 {
+		t.Fatalf("Resize = (oldMax %d, copied %d), want (16, 3)", oldMax, copied)
+	}
+
+	got, err := Open(pin)
+	if err != nil {
+		t.Fatalf("Open after resize: %v", err)
+	}
+	t.Cleanup(got.Close)
+	if got.Map.MaxEntries() != 4096 {
+		t.Fatalf("max_entries = %d, want 4096", got.Map.MaxEntries())
+	}
+	if fmt.Sprintf("%+v", got.Fields) != fmt.Sprintf("%+v", wantFields) {
+		t.Fatalf("key schema changed: %+v, want %+v", got.Fields, wantFields)
+	}
+	var gotList strings.Builder
+	if err := got.List(&gotList); err != nil {
+		t.Fatalf("List after resize: %v", err)
+	}
+	if sortedLines(gotList.String()) != sortedLines(wantList.String()) {
+		t.Fatalf("entries changed:\n got: %q\nwant: %q", gotList.String(), wantList.String())
+	}
+	if _, err := os.Stat(pin + "_resize_tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temporary pin left behind: %v", err)
+	}
+}
+
+// TestResizeShrinkBelowCountFails verifies a shrink below the live entry
+// count is rejected up front and the original map survives untouched.
+func TestResizeShrinkBelowCountFails(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_shrink_%d", os.Getpid())
+	if err := Create(pin, "teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	def, err := Open(pin)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	for i := range 3 {
+		if err := def.Add(map[string]string{"teid": fmt.Sprintf("%d", i+1)}, 1); err != nil {
+			def.Close()
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	def.Close()
+
+	if _, _, err := Resize(pin, 2); err == nil || !strings.Contains(err.Error(), "cannot shrink") {
+		t.Fatalf("Resize(2) = %v, want 'cannot shrink' error", err)
+	}
+
+	got, err := Open(pin)
+	if err != nil {
+		t.Fatalf("Open after failed shrink: %v", err)
+	}
+	t.Cleanup(got.Close)
+	if got.Map.MaxEntries() != 16 {
+		t.Fatalf("max_entries = %d, want the original 16", got.Map.MaxEntries())
+	}
+}
+
+// TestResizeSameCapacityNoop verifies a same-capacity resize succeeds
+// without touching the map.
+func TestResizeSameCapacityNoop(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	pin := fmt.Sprintf("/sys/fs/bpf/xdpninja_noop_%d", os.Getpid())
+	if err := Create(pin, "teid:u32", "", 16); err != nil {
+		t.Skipf("creating pinned set map (bpffs unavailable?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(pin) })
+
+	oldMax, copied, err := Resize(pin, 16)
+	if err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if oldMax != 16 || copied != 0 {
+		t.Fatalf("Resize = (oldMax %d, copied %d), want (16, 0)", oldMax, copied)
+	}
+}
+
+// sortedLines canonicalizes multi-line output whose line order is not
+// stable (hash map iteration order).
+func sortedLines(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}

--- a/internal/setmap/setmap.go
+++ b/internal/setmap/setmap.go
@@ -267,28 +267,40 @@ func validValueFieldSize(n uint32) bool {
 // package), so read struct bpf_map_info via a raw BPF_OBJ_GET_INFO_BY_FD
 // and look the type up in the handle's spec.
 func mapKeyBTF(m *ebpf.Map) (btf.Type, error) {
-	keyTypeID, err := mapKeyBTFTypeID(m.FD())
+	key, _, err := mapBTFTypes(m)
+	return key, err
+}
+
+// mapBTFTypes returns the map's BTF key and value types.
+func mapBTFTypes(m *ebpf.Map) (key, value btf.Type, err error) {
+	keyTypeID, valueTypeID, err := mapBTFTypeIDs(m.FD())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if keyTypeID == 0 {
-		return nil, fmt.Errorf("map has no key BTF; create it with `xdp-ninja set create` (or load it with BTF key/value types)")
+		return nil, nil, fmt.Errorf("map has no key BTF; create it with `xdp-ninja set create` (or load it with BTF key/value types)")
 	}
 
 	h, err := m.Handle()
 	if err != nil {
-		return nil, fmt.Errorf("map BTF handle: %w", err)
+		return nil, nil, fmt.Errorf("map BTF handle: %w", err)
 	}
 	defer func() { _ = h.Close() }()
 	spec, err := h.Spec(nil)
 	if err != nil {
-		return nil, fmt.Errorf("reading map BTF: %w", err)
+		return nil, nil, fmt.Errorf("reading map BTF: %w", err)
 	}
-	t, err := spec.TypeByID(btf.TypeID(keyTypeID))
+	key, err = spec.TypeByID(btf.TypeID(keyTypeID))
 	if err != nil {
-		return nil, fmt.Errorf("resolving key type id %d: %w", keyTypeID, err)
+		return nil, nil, fmt.Errorf("resolving key type id %d: %w", keyTypeID, err)
 	}
-	return t, nil
+	if valueTypeID != 0 {
+		value, err = spec.TypeByID(btf.TypeID(valueTypeID))
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving value type id %d: %w", valueTypeID, err)
+		}
+	}
+	return key, value, nil
 }
 
 // bpfMapInfo mirrors the leading fields of UAPI struct bpf_map_info up to
@@ -322,8 +334,9 @@ type bpfObjGetInfoByFDAttr struct {
 
 const bpfObjGetInfoByFD = 15 // BPF_OBJ_GET_INFO_BY_FD
 
-// mapKeyBTFTypeID reads btf_key_type_id from bpf_map_info.
-func mapKeyBTFTypeID(fd int) (uint32, error) {
+// mapBTFTypeIDs reads btf_key_type_id and btf_value_type_id from
+// bpf_map_info.
+func mapBTFTypeIDs(fd int) (keyID, valueID uint32, err error) {
 	var info bpfMapInfo
 	attr := bpfObjGetInfoByFDAttr{
 		BpfFD:   uint32(fd),
@@ -333,7 +346,7 @@ func mapKeyBTFTypeID(fd int) (uint32, error) {
 	_, _, errno := unix.Syscall(unix.SYS_BPF, bpfObjGetInfoByFD,
 		uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
 	if errno != 0 {
-		return 0, fmt.Errorf("BPF_OBJ_GET_INFO_BY_FD: %w", errno)
+		return 0, 0, fmt.Errorf("BPF_OBJ_GET_INFO_BY_FD: %w", errno)
 	}
-	return info.BTFKeyTypeID, nil
+	return info.BTFKeyTypeID, info.BTFValueTypeID, nil
 }


### PR DESCRIPTION
## Summary

- Add `xdp-ninja set resize <pin-path> --max-entries N`: BPF hash maps cannot change `max_entries` in place, so resize creates a new map with the key/value BTF **reused from the old map** (externally-created maps keep their names and types), copies every entry verbatim, and atomically replaces the pin via `rename(2)` on bpffs.
- A shrink below the live entry count is rejected up front, before any copy happens.
- The temporary pin uses an underscore suffix (`<path>_resize_tmp`) because bpffs reserves `.` in pin names (`bpf_lookup` returns `EPERM`).
- Docs: state that `set create --max-entries` defaults to 1024 and accepts 1..2^32-1 (the examples made it look fixed), and document the resize caveats.

## Caveats (documented in `set resize --help` and docs/ja/dsl-usage.md)

- A running capture holds the old map's fd from attach time; the new capacity takes effect from the **next attach**.
- Entries added to the old map between the copy and the pin swap are lost — resize while no writer is active.

## Test plan

- [x] Root-gated unit tests (`internal/setmap/ops_test.go`): grow preserves entries + BTF key schema + no temp pin left behind; shrink below count fails and leaves the original untouched; same-capacity resize is a no-op.
- [x] Manual end-to-end: `create` → `add` → `resize 1024→4096` → `schema`/`list`/`bpftool map dump` all show preserved entries and BTF field names.
- [x] `make test`, `make lint` green.
