### PR TITLE
feat: generalize attach-target hooks and add cgroup-skb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This project was renamed from **xdp-ninja** (July 2026): the tool has outgrown XDP — it also observes tc-bpf programs, and more BPF hook points are planned. GitHub redirects the old repository URL, but the Go module path changed to `github.com/takehaya/bpf-ninja`, so `go install` / imports need the new path. Environment variables are now `BPF_NINJA_*` (the old `XDP_NINJA_*` names are no longer read).
 
-bpf-ninja captures packets at BPF hook points — XDP today, tc-bpf too, with more planned. `tcpdump` runs below XDP and can't show what XDP or tc-bpf did to the packet, and cBPF filters can't walk into VXLAN / GTP / MPLS / SRv6 inner headers. Attach via fentry/fexit to a running XDP without modifying it, or `--mode xdp` for standalone capture on a netdev. Filters use the built-in DSL by default — chains like `eth/ipv4/udp/vxlan/eth/ipv4/tcp`. Plain tcpdump syntax via [cbpfc](https://github.com/cloudflare/cbpfc) is still accepted via `--cbpf`, kept for backwards compatibility and planned to retire once the DSL surface stabilises. Output is pcap (pcapng) to stdout.🥷
+bpf-ninja captures packets at BPF hook points — XDP, tc-bpf, and cgroup-skb, with more planned. `tcpdump` runs below XDP and can't show what XDP or tc-bpf did to the packet, and cBPF filters can't walk into VXLAN / GTP / MPLS / SRv6 inner headers. Attach via fentry/fexit to a running XDP without modifying it, or `--mode xdp` for standalone capture on a netdev. Filters use the built-in DSL by default — chains like `eth/ipv4/udp/vxlan/eth/ipv4/tcp`. Plain tcpdump syntax via [cbpfc](https://github.com/cloudflare/cbpfc) is still accepted via `--cbpf`, kept for backwards compatibility and planned to retire once the DSL surface stabilises. Output is pcap (pcapng) to stdout.🥷
 
 ## Install
 
@@ -25,17 +25,23 @@ make build
 
 ## Modes
 
-bpf-ninja supports five attach modes via `--mode`:
+`--mode` selects the capture point; the hook kind (XDP, TC clsact, cgroup-skb) is auto-detected from the target program's type:
 
 | Mode | Attach via | Existing program needed | Sees return action | Typical use |
 |---|---|---|---|---|
-| `entry` (default) | fentry on the target XDP | yes (with BTF) | no — packet only | observe what reaches the production XDP |
-| `exit` | fexit on the target XDP | yes (with BTF) | yes (`XDP_PASS`/`DROP`/...) | observe what the XDP decided; filter on action |
+| `entry` (default) | fentry on the target program | yes (with BTF) | no — packet only | observe what reaches the production program |
+| `exit` | fexit on the target program | yes (with BTF) | yes (`XDP_PASS` / `TC_ACT_OK` / `SK_PASS` / ...) | observe the verdict; filter on `action == ...` |
 | `xdp` | attach as the primary XDP on the netdev | no — fails if one is attached | n/a (bpf-ninja decides; always returns `XDP_PASS`) | capture on a netdev with no XDP, no BTF needed |
-| `tc-entry` | fentry on a TC clsact filter program | yes (a tc-bpf program with BTF) | no — skb only | observe what reaches a TC ingress/egress filter |
-| `tc-exit` | fexit on a TC clsact filter program | yes (same) | yes (`TC_ACT_OK`/`SHOT`/...) | observe the TC verdict; filter on `action == TC_ACT_SHOT` etc. |
 
-`entry`/`exit` and `tc-entry`/`tc-exit` are non-invasive: the target program is unmodified, attach is via BPF trampoline. `xdp` is the standalone path for "I just want to capture, there's nothing else here". The `tc-*` modes today expect the target by `-p <progID>` only (interface lookup for TC clsact is not yet wired).
+Supported hooks and how to name the target:
+
+| Hook | Target selection | Notes |
+|---|---|---|
+| XDP | `-i <iface>` (interface's XDP) or `-p <progID>` | |
+| TC clsact | `-p <progID>` only (interface lookup for clsact is not yet wired) | |
+| cgroup-skb | `--cgroup <cgroup v2 path>` (enumerates attached programs) or `-p <progID>` | packet bytes start at the IP header — root DSL chains at `ipv4`/`ipv6`, pcap-ng is LINKTYPE_RAW |
+
+`entry`/`exit` are non-invasive: the target program is unmodified, attach is via BPF trampoline. `xdp` is the standalone path for "I just want to capture, there's nothing else here". `tc-entry`/`tc-exit` remain as deprecated aliases for `entry`/`exit`.
 
 ## Usage
 
@@ -59,8 +65,14 @@ sudo bpf-ninja --cbpf -i eth0 "host 10.0.0.1 and tcp port 80" | tcpdump -n -r -
 # (output is sharded across per-CPU files; see "Sharded output" below)
 sudo bpf-ninja -i eth0 -w capture.pcap -c 100
 
-# Attach by BPF program ID (for multi-prog / libxdp setups)
+# Attach by BPF program ID — works for XDP, tc clsact, and cgroup-skb
+# programs alike (the hook is auto-detected from the program type)
 sudo bpf-ninja -p 42 | tcpdump -n -r -
+
+# cgroup-skb: capture on whatever is attached to a cgroup v2 path.
+# Packets start at the IP header, so chains root at ipv4/ipv6.
+sudo bpf-ninja --cgroup /sys/fs/cgroup/my-service "ipv4/tcp[dport==443]" | tcpdump -n -r -
+sudo bpf-ninja --cgroup /sys/fs/cgroup/my-service --mode exit "ipv4/tcp where action == SK_DROP"
 
 # List BTF functions in the target program
 sudo bpf-ninja -i eth0 --list-funcs
@@ -231,22 +243,24 @@ int parse_headers(struct xdp_md *ctx) {
 
 | Option | Description | Modes |
 |---|---|---|
-| `-i, --interface` | Network interface to capture on | entry, exit, xdp |
-| `-p, --prog-id` | BPF program ID to attach to (alternative to `-i`) | entry, exit, tc-entry, tc-exit |
-| `--mode` | `entry` (default), `exit`, `xdp`, `tc-entry`, `tc-exit` | — |
+| `-i, --interface` | Network interface to capture on (XDP hook) | entry, exit, xdp |
+| `-p, --prog-id` | BPF program ID to attach to — any supported hook, auto-detected (alternative to `-i`) | entry, exit |
+| `--cgroup` | cgroup v2 path; targets the cgroup-skb program(s) attached to it (alternative to `-i` / `-p`) | entry, exit |
+| `--mode` | `entry` (default), `exit`, `xdp` (`tc-entry`/`tc-exit` are deprecated aliases) | — |
 | `-w, --write` | Write to pcap file instead of stdout | all |
 | `-c, --count` | Stop after N packets (0 = unlimited) | all |
 | `-v, --verbose` | Verbose output to stderr | all |
 | `--cbpf` | Use the legacy tcpdump/cBPF syntax (compiled via cbpfc); default is the built-in DSL. Prints a deprecation notice when used. | all |
 | `--dsl-help` | Print the DSL grammar + bundled protocol catalogue and exit (no `-i`/`-p` required) | — |
 | `--dump-asm` | Print compiled eBPF asm and exit. Values: `filter` (kunai/cbpfc body only) \| `full` (wrapped program). No `-i`/`-p` required | — |
-| `--func` | Attach to a specific `__noinline` subfunction by BTF name | entry, exit, tc-entry, tc-exit |
-| `--list-funcs` | List available BTF functions in the target program and exit | entry, exit, tc-entry, tc-exit |
-| `--list-progs` | List tail call targets reachable from the target program and exit | entry, exit, tc-entry, tc-exit |
-| `--list-params` | List filterable parameters for `--func` (requires `--func`) | entry, exit, tc-entry, tc-exit |
-| `--arg-filter` | Filter by function argument value (requires `--func`); format: `param=value`, `param>=val`, `param<=val`, `param=min..max` | entry, exit, tc-entry, tc-exit |
+| `--dump-hook` | Hook whose capabilities/prologue `--dump-asm` renders: `xdp` (default) \| `tc` \| `cgroup-skb` (offline compiles have no target program to auto-detect from) | — |
+| `--func` | Attach to a specific `__noinline` subfunction by BTF name | entry, exit |
+| `--list-funcs` | List available BTF functions in the target program and exit | entry, exit |
+| `--list-progs` | List tail call targets reachable from the target program and exit | entry, exit |
+| `--list-params` | List filterable parameters for `--func` (requires `--func`) | entry, exit |
+| `--arg-filter` | Filter by function argument value (requires `--func`); format: `param=value`, `param>=val`, `param<=val`, `param=min..max` | entry, exit |
 
-Specify either `-i` or `-p`, not both.
+Specify exactly one of `-i`, `-p`, or `--cgroup`.
 
 ## Prerequisites
 
@@ -259,9 +273,8 @@ Common:
 
 Mode-specific:
 
-- **`--mode entry` / `exit`**: an XDP program already attached to the target interface, with BTF.
+- **`--mode entry` / `exit`**: a target BPF program (XDP, tc clsact, or cgroup-skb) already loaded with BTF. With `-i`, an XDP program attached to the interface; tc targets go by `-p <progID>`; cgroup-skb targets by `--cgroup <path>` or `-p`.
 - **`--mode xdp`**: no XDP attached to the interface (bpf-ninja becomes the XDP program).
-- **`--mode tc-entry` / `tc-exit`**: a tc clsact filter program already loaded with BTF; target by `-p <progID>`.
 - **DSL with chain quantifier (`+`, `*`, `{n,m>4}`), parser-machine self-loop (variable-length headers like IPv6 ext / GTP options / SRv6 segments), or alternation (`(a|b)`)**: kernel 5.17+ (uses `bpf_loop` + bpf2bpf subprograms). Plain DSL chains and `--cbpf` filters work on 5.8+.
 
 ```bash

--- a/cmd/bpf-ninja/convert.go
+++ b/cmd/bpf-ninja/convert.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/gopacket/layers"
 	"github.com/urfave/cli/v3"
 
 	"github.com/takehaya/bpf-ninja/internal/capture"
@@ -95,7 +96,10 @@ func runConvert(ctx context.Context, cmd *cli.Command) error {
 	bw := bufio.NewWriterSize(sink, 1<<20)
 	defer func() { _ = bw.Flush() }()
 
-	fastW, err := output.NewFastNgWriter(bw)
+	// Raw dumps carry no hook identity in their header today, so the
+	// offline convert always renders Ethernet framing (all raw-dump
+	// capable hooks are L2 hooks).
+	fastW, err := output.NewFastNgWriter(bw, layers.LinkTypeEthernet)
 	if err != nil {
 		return fmt.Errorf("creating pcap-ng writer: %w", err)
 	}

--- a/cmd/bpf-ninja/main.go
+++ b/cmd/bpf-ninja/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/takehaya/bpf-ninja/internal/capture"
 	"github.com/takehaya/bpf-ninja/internal/capture/fastrb"
 	"github.com/takehaya/bpf-ninja/internal/filter"
+	"github.com/takehaya/bpf-ninja/internal/hook"
 	"github.com/takehaya/bpf-ninja/internal/output"
 	"github.com/takehaya/bpf-ninja/internal/program"
 	"github.com/takehaya/bpf-ninja/internal/setmap"
@@ -679,7 +680,28 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		}
 		label = fmt.Sprintf("%d attach points: %s", len(targets), strings.Join(names, ", "))
 	}
-	return runCaptureLoop(cmd, probe, isFexit, fmt.Sprintf("%s, mode=%s", label, mode))
+	h, ok := hook.ByProgramType(targets[0].Type)
+	if !ok {
+		return hook.UnsupportedTypeError(targets[0].Type)
+	}
+	return runCaptureLoop(cmd, probe, outputConfigFor(h, isFexit), fmt.Sprintf("%s, mode=%s", label, mode))
+}
+
+// outputConfigFor renders a hook descriptor into the writer layout for
+// one capture run (per-verdict interfaces in exit mode, link type).
+func outputConfigFor(h *hook.Hook, isFexit bool) output.Config {
+	cfg := output.Config{
+		IsFexit:  isFexit,
+		LinkType: h.LinkType,
+		HookName: string(h.Kind),
+	}
+	if isFexit {
+		cfg.Actions = make([]output.ActionName, len(h.Actions))
+		for i, a := range h.Actions {
+			cfg.Actions[i] = output.ActionName{Value: a.Value, Name: a.Name}
+		}
+	}
+	return cfg
 }
 
 // runArgEchoLoop reads the probe's dedicated arg-echo ringbuf and prints
@@ -811,7 +833,7 @@ func resolveFilterSyntax(cmd *cli.Command) (useDSL bool, err error) {
 // capture; afterward output.MergeShardFiles merges them into a single
 // time-ordered pcap-ng at `path` (the shards are left in place). Integration
 // tests (run_pcap_test) read the `.cpuN` shards.
-func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label string) error {
+func runCaptureLoop(cmd *cli.Command, probe *program.Probe, cfg output.Config, label string) error {
 	defer func() {
 		if cerr := probe.Close(); cerr != nil {
 			fmt.Fprintf(os.Stderr, "warning: closing probe: %v\n", cerr)
@@ -820,7 +842,7 @@ func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label 
 	if len(probe.InnerMaps) == 0 {
 		return fmt.Errorf("probe has no inner ringbufs — sharded ringbuf hoist (R22) should populate them for every attach mode")
 	}
-	if err := captureLoopSharded(cmd, probe.InnerMaps, isFexit, label); err != nil {
+	if err := captureLoopSharded(cmd, probe.InnerMaps, cfg, label); err != nil {
 		return err
 	}
 
@@ -839,14 +861,14 @@ func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label 
 			// shards into <base>.<tag>. A kill skips this — `bpf-ninja merge`
 			// reconciles the leftover per-CPU files later.
 			fmt.Fprintf(os.Stderr, "merging per-CPU tag shards for %s ...\n", basePath)
-			if err := output.MergeTagShards(basePath, isFexit); err != nil {
+			if err := output.MergeTagShards(basePath, cfg); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: merging tag shards for %s: %v\n", basePath, err)
 			} else {
 				fmt.Fprintf(os.Stderr, "merged per tag (per-CPU .cpuN.<tag> kept)\n")
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "merging %d shard(s) into %s ...\n", len(probe.InnerMaps), basePath)
-			if err := output.MergeShardFiles(basePath, len(probe.InnerMaps), isFexit); err != nil {
+			if err := output.MergeShardFiles(basePath, len(probe.InnerMaps), cfg); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: merging shards into %s: %v\n", basePath, err)
 			} else {
 				fmt.Fprintf(os.Stderr, "merged into %s (per-CPU .cpuN kept)\n", basePath)
@@ -861,7 +883,7 @@ func runCaptureLoop(cmd *cli.Command, probe *program.Probe, isFexit bool, label 
 // stdout all shards funnel into one writer serialized by a mutex.
 // --null-output skips file writes for benchmarking; --raw-dump switches to
 // the raw-bytes path.
-func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, label string) error {
+func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, cfg output.Config, label string) error {
 	basePath := cmd.String("write")
 	null := cmd.Bool("null-output")
 	rawDump := cmd.Bool("raw-dump")
@@ -871,7 +893,7 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 	if cmd.Bool("split-by-tag") {
 		// run() already rejected --split-by-tag with stdout / --raw-dump /
 		// --null-output, so basePath is a real file here.
-		return captureLoopShardedSplit(cmd, inners, isFexit, label, basePath)
+		return captureLoopShardedSplit(cmd, inners, cfg, label, basePath)
 	}
 
 	// stdout (no -w) merges every shard into a single pcap-ng stream,
@@ -897,14 +919,14 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 	}()
 	if !null {
 		if stdoutMerge {
-			w, err := output.NewWriter("", isFexit)
+			w, err := output.NewWriter("", cfg)
 			if err != nil {
 				return fmt.Errorf("opening stdout writer: %w", err)
 			}
 			sharedW = w
 		} else {
 			for i := range inners {
-				w, err := output.NewWriter(fmt.Sprintf("%s.cpu%d", basePath, i), isFexit)
+				w, err := output.NewWriter(fmt.Sprintf("%s.cpu%d", basePath, i), cfg)
 				if err != nil {
 					return fmt.Errorf("opening per-CPU writer %d: %w", i, err)
 				}
@@ -944,7 +966,7 @@ func captureLoopSharded(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, labe
 // mid-capture. Each shard's tag->writer map is owned by its own goroutine,
 // so there is no lock on the write path. runCaptureLoop merges the per-CPU
 // tag files into <base>.<tag><ext> on a clean shutdown.
-func captureLoopShardedSplit(cmd *cli.Command, inners []*ebpf.Map, isFexit bool, label, basePath string) error {
+func captureLoopShardedSplit(cmd *cli.Command, inners []*ebpf.Map, cfg output.Config, label, basePath string) error {
 	// One tag->writer map per shard; only ever touched by that shard's
 	// goroutine (writeShard runs single-threaded per shardIdx).
 	shardWriters := make([]map[uint32]*output.Writer, len(inners))
@@ -964,7 +986,7 @@ func captureLoopShardedSplit(cmd *cli.Command, inners []*ebpf.Map, isFexit bool,
 		if w := m[tag]; w != nil {
 			return w, nil
 		}
-		w, err := output.NewWriter(output.TagShardPath(basePath, shardIdx, tag), isFexit)
+		w, err := output.NewWriter(output.TagShardPath(basePath, shardIdx, tag), cfg)
 		if err != nil {
 			// Splitting opens one file (and fd) per distinct tag per CPU, so
 			// a large tag cardinality can exhaust the fd limit mid-capture;
@@ -1383,7 +1405,8 @@ func runXDPNative(cmd *cli.Command) error {
 		return err
 	}
 	printProbeWarnings(probe)
-	return runCaptureLoop(cmd, probe, false, fmt.Sprintf("xdp-native on %s", ifaceName))
+	xdpHook, _ := hook.ByName(hook.KindXDP)
+	return runCaptureLoop(cmd, probe, outputConfigFor(xdpHook, false), fmt.Sprintf("xdp-native on %s", ifaceName))
 }
 
 // validateXDPNativeFlags rejects flags that don't apply to --mode xdp

--- a/cmd/bpf-ninja/main.go
+++ b/cmd/bpf-ninja/main.go
@@ -56,7 +56,7 @@ var flags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name: "mode", Value: "entry",
-		Usage: "capture point: entry / exit (XDP fentry/fexit observer), tc-entry / tc-exit (tc clsact fentry/fexit observer), or xdp (attach as native XDP)",
+		Usage: "capture point: entry / exit (fentry/fexit observer on the target program — the hook kind is auto-detected from the program type), or xdp (attach as native XDP). tc-entry / tc-exit are deprecated aliases for entry / exit",
 	},
 	&cli.IntFlag{
 		Name: "count", Aliases: []string{"c"},
@@ -105,6 +105,10 @@ var flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:  "dump-asm",
 		Usage: "compile the filter and print the resulting eBPF asm without loading; values: filter (kunai/cbpfc Main + Callbacks) | full (wrapped tracing program)",
+	},
+	&cli.StringFlag{
+		Name:  "dump-hook",
+		Usage: "hook whose capabilities/prologue --dump-asm renders (no target program exists to auto-detect from): xdp | tc (default xdp; deprecated --mode tc-* aliases imply tc)",
 	},
 	&cli.BoolFlag{
 		Name: "verbose", Aliases: []string{"v"},
@@ -270,11 +274,14 @@ func newRootCommand() *cli.Command {
 		Description: `Outputs pcap (pcapng) to stdout. Pipe to tcpdump, wireshark, etc.
 
 Modes (--mode):
-  entry     fentry on the existing XDP — observe packets before the program runs (default)
-  exit      fexit on the existing XDP — observe action returned (filter on XDP_PASS/DROP/...)
-  tc-entry  fentry on a tc clsact program (specify target via -p)
-  tc-exit   fexit on a tc clsact program (filter on TC_ACT_OK/SHOT/...)
+  entry     fentry observer — see packets before the target program runs (default)
+  exit      fexit observer — also see the verdict returned (filter on XDP_PASS / TC_ACT_OK / ...)
   xdp       attach as the primary XDP on the netdev (no existing XDP needed)
+
+The hook kind (XDP, tc clsact, ...) is auto-detected from the target
+program's type: -p <prog-id> works for any supported program, -i looks
+up the interface's XDP program. tc-entry / tc-exit remain as deprecated
+aliases for entry / exit.
 
 Examples:
   bpf-ninja -i eth0 | tcpdump -n -r -
@@ -282,7 +289,8 @@ Examples:
   bpf-ninja -i eth0 --mode exit | tcpdump -r -
   bpf-ninja --mode xdp -i eth0 "eth/ipv4/tcp[dport==443]" | tcpdump -r -
   bpf-ninja --cbpf --mode xdp -i eth0 "tcp port 443" | tcpdump -r -   # legacy pcap syntax
-  bpf-ninja -p 42 | tcpdump -n -r -
+  bpf-ninja -p 42 | tcpdump -n -r -                  # XDP or tc program, auto-detected
+  bpf-ninja -p 42 --mode exit "eth/ipv4 where action == TC_ACT_SHOT"  # tc verdict filter
   bpf-ninja -i eth0 -w out.pcap`,
 		Flags:                 flags,
 		Action:                run,
@@ -387,20 +395,31 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	mode := cmd.String("mode")
-	var isFexit, isXDPNative, isTC bool
+	// The hook kind (xdp / tc / ...) is auto-detected from the target
+	// program's type; --mode only picks the capture point. dumpHook is
+	// the one place a hook must be named explicitly, because --dump-asm
+	// compiles without a target program to detect from.
+	dumpHook := hook.Kind(cmd.String("dump-hook"))
+	var isFexit, isXDPNative bool
 	switch mode {
 	case "entry":
 	case "exit":
 		isFexit = true
-	case "tc-entry":
-		isTC = true
-	case "tc-exit":
-		isTC = true
-		isFexit = true
+	case "tc-entry", "tc-exit":
+		newMode := strings.TrimPrefix(mode, "tc-")
+		fmt.Fprintf(os.Stderr, "warning: --mode %s is deprecated; the hook is auto-detected from the target program, use --mode %s\n", mode, newMode)
+		if dumpHook == "" {
+			dumpHook = hook.KindTC
+		}
+		mode = newMode
+		isFexit = mode == "exit"
 	case "xdp":
 		isXDPNative = true
 	default:
-		return fmt.Errorf("invalid mode %q: must be entry, exit, tc-entry, tc-exit, or xdp", mode)
+		return fmt.Errorf("invalid mode %q: must be entry, exit, or xdp (tc-entry / tc-exit are deprecated aliases)", mode)
+	}
+	if dumpHook == "" {
+		dumpHook = hook.KindXDP
 	}
 
 	if scope := cmd.String("dump-asm"); scope != "" {
@@ -409,14 +428,14 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		return program.DumpAsm(os.Stdout, program.DumpScope(scope), filterExpr, useDSL, mode)
+		return program.DumpAsm(os.Stdout, program.DumpScope(scope), filterExpr, useDSL, mode, dumpHook)
 	}
 
 	if isXDPNative {
 		return runXDPNative(cmd)
 	}
 
-	infos, err := findTargets(cmd, isTC)
+	infos, err := findTargets(cmd)
 	if err != nil {
 		return err
 	}
@@ -1441,7 +1460,12 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 // Several programs come from repeated -p, or from -i with --prog-name (which
 // picks named programs out of the interface's reachable tree); a bare -i
 // resolves to just the single XDP program attached to the interface.
-func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
+//
+// -p accepts any program type the hook registry supports — the hook kind
+// is detected from the opened program, not from a flag. -i remains an
+// XDP lookup (there is no interface-based clsact qdisc walk yet; select
+// tc targets with -p <prog-id>).
+func findTargets(cmd *cli.Command) ([]*attach.ProgInfo, error) {
 	ifaceName := cmd.String("interface")
 	progIDs := cmd.IntSlice("prog-id")
 	progNames := cmd.StringSlice("prog-name")
@@ -1452,21 +1476,11 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 	if ifaceName == "" && len(progIDs) == 0 {
 		return nil, fmt.Errorf("specify -i <interface> or -p <prog-id>")
 	}
-	if len(progNames) > 0 {
-		if ifaceName == "" {
-			return nil, fmt.Errorf("--prog-name requires -i <interface> (names resolve against the interface's reachable program tree)")
-		}
-		if isTC {
-			return nil, fmt.Errorf("--prog-name is XDP-only; select tc clsact targets with -p <prog-id>")
-		}
+	if len(progNames) > 0 && ifaceName == "" {
+		return nil, fmt.Errorf("--prog-name requires -i <interface> (names resolve against the interface's reachable program tree)")
 	}
 
 	if ifaceName != "" {
-		if isTC {
-			// tc clsact targets are addressed by program ID — no
-			// interface-based clsact qdisc walk wired up yet.
-			return nil, fmt.Errorf("--mode tc-* requires -p <prog-id>; interface-based tc target lookup is not implemented")
-		}
 		if len(progNames) > 0 {
 			return attach.ResolveXDPTargetsByName(ifaceName, progNames)
 		}
@@ -1488,13 +1502,7 @@ func findTargets(cmd *cli.Command, isTC bool) ([]*attach.ProgInfo, error) {
 			continue
 		}
 		seen[pid] = true
-		var info *attach.ProgInfo
-		var err error
-		if isTC {
-			info, err = attach.FindBPFProgramByID(pid)
-		} else {
-			info, err = attach.FindXDPProgramByID(pid)
-		}
+		info, err := attach.FindBPFProgramByID(pid)
 		if err != nil {
 			for _, prev := range infos {
 				_ = prev.Program.Close()

--- a/cmd/bpf-ninja/main.go
+++ b/cmd/bpf-ninja/main.go
@@ -108,7 +108,7 @@ var flags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "dump-hook",
-		Usage: "hook whose capabilities/prologue --dump-asm renders (no target program exists to auto-detect from): xdp | tc (default xdp; deprecated --mode tc-* aliases imply tc)",
+		Usage: "hook whose capabilities/prologue --dump-asm renders (no target program exists to auto-detect from): xdp | tc | cgroup-skb (default xdp; deprecated --mode tc-* aliases imply tc)",
 	},
 	&cli.BoolFlag{
 		Name: "verbose", Aliases: []string{"v"},

--- a/cmd/bpf-ninja/main.go
+++ b/cmd/bpf-ninja/main.go
@@ -51,6 +51,10 @@ var flags = []cli.Flag{
 		Usage: "select target program(s) by name instead of ID (requires -i); resolved against the interface's reachable program tree, so you skip looking up numeric IDs. Repeatable. Kernel program names are truncated to 15 chars; a full name matches by prefix",
 	},
 	&cli.StringFlag{
+		Name:  "cgroup",
+		Usage: "capture on the cgroup-skb program(s) attached to this cgroup v2 path (enumerated via BPF_PROG_QUERY, ingress + egress); alternative to -i / -p",
+	},
+	&cli.StringFlag{
 		Name: "write", Aliases: []string{"w"},
 		Usage: "write packets to pcap file instead of stdout",
 	},
@@ -1441,6 +1445,9 @@ func validateXDPNativeFlags(cmd *cli.Command) error {
 	if len(cmd.StringSlice("prog-name")) > 0 {
 		return fmt.Errorf("--mode xdp does not accept --prog-name (the program is bpf-ninja itself, not an existing one)")
 	}
+	if cmd.String("cgroup") != "" {
+		return fmt.Errorf("--mode xdp does not accept --cgroup (it attaches to a netdev, not a cgroup)")
+	}
 	if len(cmd.StringSlice("func")) > 0 {
 		return fmt.Errorf("--func is only valid with --mode entry/exit (no BTF subfunction concept in xdp-native)")
 	}
@@ -1469,15 +1476,26 @@ func findTargets(cmd *cli.Command) ([]*attach.ProgInfo, error) {
 	ifaceName := cmd.String("interface")
 	progIDs := cmd.IntSlice("prog-id")
 	progNames := cmd.StringSlice("prog-name")
+	cgroupPath := cmd.String("cgroup")
 
-	if ifaceName != "" && len(progIDs) > 0 {
-		return nil, fmt.Errorf("specify either -i or -p, not both")
+	selectors := 0
+	for _, set := range []bool{ifaceName != "", len(progIDs) > 0, cgroupPath != ""} {
+		if set {
+			selectors++
+		}
 	}
-	if ifaceName == "" && len(progIDs) == 0 {
-		return nil, fmt.Errorf("specify -i <interface> or -p <prog-id>")
+	if selectors > 1 {
+		return nil, fmt.Errorf("specify only one of -i, -p, or --cgroup")
+	}
+	if selectors == 0 {
+		return nil, fmt.Errorf("specify -i <interface>, -p <prog-id>, or --cgroup <path>")
 	}
 	if len(progNames) > 0 && ifaceName == "" {
 		return nil, fmt.Errorf("--prog-name requires -i <interface> (names resolve against the interface's reachable program tree)")
+	}
+
+	if cgroupPath != "" {
+		return attach.FindCgroupSKBPrograms(cgroupPath)
 	}
 
 	if ifaceName != "" {

--- a/cmd/bpf-ninja/merge.go
+++ b/cmd/bpf-ninja/merge.go
@@ -21,7 +21,7 @@ var mergeFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:  "fexit",
-		Usage: "the shards came from --mode exit / tc-exit (they carry a per-action pcap-ng interface); set this so the merged file keeps the same interfaces",
+		Usage: "the shards came from --mode exit (they carry a per-verdict pcap-ng interface); set this so the merged file keeps the same interfaces",
 	},
 }
 

--- a/cmd/bpf-ninja/merge.go
+++ b/cmd/bpf-ninja/merge.go
@@ -46,7 +46,9 @@ func runMerge(_ context.Context, cmd *cli.Command) error {
 	if base == "" {
 		return fmt.Errorf("--base/-b required")
 	}
-	if err := output.MergeTagShards(base, cmd.Bool("fexit")); err != nil {
+	// No hook flag here: for --fexit shards the merge seeds its verdict
+	// interfaces from the shard files themselves, whichever hook wrote them.
+	if err := output.MergeTagShards(base, output.Config{IsFexit: cmd.Bool("fexit")}); err != nil {
 		return fmt.Errorf("merging tag shards for %s: %w", base, err)
 	}
 	return nil

--- a/docs/ja/dsl-grammar.md
+++ b/docs/ja/dsl-grammar.md
@@ -381,7 +381,8 @@ DSL の `layer-chain` は grammar 上 root を制約しませんが、operationa
 
 例外は次のとおりです。
 
-- `--mode tc-entry` の clsact では、入り口で既に L2 解析済みの場合があり、短い chain で問題ありません。
+- tc clsact ターゲット (fentry) では、入り口で既に L2 解析済みの場合があり、短い chain で問題ありません。
+- cgroup-skb ターゲットでは packet が network header (L3) 始まりなので、`ipv4/...` / `ipv6/...` 起点が正しい chain です (`eth` 起点は逆に warning)。
 - vocab 学習目的で、自前 testing として特定 protocol だけ codegen を確認したい時は、短 chain も valid です。
 
 root が `eth` 以外の短 chain は resolver で warning が出ますが、compile は通ります。

--- a/docs/ja/dsl-internals.md
+++ b/docs/ja/dsl-internals.md
@@ -572,7 +572,7 @@ NOT は inner success label を作って `Ja failLabel` で反転します。
 
 het-alt 後の field addressing では、resolver の `markRuntimeOffsetLayers` が het-alt より後ろの layer を `NeedsRuntimeOffset = true` でマークします。codegen は `layerAnchorFor` で、その layer の field load を abs anchor (R0+静的 prefix) ではなく slot anchor (R10[whereLayerEntrySlot] + R0) で emit します。het-alt の無い filter は、slot 経路ゼロ、命令数増加なしの完全 fast path を維持します。詳細は `codegen.go::layerAnchor` 周辺と `where.go::layerAnchorFor` を参照してください。
 
-action atom (`action == NAME`) では、codegen は `caps.Lang.ActionFetcher.EmitFetch(R3)` を呼んで R3 に action u32 をロードする命令列を取得し、続けて `JNE R3, caps.Lang.Action[NAME], dsl_reject` を emit します。既定 fexit ABI (`pkg/kunai/host/xdp.FexitFetcher` / `pkg/kunai/host/tc.FexitFetcher`) は `stack[-48] → args[1]` の 2 段 LDX を返します。BPF tracing args ABI が host 非依存なので EmitFetch ロジックは XDP / tc で共通で、違いは XDP_DROP=1 と TC_ACT_SHOT=2 のような Actions map の値です。`caps.Lang.Action == nil` のときは、host が action 値を提供できないため resolver が atom を拒否します。userspace target 等は `pkg/kunai/host/<name>/` で独自の fetcher を実装すれば再利用可能で、kunai コアは host 知識を持ちません。
+action atom (`action == NAME`) では、codegen は `caps.Lang.ActionFetcher.EmitFetch(R3)` を呼んで R3 に action u32 をロードする命令列を取得し、続けて `JNE R3, caps.Lang.Action[NAME], dsl_reject` を emit します。既定 fexit ABI (`pkg/kunai/host/{xdp,tc,cgroupskb}` 各パッケージの `FexitFetcher`) は `stack[-48] → args[1]` の 2 段 LDX を返します。BPF tracing args ABI が host 非依存なので EmitFetch ロジックは XDP / tc / cgroup-skb で共通で、違いは XDP_DROP=1、TC_ACT_SHOT=2、SK_DROP=0 のような Actions map の値です。`caps.Lang.Action == nil` のときは、host が action 値を提供できないため resolver が atom を拒否します。userspace target 等は `pkg/kunai/host/<name>/` で独自の fetcher を実装すれば再利用可能で、kunai コアは host 知識を持ちません。
 
 ### 4.7 capture 節
 

--- a/docs/ja/dsl-overview.md
+++ b/docs/ja/dsl-overview.md
@@ -45,14 +45,14 @@ filter expr  →  AST  →  IR (vocab 解決済)  →  asm.Instructions  →  ci
 
 - `eth/ipv4/tcp[dport==443]` 風の layer chain が書けます。各 layer は vocab `.p4` ファイル (`pkg/kunai/protocols/*.p4`) で定義された protocol です。
 - vocab は P4-16 の strict subset である p4lite を Go 側の `pkg/kunai/vocab/p4lite/` で parse します。p4c で標準パースできるのが目標です。詳しくは internals §5 を参照してください。
-- 出力は cilium/ebpf の `asm.Instructions` で、target portable な eBPF subprogram です。kunai コアは XDP / tc 等の host 知識を持たず、host adapter は `pkg/kunai/host/<name>/` サブパッケージに局所化しています。`host/xdp` は XDP fentry/fexit、`host/tc` は TC clsact fentry/fexit です。
-- caller (`internal/program/program.go`) は `kunai.Compile(expr, caps)` に host capability (`xdphost.FexitCapabilities()` / `tchost.FexitCapabilities()` 等) を渡すことで host を選びます。zero `Capabilities` だと、action atom を使えない target-agnostic な filter が出ます。
+- 出力は cilium/ebpf の `asm.Instructions` で、target portable な eBPF subprogram です。kunai コアは XDP / tc 等の host 知識を持たず、host adapter は `pkg/kunai/host/<name>/` サブパッケージに局所化しています。`host/xdp` は XDP fentry/fexit、`host/tc` は TC clsact fentry/fexit、`host/cgroupskb` は cgroup-skb fentry/fexit (L3 始まりの packet window) です。
+- caller (`internal/program/program.go`) は `kunai.Compile(expr, caps)` に host capability (`xdphost.FexitCapabilities()` / `tchost.FexitCapabilities()` 等) を渡すことで host を選びます。どの host caps を使うかは `internal/hook` の registry がターゲットプログラムの型から決めます。zero `Capabilities` だと、action atom を使えない target-agnostic な filter が出ます。
 
 ## 関連コード
 
 - DSL 本体: `pkg/kunai/`
 - Vocab: `pkg/kunai/protocols/*.p4`
-- Host adapter: `pkg/kunai/host/xdp/` (XDP fentry/fexit) + `pkg/kunai/host/tc/` (TC clsact fentry/fexit、sk_buff data/len offset を BTF で実行時解決)。新 host を追加するときは `host/<name>/` を並べます
+- Host adapter: `pkg/kunai/host/xdp/` (XDP fentry/fexit) + `pkg/kunai/host/tc/` (TC clsact fentry/fexit、sk_buff data/len offset を BTF で実行時解決) + `pkg/kunai/host/cgroupskb/` (cgroup-skb fentry/fexit、SK_DROP/SK_PASS + L3 始まり layout)。新 host を追加するときは `host/<name>/` を並べ、`internal/hook` に記述子を 1 個足します
 - ABI 契約 (kunai ↔ host): `pkg/kunai/codegen/codegen.go` の package doc + `KunaiStackTop` constant
 - 既存 fentry/fexit との接続: `internal/program/program.go::compileFilter`
 - CLI 入口: `cmd/bpf-ninja/main.go` の `resolveFilterSyntax()` (DSL がデフォルト、`--cbpf` で legacy)

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -12,19 +12,19 @@ sudo bpf-ninja -i veth0 "eth/ipv4/tcp[dport==443]"
 
 - DSL が default です。tcpdump/cBPF 構文を使いたいときだけ `--cbpf` を付けますが、これは legacy 扱いで deprecation notice が出ます。
 - フィルタ式は位置引数として末尾に渡します。
-- 既存の `-w pcap`、`-c count`、`--mode entry/exit/xdp/tc-entry/tc-exit` などはすべて DSL でも使えます。
+- 既存の `-w pcap`、`-c count`、`--mode entry/exit/xdp` などはすべて DSL でも使えます。
 
 #### `--mode` 一覧
 
-| Mode | Attach 方法 | 既存プログラム | XDP/TC return action 観測 | 主用途 |
+| Mode | Attach 方法 | 既存プログラム | return action 観測 | 主用途 |
 |---|---|---|---|---|
-| `entry` (default) | XDP fentry trampoline | 必須 (BTF 付) | × (packet only) | production XDP に来る前のパケットを観測 |
-| `exit` | XDP fexit trampoline | 必須 (BTF 付) | ○ (`XDP_PASS`/`DROP`/...) | XDP の判断結果を観測する。`where action == XDP_DROP` 等で絞れる |
+| `entry` (default) | fentry trampoline | 必須 (BTF 付) | × (packet only) | production プログラムに来る前のパケットを観測 |
+| `exit` | fexit trampoline | 必須 (BTF 付) | ○ (`XDP_PASS`/`TC_ACT_OK`/...) | 判断結果を観測する。`where action == XDP_DROP` 等で絞れる |
 | `xdp` | netdev に直接 attach | 不要 (既に attach されているとエラー) | n/a (常に `XDP_PASS`) | XDP が attach されていない netdev の standalone capture |
-| `tc-entry` | TC clsact fentry trampoline | 必須 (TC clsact filter; `tc filter add ... direction ingress/egress`) | × (skb の pre-state) | tc-bpf が来る前の skb を観測 |
-| `tc-exit` | TC clsact fexit trampoline | 必須 (同上) | ○ (`TC_ACT_OK/SHOT/...`) | tc-bpf の verdict を観測する。`where action == TC_ACT_SHOT` 等 |
 
-`tc-entry`/`tc-exit` は TC 層の clsact filter に対する fentry/fexit なので、XDP は不要です。TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
+hook 種別 (XDP / TC clsact) は指定不要です。ターゲットプログラムの型から自動判別されます。`-p <progID>` はどの対応型でも受け付け、`-i <iface>` は interface の XDP プログラムを引きます。TC clsact filter (`tc filter add ... direction ingress/egress` で張ったもの) も fentry/fexit の対象にできますが、TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
+
+旧 `--mode tc-entry` / `tc-exit` は `entry` / `exit` の deprecated alias として残っています (stderr に警告が出ます)。
 
 ## 文法
 
@@ -180,12 +180,12 @@ SRv6 segments のような parent-count 系には自動 count guard が入り、
 
 #### action atom
 
-`action == <NAME>` は fexit 系の mode (`--mode exit` / `--mode tc-exit`) でのみ使えます。fentry 系 (`entry` / `tc-entry`) では下流プログラムの戻り値がまだ存在せず、`--mode xdp` は bpf-ninja 自身が常に `XDP_PASS` を返す立場で観測対象がないため、いずれも resolver で reject されます。
+`action == <NAME>` は `--mode exit` (fexit) でのみ使えます。`entry` (fentry) では下流プログラムの戻り値がまだ存在せず、`--mode xdp` は bpf-ninja 自身が常に `XDP_PASS` を返す立場で観測対象がないため、いずれも resolver で reject されます。
 
-| Mode | サポートされる定数 |
+| ターゲット (自動判別) | サポートされる定数 |
 |---|---|
-| `--mode exit` (XDP fexit) | `XDP_ABORTED`, `XDP_DROP`, `XDP_PASS`, `XDP_TX`, `XDP_REDIRECT` |
-| `--mode tc-exit` (TC fexit) | `TC_ACT_UNSPEC` (-1), `TC_ACT_OK`, `TC_ACT_RECLASSIFY`, `TC_ACT_SHOT`, `TC_ACT_PIPE`, `TC_ACT_STOLEN`, `TC_ACT_QUEUED`, `TC_ACT_REPEAT`, `TC_ACT_REDIRECT`, `TC_ACT_TRAP` |
+| XDP プログラム (fexit) | `XDP_ABORTED`, `XDP_DROP`, `XDP_PASS`, `XDP_TX`, `XDP_REDIRECT` |
+| TC clsact プログラム (fexit) | `TC_ACT_UNSPEC` (-1), `TC_ACT_OK`, `TC_ACT_RECLASSIFY`, `TC_ACT_SHOT`, `TC_ACT_PIPE`, `TC_ACT_STOLEN`, `TC_ACT_QUEUED`, `TC_ACT_REPEAT`, `TC_ACT_REDIRECT`, `TC_ACT_TRAP` |
 
 host adapter ごとの定数表は `pkg/kunai/host/xdp/xdp.go` / `pkg/kunai/host/tc/tc.go` の `FexitCapabilities()` を参照してください。新 host を足すときは `Capabilities.Lang` に同 shape の `Action map[string]int32` + `ActionFetcher` を提供します。
 
@@ -755,7 +755,7 @@ Ctrl-C などでクリーンに終了すると、per-CPU の tag ファイルを
 
 ```bash
 sudo bpf-ninja merge --base out.pcap        # out.cpuN.<tag> を out.<tag> にまとめる
-sudo bpf-ninja merge --base out.pcap --fexit  # --mode exit / tc-exit で録った場合
+sudo bpf-ninja merge --base out.pcap --fexit  # --mode exit で録った場合
 ```
 
 注意点は次のとおりです。

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -22,7 +22,9 @@ sudo bpf-ninja -i veth0 "eth/ipv4/tcp[dport==443]"
 | `exit` | fexit trampoline | 必須 (BTF 付) | ○ (`XDP_PASS`/`TC_ACT_OK`/...) | 判断結果を観測する。`where action == XDP_DROP` 等で絞れる |
 | `xdp` | netdev に直接 attach | 不要 (既に attach されているとエラー) | n/a (常に `XDP_PASS`) | XDP が attach されていない netdev の standalone capture |
 
-hook 種別 (XDP / TC clsact) は指定不要です。ターゲットプログラムの型から自動判別されます。`-p <progID>` はどの対応型でも受け付け、`-i <iface>` は interface の XDP プログラムを引きます。TC clsact filter (`tc filter add ... direction ingress/egress` で張ったもの) も fentry/fexit の対象にできますが、TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
+hook 種別 (XDP / TC clsact / cgroup-skb) は指定不要です。ターゲットプログラムの型から自動判別されます。`-p <progID>` はどの対応型でも受け付け、`-i <iface>` は interface の XDP プログラムを引き、`--cgroup <path>` は cgroup v2 パスに attach された cgroup-skb プログラムを列挙します (BPF_PROG_QUERY、ingress + egress)。TC clsact filter (`tc filter add ... direction ingress/egress` で張ったもの) も fentry/fexit の対象にできますが、TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
+
+cgroup-skb ターゲットには注意点が 2 つあります。パケットは network header (L3) 始まりで Ethernet ヘッダを含まないため、DSL チェインは `ipv4/...` または `ipv6/...` を起点にします (`eth/...` は警告付きで誤 parse になります)。pcap-ng 出力も LINKTYPE_RAW になり、Wireshark / tcpdump はバージョン nibble から v4/v6 を自動判定します。
 
 旧 `--mode tc-entry` / `tc-exit` は `entry` / `exit` の deprecated alias として残っています (stderr に警告が出ます)。
 
@@ -186,8 +188,9 @@ SRv6 segments のような parent-count 系には自動 count guard が入り、
 |---|---|
 | XDP プログラム (fexit) | `XDP_ABORTED`, `XDP_DROP`, `XDP_PASS`, `XDP_TX`, `XDP_REDIRECT` |
 | TC clsact プログラム (fexit) | `TC_ACT_UNSPEC` (-1), `TC_ACT_OK`, `TC_ACT_RECLASSIFY`, `TC_ACT_SHOT`, `TC_ACT_PIPE`, `TC_ACT_STOLEN`, `TC_ACT_QUEUED`, `TC_ACT_REPEAT`, `TC_ACT_REDIRECT`, `TC_ACT_TRAP` |
+| cgroup-skb プログラム (fexit) | `SK_DROP` (0), `SK_PASS` (1)。egress 専用の 2/3 (輻輳通知付き drop) は uapi 名が無いため atom は無く、pcap 側では `cgroup-skb:UNKNOWN(n)` interface に落ちます |
 
-host adapter ごとの定数表は `pkg/kunai/host/xdp/xdp.go` / `pkg/kunai/host/tc/tc.go` の `FexitCapabilities()` を参照してください。新 host を足すときは `Capabilities.Lang` に同 shape の `Action map[string]int32` + `ActionFetcher` を提供します。
+host adapter ごとの定数表は `pkg/kunai/host/xdp/xdp.go` / `pkg/kunai/host/tc/tc.go` / `pkg/kunai/host/cgroupskb/cgroupskb.go` の `FexitCapabilities()` を参照してください。新 host を足すときは `Capabilities.Lang` に同 shape の `Action map[string]int32` + `ActionFetcher` を提供します。
 
 ### Capture 節
 

--- a/docs/ja/kunai-overview-article.md
+++ b/docs/ja/kunai-overview-article.md
@@ -229,7 +229,7 @@ GTP の optional header `gtp.opt`、SRv6 の `srv6.segments[N]`、TCP の `tcp.o
 
 kunai の output は XDP に固定されません。2 レジスタの packet window と少数のワーキングレジスタしか仮定せず、attach point 固有の prologue / epilogue である host adapter が、context から R0 / R1 / R9 をセットアップする責務を持ちます。
 
-`pkg/kunai/host/xdp/` が bpf-ninja の fentry/fexit 用 adapter で、同じ paradigm で tc clsact / userspace `BPF_PROG_TEST_RUN` / 独自 tracing 等の host adapter を書けます。fexit attach では `where action == XDP_DROP` のような action atom が使えますが、fentry では return code がまだ無いため使えません。これは `Capabilities.Lang.Action` map で host から kunai に declare する設計です。
+bpf-ninja は `pkg/kunai/host/xdp/`・`host/tc/`・`host/cgroupskb/` の 3 つの fentry/fexit 用 adapter を同梱していて、同じ paradigm で userspace `BPF_PROG_TEST_RUN` / 独自 tracing 等の host adapter も書けます。fexit attach では `where action == XDP_DROP` のような action atom が使えますが、fentry では return code がまだ無いため使えません。これは `Capabilities.Lang.Action` map で host から kunai に declare する設計です。
 
 kunai 自身は XDP を知らず、XDP を知る adapter が wrap する、というのが kunai のスタンスです。結果として、library として完全に独立して使えます。使い方は `pkg/kunai/README.md` の Quick start を参照してください。
 

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
+	"github.com/takehaya/bpf-ninja/internal/hook"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 )
@@ -77,9 +78,9 @@ func FindBPFProgramByID(progID uint32) (*ProgInfo, error) {
 		return nil, fmt.Errorf("reading program info (id=%d): %w", progID, err)
 	}
 	progType := progInfo.Type
-	if progType != ebpf.XDP && progType != ebpf.SchedCLS && progType != ebpf.SchedACT {
+	if _, ok := hook.ByProgramType(progType); !ok {
 		_ = prog.Close()
-		return nil, fmt.Errorf("program (id=%d) type %s is not supported (need XDP, SchedCLS, or SchedACT)", progID, progType)
+		return nil, fmt.Errorf("program (id=%d): %w", progID, hook.UnsupportedTypeError(progType))
 	}
 
 	funcName, spec, err := resolveEntryFunc(prog, progID)

--- a/internal/attach/cgroup.go
+++ b/internal/attach/cgroup.go
@@ -1,0 +1,61 @@
+package attach
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+// cgroupSKBAttachTypes are the cgroup attach points a
+// BPF_PROG_TYPE_CGROUP_SKB program can hang off — the set the --cgroup
+// selector enumerates.
+var cgroupSKBAttachTypes = []ebpf.AttachType{
+	ebpf.AttachCGroupInetIngress,
+	ebpf.AttachCGroupInetEgress,
+}
+
+// FindCgroupSKBPrograms enumerates the cgroup-skb programs attached
+// (directly, not inherited) to the given cgroup v2 path via
+// BPF_PROG_QUERY, and opens each as a probe target. Peer of
+// FindXDPProgram for the cgroup world: `--cgroup /sys/fs/cgroup/foo`
+// is to cgroup-skb what `-i eth0` is to XDP.
+func FindCgroupSKBPrograms(cgroupPath string) ([]*ProgInfo, error) {
+	dir, err := os.Open(cgroupPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening cgroup %s: %w", cgroupPath, err)
+	}
+	defer func() { _ = dir.Close() }()
+
+	seen := map[ebpf.ProgramID]bool{}
+	var ids []ebpf.ProgramID
+	for _, at := range cgroupSKBAttachTypes {
+		res, err := link.QueryPrograms(link.QueryOptions{Target: int(dir.Fd()), Attach: at})
+		if err != nil {
+			return nil, fmt.Errorf("querying %s programs on %s: %w", at, cgroupPath, err)
+		}
+		for _, p := range res.Programs {
+			if !seen[p.ID] {
+				seen[p.ID] = true
+				ids = append(ids, p.ID)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("no cgroup-skb programs attached to %s (BPF_PROG_QUERY over ingress+egress found none)", cgroupPath)
+	}
+
+	var infos []*ProgInfo
+	for _, id := range ids {
+		info, err := FindBPFProgramByID(uint32(id))
+		if err != nil {
+			for _, prev := range infos {
+				_ = prev.Program.Close()
+			}
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -93,19 +93,10 @@ func init() {
 type Packet struct {
 	Timestamp time.Time
 	Data      []byte
-	Action    uint32 // XDP action (fexit only)
+	Action    uint32 // hook verdict: XDP action / TC verdict (fexit only)
 	Mode      uint8  // 0=entry(fentry), 1=exit(fexit), 2=xdp-native
 	CapLen    uint16 // bytes the BPF side actually copied into Data
 	Tag       uint32 // set-map value of the matched entry (0 when no set matched)
-}
-
-// XDP actions for display.
-var XDPActionNames = map[uint32]string{
-	0: "ABORTED",
-	1: "DROP",
-	2: "PASS",
-	3: "TX",
-	4: "REDIRECT",
 }
 
 // Reader reads captured packets from the ringbuf.

--- a/internal/hook/cgroupskb.go
+++ b/internal/hook/cgroupskb.go
@@ -1,0 +1,29 @@
+package hook
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/google/gopacket/layers"
+	cgskbhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/cgroupskb"
+)
+
+var cgroupSKBHook = &Hook{
+	Kind:      KindCgroupSKB,
+	ProgTypes: []ebpf.ProgramType{ebpf.CGroupSKB},
+	// fentry/fexit on a cgroup-skb program sees the same kernel
+	// struct sk_buff * at args[0] as tc, so the skb prologue is shared.
+	// The packet window differs though: skb->data points at the
+	// network (L3) header — no Ethernet framing — hence LinkTypeRaw
+	// and the L3-start host capabilities.
+	PacketPrologue: skbPacketPrologue,
+	EntryCaps:      cgskbhost.EntryCapabilities,
+	FexitCaps:      cgskbhost.FexitCapabilities,
+	// Mirrors cgskbhost.Actions; consistency is asserted by
+	// TestHookActionsMatchHostVocab. Egress verdicts 2/3 (drop with
+	// congestion notification) have no uapi symbol and land on the
+	// lazily-added UNKNOWN interface.
+	Actions: []ActionName{
+		{Value: 0, Name: "cgroup-skb:SK_DROP"},
+		{Value: 1, Name: "cgroup-skb:SK_PASS"},
+	},
+	LinkType: layers.LinkTypeRaw,
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,0 +1,102 @@
+// Package hook is the registry of BPF attach-target kinds bpf-ninja can
+// trace. Each supported kind (XDP, tc clsact, ...) is described once by a
+// Hook value: which ebpf.ProgramType(s) it covers, how the tracing
+// prologue reads the packet window out of the target's context, and which
+// kunai host capabilities apply at fentry/fexit. Callers look hooks up by
+// program type (auto-detection from a target program) or by name, instead
+// of switching on ebpf.ProgramType at every site.
+package hook
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
+)
+
+// Kind names a hook in CLI/docs-facing contexts.
+type Kind string
+
+const (
+	KindXDP Kind = "xdp"
+	KindTC  Kind = "tc"
+)
+
+// Hook describes one attach-target kind.
+type Hook struct {
+	Kind Kind
+
+	// ProgTypes is the set of ebpf.ProgramType values this hook covers
+	// (tc clsact spans SchedCLS and SchedACT).
+	ProgTypes []ebpf.ProgramType
+
+	// PacketPrologue emits the tracing-program prelude that loads the
+	// packet window from the target's context. Contract on exit:
+	// R6=ctx, R7=data, R8=data_end, R9=pkt_len, stack[-48]=args ptr.
+	PacketPrologue func() (asm.Instructions, error)
+
+	// EntryCaps / FexitCaps are the kunai host capabilities for fentry
+	// and fexit compiles respectively (action atoms, packet layout).
+	EntryCaps func() codegen.Capabilities
+	FexitCaps func() codegen.Capabilities
+}
+
+// registry lists all supported hooks. Order defines the wording of
+// SupportedLabel (and therefore user-facing error messages).
+var registry = []*Hook{xdpHook, tcHook}
+
+// ByProgramType finds the hook covering pt. The single lookup replaces
+// the per-site `pt == XDP || pt == SchedCLS || ...` supported-type checks.
+func ByProgramType(pt ebpf.ProgramType) (*Hook, bool) {
+	for _, h := range registry {
+		for _, t := range h.ProgTypes {
+			if t == pt {
+				return h, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// ByName finds a hook by its Kind name.
+func ByName(name Kind) (*Hook, bool) {
+	for _, h := range registry {
+		if h.Kind == name {
+			return h, true
+		}
+	}
+	return nil, false
+}
+
+// SupportedLabel renders the supported program types for error messages,
+// e.g. "XDP, SchedCLS, or SchedACT".
+func SupportedLabel() string {
+	var names []string
+	for _, h := range registry {
+		for _, t := range h.ProgTypes {
+			names = append(names, t.String())
+		}
+	}
+	if len(names) <= 1 {
+		return strings.Join(names, "")
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}
+
+// UnsupportedTypeError is the shared error shape for a target program
+// whose type no hook covers.
+func UnsupportedTypeError(pt ebpf.ProgramType) error {
+	return fmt.Errorf("target program type %s is not supported (need %s)", pt, SupportedLabel())
+}
+
+// tracingPrelude is the hook-independent head of every PacketPrologue:
+// save the tracing args pointer at stack[-48] (fexit action lookup, arg
+// filters) and load args[0] — the host-specific packet ctx — into R6.
+func tracingPrelude() asm.Instructions {
+	return asm.Instructions{
+		asm.StoreMem(asm.R10, -48, asm.R1, asm.DWord),
+		asm.LoadMem(asm.R6, asm.R1, 0, asm.DWord),
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -9,10 +9,12 @@ package hook
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/google/gopacket/layers"
 	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
 )
 
@@ -41,6 +43,23 @@ type Hook struct {
 	// and fexit compiles respectively (action atoms, packet layout).
 	EntryCaps func() codegen.Capabilities
 	FexitCaps func() codegen.Capabilities
+
+	// Actions lists the hook's verdict values in pcap-ng interface
+	// creation order, with their display names (exit mode writes one
+	// interface per verdict so Wireshark shows the verdict as the
+	// interface name). Signed verdicts are stored as their uint32 bit
+	// pattern (TC_ACT_UNSPEC = 0xffffffff).
+	Actions []ActionName
+
+	// LinkType is the pcap-ng link type of the packet bytes this hook
+	// observes (Ethernet for xdp/tc; raw IP for L3-start hooks).
+	LinkType layers.LinkType
+}
+
+// ActionName pairs a verdict value with its pcap-ng interface name.
+type ActionName struct {
+	Value uint32
+	Name  string
 }
 
 // registry lists all supported hooks. Order defines the wording of
@@ -51,10 +70,8 @@ var registry = []*Hook{xdpHook, tcHook}
 // the per-site `pt == XDP || pt == SchedCLS || ...` supported-type checks.
 func ByProgramType(pt ebpf.ProgramType) (*Hook, bool) {
 	for _, h := range registry {
-		for _, t := range h.ProgTypes {
-			if t == pt {
-				return h, true
-			}
+		if slices.Contains(h.ProgTypes, pt) {
+			return h, true
 		}
 	}
 	return nil, false

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -22,8 +22,9 @@ import (
 type Kind string
 
 const (
-	KindXDP Kind = "xdp"
-	KindTC  Kind = "tc"
+	KindXDP       Kind = "xdp"
+	KindTC        Kind = "tc"
+	KindCgroupSKB Kind = "cgroup-skb"
 )
 
 // Hook describes one attach-target kind.
@@ -64,7 +65,7 @@ type ActionName struct {
 
 // registry lists all supported hooks. Order defines the wording of
 // SupportedLabel (and therefore user-facing error messages).
-var registry = []*Hook{xdpHook, tcHook}
+var registry = []*Hook{xdpHook, tcHook, cgroupSKBHook}
 
 // ByProgramType finds the hook covering pt. The single lookup replaces
 // the per-site `pt == XDP || pt == SchedCLS || ...` supported-type checks.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
+	cgskbhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/cgroupskb"
 	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
 	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
 )
@@ -18,7 +19,7 @@ func TestByProgramType(t *testing.T) {
 		{ebpf.XDP, KindXDP, true},
 		{ebpf.SchedCLS, KindTC, true},
 		{ebpf.SchedACT, KindTC, true},
-		{ebpf.CGroupSKB, "", false},
+		{ebpf.CGroupSKB, KindCgroupSKB, true},
 		{ebpf.SocketFilter, "", false},
 	}
 	for _, c := range cases {
@@ -34,7 +35,7 @@ func TestByProgramType(t *testing.T) {
 }
 
 func TestByName(t *testing.T) {
-	for _, k := range []Kind{KindXDP, KindTC} {
+	for _, k := range []Kind{KindXDP, KindTC, KindCgroupSKB} {
 		h, ok := ByName(k)
 		if !ok || h.Kind != k {
 			t.Errorf("ByName(%s) = %v, %v", k, h, ok)
@@ -59,6 +60,7 @@ func TestHookActionsMatchHostVocab(t *testing.T) {
 	}{
 		{KindXDP, xdphost.Actions, func(k string) string { return "xdp:" + strings.TrimPrefix(k, "XDP_") }},
 		{KindTC, tchost.Actions, func(k string) string { return "tc:" + k }},
+		{KindCgroupSKB, cgskbhost.Actions, func(k string) string { return "cgroup-skb:" + k }},
 	}
 	for _, c := range cases {
 		h, ok := ByName(c.hook)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,0 +1,89 @@
+package hook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
+	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
+)
+
+func TestByProgramType(t *testing.T) {
+	cases := []struct {
+		pt   ebpf.ProgramType
+		want Kind
+		ok   bool
+	}{
+		{ebpf.XDP, KindXDP, true},
+		{ebpf.SchedCLS, KindTC, true},
+		{ebpf.SchedACT, KindTC, true},
+		{ebpf.CGroupSKB, "", false},
+		{ebpf.SocketFilter, "", false},
+	}
+	for _, c := range cases {
+		h, ok := ByProgramType(c.pt)
+		if ok != c.ok {
+			t.Errorf("ByProgramType(%s) ok = %v, want %v", c.pt, ok, c.ok)
+			continue
+		}
+		if ok && h.Kind != c.want {
+			t.Errorf("ByProgramType(%s) = %s, want %s", c.pt, h.Kind, c.want)
+		}
+	}
+}
+
+func TestByName(t *testing.T) {
+	for _, k := range []Kind{KindXDP, KindTC} {
+		h, ok := ByName(k)
+		if !ok || h.Kind != k {
+			t.Errorf("ByName(%s) = %v, %v", k, h, ok)
+		}
+	}
+	if _, ok := ByName("nope"); ok {
+		t.Error("ByName(nope) should not resolve")
+	}
+}
+
+// TestHookActionsMatchHostVocab pins the hook registry's verdict tables
+// to the kunai host packages' action vocabularies: every verdict value a
+// DSL `where action == NAME` atom can produce must have a matching
+// pcap-ng interface, with a name derived from the same kernel constant.
+func TestHookActionsMatchHostVocab(t *testing.T) {
+	cases := []struct {
+		hook  Kind
+		vocab map[string]int32
+		// rename maps the host vocab key to the interface display name
+		// (the xdp names predate the registry and drop the XDP_ prefix).
+		rename func(key string) string
+	}{
+		{KindXDP, xdphost.Actions, func(k string) string { return "xdp:" + strings.TrimPrefix(k, "XDP_") }},
+		{KindTC, tchost.Actions, func(k string) string { return "tc:" + k }},
+	}
+	for _, c := range cases {
+		h, ok := ByName(c.hook)
+		if !ok {
+			t.Fatalf("hook %s not registered", c.hook)
+		}
+		byValue := map[uint32]string{}
+		for _, a := range h.Actions {
+			byValue[a.Value] = a.Name
+		}
+		if len(h.Actions) != len(byValue) {
+			t.Errorf("%s: duplicate verdict values in Actions", c.hook)
+		}
+		if len(byValue) != len(c.vocab) {
+			t.Errorf("%s: %d interface actions vs %d host vocab actions", c.hook, len(byValue), len(c.vocab))
+		}
+		for key, v := range c.vocab {
+			name, ok := byValue[uint32(v)]
+			if !ok {
+				t.Errorf("%s: host action %s (%d) has no interface entry", c.hook, key, v)
+				continue
+			}
+			if want := c.rename(key); name != want {
+				t.Errorf("%s: verdict %d interface name = %q, want %q", c.hook, v, name, want)
+			}
+		}
+	}
+}

--- a/internal/hook/skbuff_btf.go
+++ b/internal/hook/skbuff_btf.go
@@ -1,4 +1,4 @@
-package program
+package hook
 
 import (
 	"fmt"

--- a/internal/hook/skbuff_btf_test.go
+++ b/internal/hook/skbuff_btf_test.go
@@ -1,4 +1,4 @@
-package program
+package hook
 
 import (
 	"testing"

--- a/internal/hook/tc.go
+++ b/internal/hook/tc.go
@@ -1,0 +1,38 @@
+package hook
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
+)
+
+var tcHook = &Hook{
+	Kind:           KindTC,
+	ProgTypes:      []ebpf.ProgramType{ebpf.SchedCLS, ebpf.SchedACT},
+	PacketPrologue: skbPacketPrologue,
+	// The tc host carries VlanInMetadata in both entry and fexit caps,
+	// because the kernel strips the outer VLAN tag into skb metadata
+	// before either attach point runs.
+	EntryCaps: tchost.EntryCapabilities,
+	FexitCaps: tchost.FexitCapabilities,
+}
+
+// skbPacketPrologue reads the packet window from a kernel
+// struct sk_buff * (the kernel struct, NOT the BPF-rewritten __sk_buff
+// view — that rewrite does not fire in tracing context). Member offsets
+// drift across kernel versions, so they are resolved from kernel BTF at
+// runtime. sk_buff has no data_end member; it is computed as data + len.
+func skbPacketPrologue() (asm.Instructions, error) {
+	dataOff, lenOff, err := skBuffPacketOffsets()
+	if err != nil {
+		return nil, fmt.Errorf("resolving struct sk_buff offsets via BTF: %w", err)
+	}
+	return append(tracingPrelude(),
+		asm.LoadMem(asm.R7, asm.R6, int16(dataOff), asm.DWord), // R7 = skb->data
+		asm.LoadMem(asm.R9, asm.R6, int16(lenOff), asm.Word),   // R9 = skb->len
+		asm.Mov.Reg(asm.R8, asm.R7),
+		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + len
+	), nil
+}

--- a/internal/hook/tc.go
+++ b/internal/hook/tc.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/google/gopacket/layers"
 	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
 )
 
@@ -17,6 +18,21 @@ var tcHook = &Hook{
 	// before either attach point runs.
 	EntryCaps: tchost.EntryCapabilities,
 	FexitCaps: tchost.FexitCapabilities,
+	// Mirrors tchost.Actions (uapi/linux/pkt_cls.h); consistency is
+	// asserted by TestHookActionsMatchHostVocab.
+	Actions: []ActionName{
+		{Value: uint32(0xffffffff), Name: "tc:TC_ACT_UNSPEC"}, // -1
+		{Value: 0, Name: "tc:TC_ACT_OK"},
+		{Value: 1, Name: "tc:TC_ACT_RECLASSIFY"},
+		{Value: 2, Name: "tc:TC_ACT_SHOT"},
+		{Value: 3, Name: "tc:TC_ACT_PIPE"},
+		{Value: 4, Name: "tc:TC_ACT_STOLEN"},
+		{Value: 5, Name: "tc:TC_ACT_QUEUED"},
+		{Value: 6, Name: "tc:TC_ACT_REPEAT"},
+		{Value: 7, Name: "tc:TC_ACT_REDIRECT"},
+		{Value: 8, Name: "tc:TC_ACT_TRAP"},
+	},
+	LinkType: layers.LinkTypeEthernet,
 }
 
 // skbPacketPrologue reads the packet window from a kernel

--- a/internal/hook/xdp.go
+++ b/internal/hook/xdp.go
@@ -1,0 +1,30 @@
+package hook
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
+	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
+)
+
+var xdpHook = &Hook{
+	Kind:           KindXDP,
+	ProgTypes:      []ebpf.ProgramType{ebpf.XDP},
+	PacketPrologue: xdpPacketPrologue,
+	// XDP entry keeps zero caps: no action value yet, and VLAN is
+	// in-band at XDP so no layout flags apply either.
+	EntryCaps: func() codegen.Capabilities { return codegen.Capabilities{} },
+	FexitCaps: xdphost.FexitCapabilities,
+}
+
+// xdpPacketPrologue reads the packet window from a kernel
+// struct xdp_buff *: data @ +0, data_end @ +8 (both 8B pointers,
+// ABI-stable so the offsets are hardcoded).
+func xdpPacketPrologue() (asm.Instructions, error) {
+	return append(tracingPrelude(),
+		asm.LoadMem(asm.R7, asm.R6, 0, asm.DWord),
+		asm.LoadMem(asm.R8, asm.R6, 8, asm.DWord),
+		asm.Mov.Reg(asm.R9, asm.R8),
+		asm.Sub.Reg(asm.R9, asm.R7),
+	), nil
+}

--- a/internal/hook/xdp.go
+++ b/internal/hook/xdp.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/google/gopacket/layers"
 	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
 	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
 )
@@ -15,6 +16,16 @@ var xdpHook = &Hook{
 	// in-band at XDP so no layout flags apply either.
 	EntryCaps: func() codegen.Capabilities { return codegen.Capabilities{} },
 	FexitCaps: xdphost.FexitCapabilities,
+	// Interface names predate the registry ("xdp:DROP", not
+	// "xdp:XDP_DROP") — kept for pcap-consumer compatibility.
+	Actions: []ActionName{
+		{Value: 0, Name: "xdp:ABORTED"},
+		{Value: 1, Name: "xdp:DROP"},
+		{Value: 2, Name: "xdp:PASS"},
+		{Value: 3, Name: "xdp:TX"},
+		{Value: 4, Name: "xdp:REDIRECT"},
+	},
+	LinkType: layers.LinkTypeEthernet,
 }
 
 // xdpPacketPrologue reads the packet window from a kernel

--- a/internal/output/fastpcapng.go
+++ b/internal/output/fastpcapng.go
@@ -29,6 +29,8 @@ import (
 	"fmt"
 	"io"
 	"time"
+
+	"github.com/google/gopacket/layers"
 )
 
 // pcap-ng block types (RFC draft, IETF opsawg-pcapng).
@@ -40,9 +42,6 @@ const (
 	shbByteOrderMagic = 0x1A2B3C4D
 	shbVersionMajor   = 1
 	shbVersionMinor   = 0
-
-	// LinkType: LINKTYPE_ETHERNET (1).
-	linkTypeEthernet = 1
 
 	// Timestamp resolution: nanoseconds, encoded in IDB option
 	// if_tsresol = 9 (i.e. 10^-9). Default is 10^-6 (microseconds);
@@ -66,12 +65,12 @@ type FastNgWriter struct {
 // Caller writes packets via WritePacket. The IDB has timestamp
 // resolution = nanoseconds (matches gopacket pcapgo default of
 // TimestampResolution: 9).
-func NewFastNgWriter(w io.Writer) (*FastNgWriter, error) {
+func NewFastNgWriter(w io.Writer, linkType layers.LinkType) (*FastNgWriter, error) {
 	fw := &FastNgWriter{w: w}
 	if err := fw.writeSHB(); err != nil {
 		return nil, err
 	}
-	if err := fw.writeIDB(linkTypeEthernet); err != nil {
+	if err := fw.writeIDB(uint16(linkType)); err != nil {
 		return nil, err
 	}
 	return fw, nil

--- a/internal/output/fastpcapng_test.go
+++ b/internal/output/fastpcapng_test.go
@@ -25,7 +25,7 @@ func writePacketsToFile(t *testing.T, path string, pkts []capture.Packet, fast b
 	} else {
 		t.Setenv("BPF_NINJA_FAST_PCAPNG", "0")
 	}
-	w, err := NewWriter(path, false)
+	w, err := NewWriter(path, Config{})
 	if err != nil {
 		t.Fatalf("NewWriter(fast=%v): %v", fast, err)
 	}

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -11,15 +11,13 @@ import (
 	"time"
 
 	"github.com/google/gopacket/pcapgo"
-
-	"github.com/takehaya/bpf-ninja/internal/capture"
 )
 
 type mergeItem struct {
-	ts     time.Time
-	data   []byte
-	action uint32 // source interface index = XDP action (fexit); preserved on write
-	idx    int    // which shard reader to pull the next packet from
+	ts       time.Time
+	data     []byte
+	srcIface int // source-file interface index; mapped to the output by name (fexit)
+	idx      int // which shard reader to pull the next packet from
 }
 
 // mergeHeap is a min-heap on packet timestamp.
@@ -40,12 +38,12 @@ func (h *mergeHeap) Pop() any {
 // MergeShardFiles merges <basePath>.cpu0..cpu(numShards-1) into a single
 // time-ordered pcap-ng written to basePath. Missing or empty shard files
 // are skipped. The shard files are left in place.
-func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
+func MergeShardFiles(basePath string, numShards int, cfg Config) error {
 	inPaths := make([]string, numShards)
 	for i := range numShards {
 		inPaths[i] = fmt.Sprintf("%s.cpu%d", basePath, i)
 	}
-	return mergeFiles(inPaths, basePath, isFexit)
+	return mergeFiles(inPaths, basePath, cfg)
 }
 
 // mergeFiles k-way merges the given pcap-ng input files (each already in
@@ -54,7 +52,7 @@ func MergeShardFiles(basePath string, numShards int, isFexit bool) error {
 // skipped so a crashed shard never aborts the merge. Inputs are left in
 // place. Shared by MergeShardFiles, the tag-split merge, and the `merge`
 // subcommand.
-func mergeFiles(inPaths []string, outPath string, isFexit bool) error {
+func mergeFiles(inPaths []string, outPath string, cfg Config) error {
 	var closers []*os.File
 	var readers []*pcapgo.NgReader
 	defer func() {
@@ -82,11 +80,35 @@ func mergeFiles(inPaths []string, outPath string, isFexit bool) error {
 		readers = append(readers, r)
 	}
 
+	// Exit-mode merge with no configured verdict interfaces (the
+	// standalone `bpf-ninja merge` subcommand does not know the hook):
+	// seed the output layout from the first input's interface table so
+	// the merged file keeps the shards' interface names whatever hook
+	// wrote them.
+	if cfg.IsFexit && len(cfg.Actions) == 0 && len(readers) > 0 {
+		r := readers[0]
+		for i := range r.NInterfaces() {
+			intf, ierr := r.Interface(i)
+			if ierr != nil {
+				break
+			}
+			cfg.Actions = append(cfg.Actions, ActionName{Value: uint32(i), Name: intf.Name})
+			if cfg.LinkType == 0 {
+				cfg.LinkType = intf.LinkType
+			}
+		}
+	}
+	if cfg.IsFexit && len(cfg.Actions) == 0 {
+		// Nothing usable to seed from (all inputs missing/unreadable):
+		// behave like the readerless merge below and produce no output.
+		return nil
+	}
+
 	// Write to a temp file and rename on success so a mid-merge failure
 	// (disk full / short write) never leaves a truncated base file over the
 	// still-valid per-CPU shards — the merge is atomic.
 	tmpPath := outPath + ".merging"
-	out, err := NewWriter(tmpPath, isFexit)
+	out, err := NewWriter(tmpPath, cfg)
 	if err != nil {
 		return err
 	}
@@ -110,12 +132,34 @@ func mergeFiles(inPaths []string, outPath string, isFexit bool) error {
 		}
 	}
 
+	// Exit-mode interface mapping is by NAME, not index: each shard may
+	// have lazily added unknown-verdict interfaces in its own encounter
+	// order, so the same index can mean different verdicts across shards.
+	// ifaceMap caches source-index → output-id per reader.
+	ifaceMap := make([]map[int]int, len(readers))
+	outIface := func(rIdx, srcIdx int) int {
+		if !cfg.IsFexit {
+			return 0
+		}
+		m := ifaceMap[rIdx]
+		if m == nil {
+			m = map[int]int{}
+			ifaceMap[rIdx] = m
+		}
+		if id, ok := m[srcIdx]; ok {
+			return id
+		}
+		id := 0
+		if intf, ierr := readers[rIdx].Interface(srcIdx); ierr == nil {
+			id = out.ifaceIDByName(intf.Name)
+		}
+		m[srcIdx] = id
+		return id
+	}
+
 	for h.Len() > 0 {
 		it := heap.Pop(h).(mergeItem)
-		// Action carries the source interface index so fexit merges keep
-		// the per-action interface (xdp:PASS/DROP/...); output.Writer maps
-		// action->interface identically to how the shards were written.
-		if err := out.Write(capture.Packet{Timestamp: it.ts, Data: it.data, Action: it.action}); err != nil {
+		if err := out.writePacketIface(it.ts, it.data, outIface(it.idx, it.srcIface)); err != nil {
 			return fmt.Errorf("writing merged packet: %w", err)
 		}
 		if next, ok := nextItem(readers[it.idx], it.idx, &bufs[it.idx]); ok {
@@ -150,5 +194,5 @@ func nextItem(r *pcapgo.NgReader, idx int, buf *[]byte) (mergeItem, bool) {
 		*buf = (*buf)[:len(data)]
 	}
 	copy(*buf, data)
-	return mergeItem{ts: ci.Timestamp, data: *buf, action: uint32(ci.InterfaceIndex), idx: idx}, true
+	return mergeItem{ts: ci.Timestamp, data: *buf, srcIface: ci.InterfaceIndex, idx: idx}, true
 }

--- a/internal/output/merge.go
+++ b/internal/output/merge.go
@@ -99,9 +99,11 @@ func mergeFiles(inPaths []string, outPath string, cfg Config) error {
 		}
 	}
 	if cfg.IsFexit && len(cfg.Actions) == 0 {
-		// Nothing usable to seed from (all inputs missing/unreadable):
-		// behave like the readerless merge below and produce no output.
-		return nil
+		// Nothing usable to seed from (all inputs missing/unreadable),
+		// so there are no packets either: drop to the plain single-
+		// interface layout and still produce a valid empty pcap-ng at
+		// outPath, matching the non-fexit readerless behavior.
+		cfg = Config{LinkType: cfg.LinkType}
 	}
 
 	// Write to a temp file and rename on success so a mid-merge failure

--- a/internal/output/merge_test.go
+++ b/internal/output/merge_test.go
@@ -149,19 +149,32 @@ func TestMergeShardFilesFexitPreservesAction(t *testing.T) {
 }
 
 // TestMergeShardFilesEmpty verifies merging when no shard files exist
-// produces a valid (empty) pcap-ng rather than erroring.
+// produces a valid (empty) pcap-ng rather than erroring — in both the
+// entry layout and the exit layout, where the per-verdict interfaces
+// would normally be seeded from the (absent) shard files.
 func TestMergeShardFilesEmpty(t *testing.T) {
-	dir := t.TempDir()
-	base := filepath.Join(dir, "none.pcap")
-	if err := MergeShardFiles(base, 4, Config{}); err != nil {
-		t.Fatalf("MergeShardFiles with no shards: %v", err)
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"entry", Config{}},
+		{"fexit no seed", Config{IsFexit: true}},
 	}
-	f, err := os.Open(base)
-	if err != nil {
-		t.Fatalf("open merged: %v", err)
-	}
-	defer func() { _ = f.Close() }()
-	if _, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions); err != nil {
-		t.Fatalf("merged empty file is not valid pcap-ng: %v", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			base := filepath.Join(dir, "none.pcap")
+			if err := MergeShardFiles(base, 4, c.cfg); err != nil {
+				t.Fatalf("MergeShardFiles with no shards: %v", err)
+			}
+			f, err := os.Open(base)
+			if err != nil {
+				t.Fatalf("open merged: %v", err)
+			}
+			defer func() { _ = f.Close() }()
+			if _, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions); err != nil {
+				t.Fatalf("merged empty file is not valid pcap-ng: %v", err)
+			}
+		})
 	}
 }

--- a/internal/output/merge_test.go
+++ b/internal/output/merge_test.go
@@ -11,11 +11,28 @@ import (
 	"github.com/takehaya/bpf-ninja/internal/capture"
 )
 
+// xdpExitConfig is the exit-mode layout the XDP hook produces
+// (mirrors internal/hook without importing it — output stays below hook
+// in the layering, tests included).
+func xdpExitConfig() Config {
+	return Config{
+		IsFexit:  true,
+		HookName: "xdp",
+		Actions: []ActionName{
+			{Value: 0, Name: "xdp:ABORTED"},
+			{Value: 1, Name: "xdp:DROP"},
+			{Value: 2, Name: "xdp:PASS"},
+			{Value: 3, Name: "xdp:TX"},
+			{Value: 4, Name: "xdp:REDIRECT"},
+		},
+	}
+}
+
 // writeShardFile writes a single-shard pcap-ng with packets at the given
 // second offsets from base, each a minimal 20-byte frame.
 func writeShardFile(t *testing.T, path string, base time.Time, secs []int) {
 	t.Helper()
-	w, err := NewWriter(path, false)
+	w, err := NewWriter(path, Config{})
 	if err != nil {
 		t.Fatalf("NewWriter(%s): %v", path, err)
 	}
@@ -44,7 +61,7 @@ func TestMergeShardFiles(t *testing.T) {
 	writeShardFile(t, base+".cpu2", epoch, []int{2, 4})
 
 	// numShards=3 so .cpu1 (nonexistent) exercises the skip path.
-	if err := MergeShardFiles(base, 3, false); err != nil {
+	if err := MergeShardFiles(base, 3, Config{}); err != nil {
 		t.Fatalf("MergeShardFiles: %v", err)
 	}
 
@@ -88,7 +105,7 @@ func TestMergeShardFilesFexitPreservesAction(t *testing.T) {
 	epoch := time.Unix(1700000000, 0).UTC()
 
 	// shard 0: two packets with actions 2 (PASS) and 1 (DROP).
-	w0, err := NewWriter(base+".cpu0", true) // isFexit
+	w0, err := NewWriter(base+".cpu0", xdpExitConfig())
 	if err != nil {
 		t.Fatalf("NewWriter fexit: %v", err)
 	}
@@ -102,7 +119,7 @@ func TestMergeShardFilesFexitPreservesAction(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	if err := MergeShardFiles(base, 1, true); err != nil {
+	if err := MergeShardFiles(base, 1, xdpExitConfig()); err != nil {
 		t.Fatalf("MergeShardFiles fexit: %v", err)
 	}
 
@@ -136,7 +153,7 @@ func TestMergeShardFilesFexitPreservesAction(t *testing.T) {
 func TestMergeShardFilesEmpty(t *testing.T) {
 	dir := t.TempDir()
 	base := filepath.Join(dir, "none.pcap")
-	if err := MergeShardFiles(base, 4, false); err != nil {
+	if err := MergeShardFiles(base, 4, Config{}); err != nil {
 		t.Fatalf("MergeShardFiles with no shards: %v", err)
 	}
 	f, err := os.Open(base)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -34,13 +34,53 @@ const fileBufSize = 1 << 20
 // than per-packet write costs we removed.
 const stdoutFlushInterval = time.Millisecond
 
+// ActionName pairs a verdict value with its pcap-ng interface name
+// (e.g. "xdp:DROP"). Signed verdicts are stored as their uint32 bit
+// pattern. The hook registry (internal/hook) is the source of these;
+// output only renders them.
+type ActionName struct {
+	Value uint32
+	Name  string
+}
+
+// Config selects the writer layout for one capture run. The zero value
+// is the fentry Ethernet layout.
+type Config struct {
+	// IsFexit selects the exit-mode layout: one pcap-ng interface per
+	// verdict (Actions) so Wireshark shows the verdict as the
+	// interface name.
+	IsFexit bool
+
+	// LinkType is the pcap-ng link type; the zero value means Ethernet.
+	LinkType layers.LinkType
+
+	// Actions lists the exit-mode verdict interfaces in creation order.
+	// Required when IsFexit is set (the shard merge fills it from its
+	// input files when left empty).
+	Actions []ActionName
+
+	// HookName prefixes lazily-added interfaces for verdicts outside
+	// Actions ("<HookName>:UNKNOWN(<n>)").
+	HookName string
+}
+
+// linkTypeOrDefault resolves the zero value to Ethernet.
+func (c Config) linkTypeOrDefault() layers.LinkType {
+	if c.LinkType == 0 {
+		return layers.LinkTypeEthernet
+	}
+	return c.LinkType
+}
+
 // Writer writes captured packets in pcapng format.
 type Writer struct {
+	cfg        Config
 	pcapWriter *pcapgo.NgWriter
 	fastWriter *FastNgWriter // default for non-fexit; env BPF_NINJA_FAST_PCAPNG=0 falls back to pcapWriter
 	bufWriter  *bufio.Writer // non-nil only when wrapping an *os.File
 	file       *os.File      // non-nil only when writing to a file (not stdout)
 	actionToID map[uint32]int
+	nameToID   map[string]int // exit mode: interface name → id, for the shard merge
 
 	flushStop chan struct{}
 	flushDone chan struct{}
@@ -48,11 +88,14 @@ type Writer struct {
 }
 
 // NewWriter creates a pcapng writer. If path is empty, writes to stdout.
-// In exit mode, creates one pcapng interface per XDP action so that
-// Wireshark displays the action as the interface name.
-func NewWriter(path string, isFexit bool) (*Writer, error) {
+// In exit mode (cfg.IsFexit), creates one pcapng interface per verdict in
+// cfg.Actions so that Wireshark displays the verdict as the interface name.
+func NewWriter(path string, cfg Config) (*Writer, error) {
+	if cfg.IsFexit && len(cfg.Actions) == 0 {
+		return nil, fmt.Errorf("exit-mode writer needs at least one action interface (Config.Actions)")
+	}
 	var dest io.Writer
-	w := &Writer{}
+	w := &Writer{cfg: cfg}
 
 	if path != "" {
 		f, err := os.Create(path)
@@ -72,13 +115,13 @@ func NewWriter(path string, isFexit bool) (*Writer, error) {
 	// pcap-ng (see TestFastNgWriterEquivalent). Exit mode still needs the
 	// gopacket writer for its per-action multi-interface layout. Set
 	// BPF_NINJA_FAST_PCAPNG=0 to force the gopacket writer.
-	useFast := os.Getenv("BPF_NINJA_FAST_PCAPNG") != "0" && !isFexit
+	useFast := os.Getenv("BPF_NINJA_FAST_PCAPNG") != "0" && !cfg.IsFexit
 	if useFast {
-		w.fastWriter, err = NewFastNgWriter(dest)
-	} else if isFexit {
+		w.fastWriter, err = NewFastNgWriter(dest, cfg.linkTypeOrDefault())
+	} else if cfg.IsFexit {
 		err = w.initExitMode(dest)
 	} else {
-		w.pcapWriter, err = pcapgo.NewNgWriter(dest, layers.LinkTypeEthernet)
+		w.pcapWriter, err = pcapgo.NewNgWriter(dest, cfg.linkTypeOrDefault())
 	}
 	if err != nil {
 		if w.file != nil {
@@ -96,48 +139,79 @@ func NewWriter(path string, isFexit bool) (*Writer, error) {
 	return w, nil
 }
 
-// initExitMode creates one pcapng interface per XDP action (ABORTED..REDIRECT).
+// initExitMode creates one pcapng interface per verdict in cfg.Actions
+// (e.g. xdp:ABORTED..xdp:REDIRECT, or tc:TC_ACT_UNSPEC..tc:TC_ACT_TRAP).
 func (w *Writer) initExitMode(dest io.Writer) error {
-	actions := []struct {
-		id   uint32
-		name string
-	}{
-		{0, "xdp:ABORTED"},
-		{1, "xdp:DROP"},
-		{2, "xdp:PASS"},
-		{3, "xdp:TX"},
-		{4, "xdp:REDIRECT"},
-	}
-
-	first := pcapgo.NgInterface{
-		Name:                actions[0].name,
-		LinkType:            layers.LinkTypeEthernet,
-		TimestampResolution: 9,
-		SnapLength:          0,
-		OS:                  runtime.GOOS,
-	}
-	pw, err := pcapgo.NewNgWriterInterface(dest, first, pcapgo.DefaultNgWriterOptions)
+	actions := w.cfg.Actions
+	pw, err := pcapgo.NewNgWriterInterface(dest, w.ngInterface(actions[0].Name), pcapgo.DefaultNgWriterOptions)
 	if err != nil {
 		return err
 	}
 
-	w.actionToID = map[uint32]int{actions[0].id: 0}
+	w.actionToID = map[uint32]int{actions[0].Value: 0}
+	w.nameToID = map[string]int{actions[0].Name: 0}
 	for _, a := range actions[1:] {
-		id, err := pw.AddInterface(pcapgo.NgInterface{
-			Name:                a.name,
-			LinkType:            layers.LinkTypeEthernet,
-			TimestampResolution: 9,
-			SnapLength:          0,
-			OS:                  runtime.GOOS,
-		})
+		id, err := pw.AddInterface(w.ngInterface(a.Name))
 		if err != nil {
 			return err
 		}
-		w.actionToID[a.id] = id
+		w.actionToID[a.Value] = id
+		w.nameToID[a.Name] = id
 	}
 
 	w.pcapWriter = pw
 	return nil
+}
+
+// ngInterface builds the pcap-ng interface block shared by every
+// exit-mode interface: same link type, only the name differs.
+func (w *Writer) ngInterface(name string) pcapgo.NgInterface {
+	return pcapgo.NgInterface{
+		Name:                name,
+		LinkType:            w.cfg.linkTypeOrDefault(),
+		TimestampResolution: 9,
+		SnapLength:          0,
+		OS:                  runtime.GOOS,
+	}
+}
+
+// ifaceIDForAction maps a verdict value to its pcap-ng interface id,
+// lazily adding a "<hook>:UNKNOWN(<n>)" interface for verdicts outside
+// the configured set (e.g. cgroup-skb egress congestion codes) so no
+// packet is ever silently attributed to the wrong verdict. Falls back
+// to interface 0 if the lazy add fails (a malformed file would be worse).
+func (w *Writer) ifaceIDForAction(action uint32) int {
+	if id, ok := w.actionToID[action]; ok {
+		return id
+	}
+	prefix := w.cfg.HookName
+	if prefix == "" {
+		prefix = "verdict"
+	}
+	name := fmt.Sprintf("%s:UNKNOWN(%d)", prefix, int32(action))
+	id, err := w.pcapWriter.AddInterface(w.ngInterface(name))
+	if err != nil {
+		id = 0
+	}
+	w.actionToID[action] = id
+	w.nameToID[name] = id
+	return id
+}
+
+// ifaceIDByName maps an interface name to this writer's interface id,
+// lazily adding it when unseen. Used by the shard merge, which matches
+// interfaces by name rather than by verdict value (shards may carry
+// lazily-added unknown-verdict interfaces at arbitrary indices).
+func (w *Writer) ifaceIDByName(name string) int {
+	if id, ok := w.nameToID[name]; ok {
+		return id
+	}
+	id, err := w.pcapWriter.AddInterface(w.ngInterface(name))
+	if err != nil {
+		id = 0
+	}
+	w.nameToID[name] = id
+	return id
 }
 
 // Write outputs a captured packet.
@@ -157,11 +231,30 @@ func (w *Writer) Write(pkt capture.Packet) error {
 		Length:        len(pkt.Data),
 	}
 	if w.actionToID != nil {
-		if id, ok := w.actionToID[pkt.Action]; ok {
-			ci.InterfaceIndex = id
-		}
+		ci.InterfaceIndex = w.ifaceIDForAction(pkt.Action)
 	}
 	if err := w.pcapWriter.WritePacket(ci, pkt.Data); err != nil {
+		return fmt.Errorf("writing pcap packet: %w", err)
+	}
+	return nil
+}
+
+// writePacketIface writes one packet to an explicit pcap-ng interface
+// id, bypassing the verdict→interface mapping. Only the shard merge
+// uses this (it resolves interfaces by name via ifaceIDByName).
+func (w *Writer) writePacketIface(ts time.Time, data []byte, ifaceID int) error {
+	w.flushMu.Lock()
+	defer w.flushMu.Unlock()
+	if w.fastWriter != nil {
+		return w.fastWriter.WritePacket(ts, data)
+	}
+	ci := gopacket.CaptureInfo{
+		Timestamp:      ts,
+		CaptureLength:  len(data),
+		Length:         len(data),
+		InterfaceIndex: ifaceID,
+	}
+	if err := w.pcapWriter.WritePacket(ci, data); err != nil {
 		return fmt.Errorf("writing pcap packet: %w", err)
 	}
 	return nil
@@ -193,9 +286,7 @@ func (w *Writer) WriteBatch(pkts []capture.Packet) error {
 		ci.Length = len(p.Data)
 		ci.InterfaceIndex = 0
 		if w.actionToID != nil {
-			if id, ok := w.actionToID[p.Action]; ok {
-				ci.InterfaceIndex = id
-			}
+			ci.InterfaceIndex = w.ifaceIDForAction(p.Action)
 		}
 		if err := w.pcapWriter.WritePacket(ci, p.Data); err != nil {
 			return fmt.Errorf("writing pcap packet: %w", err)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 
 	"github.com/takehaya/bpf-ninja/internal/capture"
@@ -19,13 +18,13 @@ var testPktData = []byte{
 	0xde, 0xad, 0xbe, 0xef, // payload
 }
 
-func newTestWriter(buf *bytes.Buffer, mode string) *Writer {
-	w := &Writer{}
+func newTestWriter(buf *bytes.Buffer, cfg Config) *Writer {
+	w := &Writer{cfg: cfg}
 	var err error
-	if mode == "exit" {
+	if cfg.IsFexit {
 		err = w.initExitMode(buf)
 	} else {
-		w.pcapWriter, err = pcapgo.NewNgWriter(buf, layers.LinkTypeEthernet)
+		w.pcapWriter, err = pcapgo.NewNgWriter(buf, cfg.linkTypeOrDefault())
 	}
 	if err != nil {
 		panic(err)
@@ -35,7 +34,7 @@ func newTestWriter(buf *bytes.Buffer, mode string) *Writer {
 
 func TestExitModeInterfaces(t *testing.T) {
 	var buf bytes.Buffer
-	w := newTestWriter(&buf, "exit")
+	w := newTestWriter(&buf, xdpExitConfig())
 
 	// Write one packet per action (0-4)
 	for action := uint32(0); action <= 4; action++ {
@@ -90,7 +89,7 @@ func TestExitModeInterfaces(t *testing.T) {
 
 func TestExitModeUnknownAction(t *testing.T) {
 	var buf bytes.Buffer
-	w := newTestWriter(&buf, "exit")
+	w := newTestWriter(&buf, xdpExitConfig())
 
 	pkt := capture.Packet{
 		Timestamp: time.Unix(1000000, 0),
@@ -110,18 +109,94 @@ func TestExitModeUnknownAction(t *testing.T) {
 		t.Fatalf("NewNgReader: %v", err)
 	}
 
+	// An out-of-table verdict gets its own lazily-added interface rather
+	// than being silently attributed to interface 0.
 	_, ci, err := r.ReadPacketData()
 	if err != nil {
 		t.Fatalf("ReadPacketData: %v", err)
 	}
-	if ci.InterfaceIndex != 0 {
-		t.Errorf("InterfaceIndex = %d, want 0 (fallback)", ci.InterfaceIndex)
+	if ci.InterfaceIndex != 5 {
+		t.Errorf("InterfaceIndex = %d, want 5 (lazy unknown-verdict interface)", ci.InterfaceIndex)
+	}
+	iface, err := r.Interface(5)
+	if err != nil {
+		t.Fatalf("Interface(5): %v", err)
+	}
+	if iface.Name != "xdp:UNKNOWN(99)" {
+		t.Errorf("Interface(5).Name = %q, want %q", iface.Name, "xdp:UNKNOWN(99)")
+	}
+}
+
+// tcExitConfig mirrors the tc hook's exit layout, including the signed
+// TC_ACT_UNSPEC verdict stored as its uint32 bit pattern.
+func tcExitConfig() Config {
+	return Config{
+		IsFexit:  true,
+		HookName: "tc",
+		Actions: []ActionName{
+			{Value: uint32(0xffffffff), Name: "tc:TC_ACT_UNSPEC"},
+			{Value: 0, Name: "tc:TC_ACT_OK"},
+			{Value: 1, Name: "tc:TC_ACT_RECLASSIFY"},
+			{Value: 2, Name: "tc:TC_ACT_SHOT"},
+		},
+	}
+}
+
+// TestExitModeTCInterfaces pins the fix for the old behavior where
+// tc-exit reused the hardcoded xdp interface table: TC_ACT_UNSPEC (-1)
+// must land on its own named interface, and TC_ACT_OK must not be
+// labeled as an XDP action.
+func TestExitModeTCInterfaces(t *testing.T) {
+	var buf bytes.Buffer
+	w := newTestWriter(&buf, tcExitConfig())
+
+	for _, action := range []uint32{0xffffffff /* -1 */, 0, 2} {
+		pkt := capture.Packet{
+			Timestamp: time.Unix(1000000, 0),
+			Data:      testPktData,
+			Action:    action,
+			Mode:      1,
+		}
+		if err := w.Write(pkt); err != nil {
+			t.Fatalf("Write action=%d: %v", int32(action), err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	r, err := pcapgo.NewNgReader(&buf, pcapgo.DefaultNgReaderOptions)
+	if err != nil {
+		t.Fatalf("NewNgReader: %v", err)
+	}
+	wantIfaces := []int{0 /* UNSPEC */, 1 /* OK */, 3 /* SHOT */}
+	for i, want := range wantIfaces {
+		_, ci, err := r.ReadPacketData()
+		if err != nil {
+			t.Fatalf("ReadPacketData %d: %v", i, err)
+		}
+		if ci.InterfaceIndex != want {
+			t.Errorf("packet %d: InterfaceIndex = %d, want %d", i, ci.InterfaceIndex, want)
+		}
+	}
+	wantNames := []string{"tc:TC_ACT_UNSPEC", "tc:TC_ACT_OK", "tc:TC_ACT_RECLASSIFY", "tc:TC_ACT_SHOT"}
+	if r.NInterfaces() != len(wantNames) {
+		t.Fatalf("NInterfaces = %d, want %d", r.NInterfaces(), len(wantNames))
+	}
+	for i, name := range wantNames {
+		iface, err := r.Interface(i)
+		if err != nil {
+			t.Fatalf("Interface(%d): %v", i, err)
+		}
+		if iface.Name != name {
+			t.Errorf("Interface(%d).Name = %q, want %q", i, iface.Name, name)
+		}
 	}
 }
 
 func TestEntryModeUnchanged(t *testing.T) {
 	var buf bytes.Buffer
-	w := newTestWriter(&buf, "entry")
+	w := newTestWriter(&buf, Config{})
 
 	if w.actionToID != nil {
 		t.Fatal("actionToID should be nil in entry mode")

--- a/internal/output/split_bench_test.go
+++ b/internal/output/split_bench_test.go
@@ -44,7 +44,7 @@ func benchPackets(n int, tag func(i int) uint32) []capture.Packet {
 
 func nullWriter(b *testing.B) *Writer {
 	b.Helper()
-	w, err := NewWriter(os.DevNull, false)
+	w, err := NewWriter(os.DevNull, Config{})
 	if err != nil {
 		b.Fatalf("NewWriter: %v", err)
 	}

--- a/internal/output/splitpath.go
+++ b/internal/output/splitpath.go
@@ -46,7 +46,7 @@ func TagMergedPath(base string, tag uint32) string {
 // correctly. It works whether the capture shut down cleanly (in-process) or
 // was killed and is being reconciled later by the `merge` subcommand. The
 // shard files are left in place.
-func MergeTagShards(basePath string, isFexit bool) error {
+func MergeTagShards(basePath string, cfg Config) error {
 	ext := filepath.Ext(basePath)
 	dir := filepath.Dir(basePath)
 	baseStem := strings.TrimSuffix(filepath.Base(basePath), ext)
@@ -78,7 +78,7 @@ func MergeTagShards(basePath string, isFexit bool) error {
 	for _, tag := range tags {
 		files := tagFiles[tag]
 		slices.Sort(files) // deterministic input order across shards
-		if err := mergeFiles(files, TagMergedPath(basePath, tag), isFexit); err != nil {
+		if err := mergeFiles(files, TagMergedPath(basePath, tag), cfg); err != nil {
 			return fmt.Errorf("merging tag %d: %w", tag, err)
 		}
 	}

--- a/internal/output/splitpath_test.go
+++ b/internal/output/splitpath_test.go
@@ -48,7 +48,7 @@ func TestMergeTagShards(t *testing.T) {
 	// A plain (non-tag) shard file must not be swept into any tag.
 	writeShardFile(t, base+".cpu0", epoch, []int{9})
 
-	if err := MergeTagShards(base, false); err != nil {
+	if err := MergeTagShards(base, Config{}); err != nil {
 		t.Fatalf("MergeTagShards: %v", err)
 	}
 
@@ -96,7 +96,7 @@ func TestMergeTagShardsGlobMeta(t *testing.T) {
 
 	writeShardFile(t, TagShardPath(base, 0, 3), epoch, []int{1, 2})
 
-	if err := MergeTagShards(base, false); err != nil {
+	if err := MergeTagShards(base, Config{}); err != nil {
 		t.Fatalf("MergeTagShards: %v", err)
 	}
 	merged := TagMergedPath(base, 3)

--- a/internal/program/dump.go
+++ b/internal/program/dump.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/takehaya/bpf-ninja/internal/filter"
+	"github.com/takehaya/bpf-ninja/internal/hook"
 	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
 )
 
@@ -33,20 +34,29 @@ const (
 // scope picks between filter-only ("filter") and the wrapped program
 // ("full"). mode picks the wrapper shape: "entry"/"exit" for the
 // fentry/fexit tracing wrapper, "xdp" for the XDP-native wrapper.
-// Mode is ignored when scope == DumpScopeFilter except that it
-// drives the Capabilities passed to the kunai compile (exit enables
-// the action atom).
-func DumpAsm(w io.Writer, scope DumpScope, expr string, useDSL bool, mode string) error {
+// kind names the hook whose capabilities and prologue to render —
+// there is no target program to auto-detect it from here, so the CLI
+// passes --dump-hook (default xdp). Mode is ignored when scope ==
+// DumpScopeFilter except that it drives the Capabilities passed to
+// the kunai compile (exit enables the action atom).
+func DumpAsm(w io.Writer, scope DumpScope, expr string, useDSL bool, mode string, kind hook.Kind) error {
 	if expr == "" {
 		return fmt.Errorf("--dump-asm requires a filter expression")
 	}
 
+	h, ok := hook.ByName(kind)
+	if !ok {
+		return fmt.Errorf("--dump-hook: unknown hook %q", kind)
+	}
 	isFexit := mode == "exit"
 	isXDPNative := mode == "xdp"
+	if isXDPNative && h.Kind != hook.KindXDP {
+		return fmt.Errorf("--mode xdp is XDP-native; it cannot combine with --dump-hook %s", kind)
+	}
 
 	// xdp-native uses zero Capabilities (no observed action atom),
 	// same shape as fentry — compileFilter(_, _, false) covers both.
-	out, err := compileFilter(expr, useDSL, isFexit, ebpf.XDP)
+	out, err := compileFilter(expr, useDSL, isFexit, h.ProgTypes[0])
 	if err != nil {
 		return err
 	}
@@ -56,7 +66,7 @@ func DumpAsm(w io.Writer, scope DumpScope, expr string, useDSL bool, mode string
 	case DumpScopeFilter, "":
 		renderFilter(&buf, out, useDSL, mode)
 	case DumpScopeFull:
-		if err := renderFull(&buf, out, mode, isFexit, isXDPNative); err != nil {
+		if err := renderFull(&buf, out, mode, isFexit, isXDPNative, h.ProgTypes[0]); err != nil {
 			return err
 		}
 	default:
@@ -97,7 +107,7 @@ func renderFilter(buf *strings.Builder, out codegen.Output, useDSL bool, mode st
 	}
 }
 
-func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, isXDPNative bool) error {
+func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, isXDPNative bool, progType ebpf.ProgramType) error {
 	var (
 		insns asm.Instructions
 		shape string
@@ -107,7 +117,7 @@ func renderFull(buf *strings.Builder, out codegen.Output, mode string, isFexit, 
 		shape = "XDP-native program"
 	} else {
 		var err error
-		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, ebpf.XDP, nil, nil)
+		insns, err = buildTracingInsns(out, filter.TargetFilters{}, 0, 0, isFexit, progType, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/program/dump_test.go
+++ b/internal/program/dump_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/takehaya/bpf-ninja/internal/hook"
 )
 
 // TestDumpAsmFilter checks that DumpAsm in filter scope renders the
@@ -56,7 +58,7 @@ func TestDumpAsmFilter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := DumpAsm(&buf, DumpScopeFilter, tc.expr, tc.useDSL, tc.mode); err != nil {
+			if err := DumpAsm(&buf, DumpScopeFilter, tc.expr, tc.useDSL, tc.mode, hook.KindXDP); err != nil {
 				t.Fatalf("DumpAsm: %v", err)
 			}
 			got := buf.String()
@@ -74,7 +76,7 @@ func TestDumpAsmFilter(t *testing.T) {
 // the bpf_xdp_output epilogue, with map FDs left at 0.
 func TestDumpAsmFull(t *testing.T) {
 	var buf bytes.Buffer
-	if err := DumpAsm(&buf, DumpScopeFull, "eth/ipv4/tcp", true, "exit"); err != nil {
+	if err := DumpAsm(&buf, DumpScopeFull, "eth/ipv4/tcp", true, "exit", hook.KindXDP); err != nil {
 		t.Fatalf("DumpAsm full: %v", err)
 	}
 	got := buf.String()
@@ -100,7 +102,7 @@ func TestDumpAsmFull(t *testing.T) {
 // FnRingbufSubmit epilogue) instead of the tracing wrapper.
 func TestDumpAsmFullXDP(t *testing.T) {
 	var buf bytes.Buffer
-	if err := DumpAsm(&buf, DumpScopeFull, "tcp port 443", false, "xdp"); err != nil {
+	if err := DumpAsm(&buf, DumpScopeFull, "tcp port 443", false, "xdp", hook.KindXDP); err != nil {
 		t.Fatalf("DumpAsm full xdp: %v", err)
 	}
 	got := buf.String()
@@ -162,7 +164,7 @@ func TestDumpAsmErrors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := DumpAsm(&buf, tc.scope, tc.expr, tc.useDSL, "entry")
+			err := DumpAsm(&buf, tc.scope, tc.expr, tc.useDSL, "entry", hook.KindXDP)
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
 			}

--- a/internal/program/filterset_corpus_test.go
+++ b/internal/program/filterset_corpus_test.go
@@ -161,6 +161,7 @@ func TestFilterCorpusCompiles(t *testing.T) {
 	}{
 		{"XDP", ebpf.XDP},
 		{"tc", ebpf.SchedCLS},
+		{"cgroup-skb", ebpf.CGroupSKB},
 	}
 
 	for _, c := range VerifierCorpus {

--- a/internal/program/filterset_test.go
+++ b/internal/program/filterset_test.go
@@ -83,6 +83,7 @@ func TestFilterSetCompiles(t *testing.T) {
 	}{
 		{"XDP", ebpf.XDP},
 		{"tc", ebpf.SchedCLS},
+		{"cgroup-skb", ebpf.CGroupSKB},
 	}
 
 	for _, fs := range FilterSet {

--- a/internal/program/load_dsl_test.go
+++ b/internal/program/load_dsl_test.go
@@ -258,3 +258,37 @@ func TestBpfEntryWithDSLFilterTC(t *testing.T) {
 func TestBpfExitWithDSLFilterTC(t *testing.T) {
 	runFilterMatrix(t, loadDummyTC(t), tcFuncName, dslTCExitExprs, true, true)
 }
+
+// dslCgroupSKBEntryExprs is the cgroup-skb fentry-side DSL matrix.
+// The packet window starts at the network header (no Ethernet framing),
+// so chains root at ipv4/ipv6. The context-loading path is the same
+// skb prologue as tc (runtime BTF-resolved sk_buff offsets); the
+// matrix pins the L3-rooted chain shapes on it, including a
+// parser-machine (bpf_loop) path and an option-walk predicate.
+var dslCgroupSKBEntryExprs = []string{
+	"ipv4/tcp",
+	"ipv4/udp",
+	"ipv6/tcp",
+	"ipv4/tcp[dport==443]",
+	"ipv4/tcp where tcp.dport == 443",
+	"ipv4/tcp capture headers+64",
+	"ipv4/udp/gtp/ipv4/tcp",
+	"ipv6/srv6/tcp",
+	"ipv4/tcp where tcp.options.MSS.value == 1460",
+}
+
+// dslCgroupSKBExitExprs covers the cgroup-skb fexit-side action atoms
+// (SK_DROP=0 / SK_PASS=1).
+var dslCgroupSKBExitExprs = []string{
+	"ipv4/tcp",
+	"ipv4/tcp where action == SK_DROP",
+	"ipv4/tcp where action == SK_PASS or action == SK_DROP",
+}
+
+func TestBpfEntryWithDSLFilterCgroupSKB(t *testing.T) {
+	runFilterMatrix(t, loadDummyCgroupSKB(t), cgroupSKBFuncName, dslCgroupSKBEntryExprs, false, true)
+}
+
+func TestBpfExitWithDSLFilterCgroupSKB(t *testing.T) {
+	runFilterMatrix(t, loadDummyCgroupSKB(t), cgroupSKBFuncName, dslCgroupSKBExitExprs, true, true)
+}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -133,13 +133,20 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 		return nil, fmt.Errorf("filters length %d does not match %d targets", len(filters), len(targets))
 	}
 	progType := targets[0].Type
-	for _, t := range targets[1:] {
-		if t.Type != progType {
-			return nil, fmt.Errorf("mixed target program types (%s and %s)", progType, t.Type)
-		}
-	}
-	if _, ok := hook.ByProgramType(progType); !ok {
+	h, ok := hook.ByProgramType(progType)
+	if !ok {
 		return nil, hook.UnsupportedTypeError(progType)
+	}
+	// Same-hook, not same-progType: SchedCLS and SchedACT targets share
+	// the tc hook (identical prologue and capabilities) and may mix.
+	for _, t := range targets[1:] {
+		th, tok := hook.ByProgramType(t.Type)
+		if !tok {
+			return nil, hook.UnsupportedTypeError(t.Type)
+		}
+		if th != h {
+			return nil, fmt.Errorf("mixed target hooks (%s and %s); attach one bpf-ninja per hook", h.Kind, th.Kind)
+		}
 	}
 
 	// DSL `field in @set` extracts packet fields into a host key buffer;
@@ -283,7 +290,7 @@ func compileFilter(expr string, useDSL, isFexit bool, progType ebpf.ProgramType)
 func compileFilterWithSlots(expr string, useDSL, isFexit bool, progType ebpf.ProgramType, slots *pktSetSlots) (codegen.Output, error) {
 	// Empty expression == capture everything: no filter to compile,
 	// callers wrap the zero Output with their own prologue/epilogue.
-	// Centralised here so attach modes (entry/exit/xdp/tc-*) don't
+	// Centralised here so attach modes (entry/exit/xdp) don't
 	// each reimplement the empty-filter policy and drift apart.
 	if expr == "" {
 		return codegen.Output{}, nil

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -15,11 +15,10 @@ import (
 	"github.com/google/gopacket/pcap"
 	"github.com/takehaya/bpf-ninja/internal/attach"
 	"github.com/takehaya/bpf-ninja/internal/filter"
+	"github.com/takehaya/bpf-ninja/internal/hook"
 	"github.com/takehaya/bpf-ninja/internal/setmap"
 	"github.com/takehaya/bpf-ninja/pkg/kunai"
 	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
-	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
-	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
 	"golang.org/x/net/bpf"
 )
 
@@ -139,8 +138,8 @@ func loadMulti(targets []attach.Target, filterExpr string, filters []filter.Targ
 			return nil, fmt.Errorf("mixed target program types (%s and %s)", progType, t.Type)
 		}
 	}
-	if progType != ebpf.XDP && progType != ebpf.SchedCLS && progType != ebpf.SchedACT {
-		return nil, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", progType)
+	if _, ok := hook.ByProgramType(progType); !ok {
+		return nil, hook.UnsupportedTypeError(progType)
 	}
 
 	// DSL `field in @set` extracts packet fields into a host key buffer;
@@ -221,8 +220,8 @@ func validateTracingTarget(targetProg *ebpf.Program) (ebpf.ProgramType, error) {
 		return 0, fmt.Errorf("reading target program info: %w", err)
 	}
 	pt := info.Type
-	if pt != ebpf.XDP && pt != ebpf.SchedCLS && pt != ebpf.SchedACT {
-		return 0, fmt.Errorf("target program type %s is not supported (need XDP, SchedCLS, or SchedACT)", pt)
+	if _, ok := hook.ByProgramType(pt); !ok {
+		return 0, hook.UnsupportedTypeError(pt)
 	}
 	return pt, nil
 }
@@ -294,23 +293,16 @@ func compileFilterWithSlots(expr string, useDSL, isFexit bool, progType ebpf.Pro
 		// or TC verdict, ABI shared); fentry has no action value yet,
 		// so action atoms are disabled. The bpf-ninja host wrapper saves
 		// the tracing args ptr at stack[-48] in either case, which is
-		// exactly the ABI both FexitFetcher implementations expect.
-		// The tc host also carries VlanInMetadata in both entry and
-		// fexit caps, because the kernel strips the outer VLAN tag into
-		// skb metadata before either attach point runs.
+		// exactly the ABI every FexitFetcher implementation expects.
+		// Per-hook capability details (action vocab, VLAN layout) live
+		// in the internal/hook registry entries.
 		var caps codegen.Capabilities
-		switch progType {
-		case ebpf.SchedCLS, ebpf.SchedACT:
+		if h, ok := hook.ByProgramType(progType); ok {
 			if isFexit {
-				caps = tchost.FexitCapabilities()
+				caps = h.FexitCaps()
 			} else {
-				caps = tchost.EntryCapabilities()
+				caps = h.EntryCaps()
 			}
-		case ebpf.XDP:
-			if isFexit {
-				caps = xdphost.FexitCapabilities()
-			}
-			// XDP entry keeps zero caps: VLAN is in-band at XDP.
 		}
 		// DSL `field in @set`: hand kunai the host slot resolver so it can
 		// extract packet fields into the host key buffer (host does the map
@@ -506,41 +498,15 @@ func buildTracingInsns(filterOut codegen.Output, tf filter.TargetFilters, events
 // loadPacketPointers は tracing args の args[0] (= host-specific
 // packet ctx) から packet 先頭・末尾・長さを host 別に読み出す。
 // trusted pointer (BTF 型付き) として trampoline が保証してくれる。
+// host 別の実体は internal/hook の各 PacketPrologue。
 //
 // 終了時: R6=ctx, R7=data, R8=data_end, R9=pkt_len, stack[-48]=args
 func loadPacketPointers(progType ebpf.ProgramType) (asm.Instructions, error) {
-	prelude := asm.Instructions{
-		asm.StoreMem(asm.R10, -48, asm.R1, asm.DWord),
-		asm.LoadMem(asm.R6, asm.R1, 0, asm.DWord),
+	h, ok := hook.ByProgramType(progType)
+	if !ok {
+		return nil, hook.UnsupportedTypeError(progType)
 	}
-	switch progType {
-	case ebpf.XDP:
-		// args[0] は kernel struct xdp_buff *。 data @ +0, data_end
-		// @ +8 (どちらも 8B pointer、 ABI 安定なので hardcode)。
-		return append(prelude,
-			asm.LoadMem(asm.R7, asm.R6, 0, asm.DWord),
-			asm.LoadMem(asm.R8, asm.R6, 8, asm.DWord),
-			asm.Mov.Reg(asm.R9, asm.R8),
-			asm.Sub.Reg(asm.R9, asm.R7),
-		), nil
-	case ebpf.SchedCLS, ebpf.SchedACT:
-		// args[0] は kernel struct sk_buff * (BPF が見せる
-		// __sk_buff のラッパ rewrite は fexit context で発火しない)。
-		// member offset は kernel version で動くので runtime BTF
-		// resolve が必要。 data_end は sk_buff にないので
-		// data + len で計算。
-		dataOff, lenOff, err := skBuffPacketOffsets()
-		if err != nil {
-			return nil, fmt.Errorf("resolving struct sk_buff offsets via BTF: %w", err)
-		}
-		return append(prelude,
-			asm.LoadMem(asm.R7, asm.R6, int16(dataOff), asm.DWord), // R7 = skb->data
-			asm.LoadMem(asm.R9, asm.R6, int16(lenOff), asm.Word),   // R9 = skb->len
-			asm.Mov.Reg(asm.R8, asm.R7),
-			asm.Add.Reg(asm.R8, asm.R9), // R8 = data + len
-		), nil
-	}
-	return nil, fmt.Errorf("unsupported program type %s", progType)
+	return h.PacketPrologue()
 }
 
 // ObserverPrefetch, when true, makes runFilter always probe_read the

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -324,7 +324,14 @@ func compileFilterWithSlots(expr string, useDSL, isFexit bool, progType ebpf.Pro
 		}
 		return out, nil
 	}
-	rawInsns, err := pcap.CompileBPFFilter(layers.LinkTypeEthernet, 65535, expr)
+	// Compile against the hook's link type: on an L3-start hook
+	// (LinkTypeRaw) libpcap then resolves `ip` / `tcp port 80` at the
+	// right offsets and rejects L2 atoms like `ether host` on its own.
+	linkType := layers.LinkTypeEthernet
+	if h, ok := hook.ByProgramType(progType); ok {
+		linkType = h.LinkType
+	}
+	rawInsns, err := pcap.CompileBPFFilter(linkType, 65535, expr)
 	if err != nil {
 		return codegen.Output{}, fmt.Errorf("compiling filter %q: %w", expr, err)
 	}

--- a/internal/program/testutil_test.go
+++ b/internal/program/testutil_test.go
@@ -101,6 +101,39 @@ func loadDummyTC(t testing.TB) *ebpf.Program {
 	return objs.Prog
 }
 
+const cgroupSKBFuncName = "cgroup_skb_pass_test"
+
+const cgroupSKBPassSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+SEC("cgroup_skb/ingress")
+int cgroup_skb_pass_test(struct __sk_buff *skb) { return 1; }
+char _license[] SEC("license") = "GPL";
+`
+
+// loadDummyCgroupSKB compiles and loads a minimal cgroup-skb program
+// with BTF — peer of loadDummyTC. Returns SK_PASS (1); the observer
+// attaches as fentry/fexit, so no cgroup attachment is needed for the
+// verifier-load matrix.
+func loadDummyCgroupSKB(t testing.TB) *ebpf.Program {
+	t.Helper()
+	testutil.SkipIfNotRoot(t)
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, cgroupSKBPassSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"cgroup_skb_pass_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading cgroup-skb program: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Prog.Close() })
+	return objs.Prog
+}
+
 // loadDummyXDP compiles and loads a minimal XDP_PASS program with BTF.
 func loadDummyXDP(t testing.TB) *ebpf.Program {
 	t.Helper()

--- a/pkg/kunai/codegen/caps.go
+++ b/pkg/kunai/codegen/caps.go
@@ -102,6 +102,17 @@ type HostLayout struct {
 	// layer at compile time rather than silently parsing the wrong
 	// bytes. Reading the tag from skb metadata is future work.
 	VlanInMetadata bool
+
+	// PacketStartsAtL3 declares that the host presents packet bytes
+	// starting at the network (L3) header — there is no Ethernet
+	// header in the window the filter parses. This is the case at
+	// cgroup-skb attach points, where skb->data points at the IP
+	// header. Codegen offsets are chain-root-relative either way; the
+	// flag only flips the resolver's chain-root advice, warning on an
+	// `eth/...` root (which would misparse) instead of on a non-eth
+	// root. The zero value (false) keeps the L2 expectation — correct
+	// for XDP and tc.
+	PacketStartsAtL3 bool
 }
 
 // ActionFetcher loads the current action value into a register so the

--- a/pkg/kunai/compile.go
+++ b/pkg/kunai/compile.go
@@ -57,7 +57,9 @@ func CompileWithVocab(expr string, v map[string]*vocab.ProtocolSpec, caps codege
 	if err != nil {
 		return codegen.Output{}, err
 	}
-	prog, err := resolve.Resolve(f, v, caps.Lang.Action)
+	prog, err := resolve.ResolveWithOptions(f, v, caps.Lang.Action, resolve.Options{
+		PacketStartsAtL3: caps.Host.PacketStartsAtL3,
+	})
 	if err != nil {
 		return codegen.Output{}, err
 	}

--- a/pkg/kunai/compile_test.go
+++ b/pkg/kunai/compile_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 
 	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
+	cgskbhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/cgroupskb"
 	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
 )
 
@@ -1248,3 +1249,60 @@ func TestVlanInMetadataRejectsVlanLayers(t *testing.T) {
 
 // Cache correctness for dslvocab.Bundled is covered in its own
 // package; Compile merely threads the call through.
+
+// TestCompileCgroupSKBHost pins the cgroup-skb host adapter surface:
+// SK_* action atoms resolve at fexit, and the L3-start layout flips
+// the chain-root advice (warn on eth roots, stay silent on ipv4/ipv6).
+func TestCompileCgroupSKBHost(t *testing.T) {
+	t.Run("action atoms", func(t *testing.T) {
+		out, err := Compile("ipv4/tcp where action == SK_DROP", cgskbhost.FexitCapabilities())
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if len(out.Main) == 0 {
+			t.Fatal("empty instructions")
+		}
+	})
+	t.Run("action atoms rejected at entry", func(t *testing.T) {
+		_, err := Compile("ipv4/tcp where action == SK_DROP", cgskbhost.EntryCapabilities())
+		if err == nil {
+			t.Fatal("expected entry-caps compile to reject the action atom")
+		}
+	})
+	t.Run("ipv4 root has no warning", func(t *testing.T) {
+		out, err := Compile("ipv4/tcp", cgskbhost.EntryCapabilities())
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if len(out.Warnings) != 0 {
+			t.Fatalf("unexpected warnings: %v", out.Warnings)
+		}
+	})
+	t.Run("eth root warns", func(t *testing.T) {
+		out, err := Compile("eth/ipv4/tcp", cgskbhost.EntryCapabilities())
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		if len(out.Warnings) != 1 || !strings.Contains(out.Warnings[0], "no Ethernet header") {
+			t.Fatalf("expected the L3-start eth-root warning, got %v", out.Warnings)
+		}
+	})
+	t.Run("vlan layer rejected", func(t *testing.T) {
+		_, err := Compile("eth/vlan/ipv4/tcp", cgskbhost.EntryCapabilities())
+		if !errors.Is(err, codegen.ErrNotImplemented) {
+			t.Fatalf("expected ErrNotImplemented for vlan on cgroup-skb, got %v", err)
+		}
+	})
+}
+
+// TestCompileL2HostRootWarningUnchanged pins the default polarity: with
+// the zero Capabilities a non-eth root still draws the L2 advice.
+func TestCompileL2HostRootWarningUnchanged(t *testing.T) {
+	out, err := Compile("ipv4/tcp", codegen.Capabilities{})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(out.Warnings) != 1 || !strings.Contains(out.Warnings[0], "is not 'eth'") {
+		t.Fatalf("expected the L2 non-eth-root warning, got %v", out.Warnings)
+	}
+}

--- a/pkg/kunai/host/cgroupskb/cgroupskb.go
+++ b/pkg/kunai/host/cgroupskb/cgroupskb.go
@@ -1,0 +1,80 @@
+// Package cgroupskb provides kunai host adapters for hosts attached as
+// fentry / fexit on a cgroup-skb (BPF_PROG_TYPE_CGROUP_SKB) program.
+// Importing this package is the canonical way to enable cgroup-skb
+// specific DSL atoms (currently `where action == SK_DROP/SK_PASS`) in a
+// kunai filter; the kunai core itself holds no cgroup knowledge — see
+// pkg/kunai/codegen/caps.go for the Capabilities contract this package
+// conforms to.
+//
+// A cgroup-skb program sees skb->data pointing at the NETWORK (L3)
+// header — there is no Ethernet header in the packet window — so both
+// capability sets carry HostLayout.PacketStartsAtL3 and DSL chains
+// should root at ipv4/ipv6.
+package cgroupskb
+
+import (
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
+)
+
+// Actions matches the cgroup-skb filter verdicts (kernel SK_DROP /
+// SK_PASS, include/linux/bpf.h). Egress programs may additionally
+// return 2 or 3 (drop with congestion notification); those have no
+// uapi symbol, so they are intentionally absent here and surface as
+// unknown verdicts downstream.
+var Actions = map[string]int32{
+	"SK_DROP": 0,
+	"SK_PASS": 1,
+}
+
+// FexitFetcher returns a codegen.ActionFetcher for hosts attached as
+// fexit on a cgroup-skb program. It assumes the host wrapper saved the
+// BPF tracing args pointer at stack[-48] at program entry and that
+// args[1] is the verdict slot — the same tracing-args ABI as the xdp
+// and tc fetchers, met by the bpf-ninja host program (see
+// internal/program/program.go).
+//
+// Different host wrappers with a different stack ABI should provide
+// their own fetcher rather than reusing this one.
+func FexitFetcher() codegen.ActionFetcher { return fexitFetcher{} }
+
+type fexitFetcher struct{}
+
+func (fexitFetcher) EmitFetch(dst asm.Register) asm.Instructions {
+	return asm.Instructions{
+		asm.LoadMem(dst, asm.R10, -48, asm.DWord),
+		asm.LoadMem(dst, dst, 8, asm.Word),
+	}
+}
+
+// FexitCapabilities returns the standard codegen.Capabilities for hosts
+// attached as fexit on a cgroup-skb program. The Lang group carries the
+// SK_* action atoms (parser label reservation is derived from
+// Lang.Action by kunai.Compile). Host sets PacketStartsAtL3 (no
+// Ethernet header in the window) and VlanInMetadata (with no L2 header
+// there are no in-band VLAN tags to parse either).
+func FexitCapabilities() codegen.Capabilities {
+	return codegen.Capabilities{
+		Lang: codegen.LangCaps{
+			Action:        Actions,
+			ActionFetcher: FexitFetcher(),
+		},
+		Host: hostLayout(),
+	}
+}
+
+// EntryCapabilities returns the codegen.Capabilities for hosts attached
+// as fentry on a cgroup-skb program. fentry has no verdict yet, so the
+// Lang group stays empty; the packet-layout facts hold at both attach
+// points.
+func EntryCapabilities() codegen.Capabilities {
+	return codegen.Capabilities{Host: hostLayout()}
+}
+
+func hostLayout() codegen.HostLayout {
+	return codegen.HostLayout{
+		VlanInMetadata:   true,
+		PacketStartsAtL3: true,
+	}
+}

--- a/pkg/kunai/resolve/resolve.go
+++ b/pkg/kunai/resolve/resolve.go
@@ -45,7 +45,7 @@ type Options struct {
 	// PacketStartsAtL3 mirrors codegen.HostLayout.PacketStartsAtL3:
 	// the host's packet window begins at the network header, so the
 	// chain-root advice flips — an `eth/...` root would misparse and
-	// draws the warning, while ipv4/ipv6 roots are the expected entry.
+	// draw the warning, while ipv4/ipv6 roots are the expected entry.
 	PacketStartsAtL3 bool
 }
 

--- a/pkg/kunai/resolve/resolve.go
+++ b/pkg/kunai/resolve/resolve.go
@@ -166,10 +166,10 @@ func addChainRootWarning(p *ir.Program, f *ast.Filter, opts Options) {
 			return
 		case "eth":
 			p.Warnings = append(p.Warnings,
-				"chain root is 'eth' but this attach point has no Ethernet header in the packet bytes; start the chain at 'ipv4/...' or 'ipv6/...'. Use --dump-asm filter to inspect the generated BPF.")
+				"chain root is 'eth' but this attach point has no Ethernet header in the packet bytes; start the chain at 'ipv4/...' or 'ipv6/...'. Use --dump-asm filter (with --dump-hook matching the attach point) to inspect the generated BPF.")
 		default:
 			p.Warnings = append(p.Warnings, fmt.Sprintf(
-				"chain root %q is not 'ipv4' or 'ipv6'; this attach point's packet bytes start at the network header. Use --dump-asm filter to inspect the generated BPF.",
+				"chain root %q is not 'ipv4' or 'ipv6'; this attach point's packet bytes start at the network header. Use --dump-asm filter (with --dump-hook matching the attach point) to inspect the generated BPF.",
 				root.ProtoName,
 			))
 		}

--- a/pkg/kunai/resolve/resolve.go
+++ b/pkg/kunai/resolve/resolve.go
@@ -41,6 +41,12 @@ type Options struct {
 	// default so the existing typed-OK / silent-wrap behaviour stays
 	// the contract for unaware callers.
 	StrictArithLint bool
+
+	// PacketStartsAtL3 mirrors codegen.HostLayout.PacketStartsAtL3:
+	// the host's packet window begins at the network header, so the
+	// chain-root advice flips — an `eth/...` root would misparse and
+	// draws the warning, while ipv4/ipv6 roots are the expected entry.
+	PacketStartsAtL3 bool
 }
 
 // Resolve walks an AST filter, binds every symbolic reference to the
@@ -129,19 +135,21 @@ func (r *resolver) resolveFilter(f *ast.Filter) (*ir.Program, error) {
 		LabelTable: r.labels,
 		Pos:        f.Pos,
 	}
-	addChainRootWarning(p, f)
+	addChainRootWarning(p, f, r.opts)
 	markRuntimeOffsetLayers(p)
 	return p, nil
 }
 
 // addChainRootWarning appends a notice to p.Warnings when the chain's
-// first protocol is not "eth". Standard L2 packet entry expects an
-// `eth/...` root, so a non-eth root is almost always a typo (e.g.
-// `tcp` instead of `eth/ipv4/tcp`) — but it can be legitimate for
-// callers that attach to a non-Ethernet datapath, so it stays a
+// root protocol does not match the host's packet entry point. For the
+// default L2 layout a non-eth root is almost always a typo (e.g. `tcp`
+// instead of `eth/ipv4/tcp`); for an L3-start host (PacketStartsAtL3)
+// the polarity flips — an `eth/...` root would misparse because the
+// window has no Ethernet header, and ipv4/ipv6 are the expected roots.
+// Either way it can be legitimate for unusual datapaths, so it stays a
 // warning rather than an error. Skips alternation-group roots and
 // empty chains; both are handled by other passes.
-func addChainRootWarning(p *ir.Program, f *ast.Filter) {
+func addChainRootWarning(p *ir.Program, f *ast.Filter, opts Options) {
 	if p == nil || len(f.Layers) == 0 {
 		return
 	}
@@ -149,7 +157,25 @@ func addChainRootWarning(p *ir.Program, f *ast.Filter) {
 	if root.Kind == ast.LayerAltGroup {
 		return
 	}
-	if root.ProtoName == "" || root.ProtoName == "eth" {
+	if root.ProtoName == "" {
+		return
+	}
+	if opts.PacketStartsAtL3 {
+		switch root.ProtoName {
+		case "ipv4", "ipv6":
+			return
+		case "eth":
+			p.Warnings = append(p.Warnings,
+				"chain root is 'eth' but this attach point has no Ethernet header in the packet bytes; start the chain at 'ipv4/...' or 'ipv6/...'. Use --dump-asm filter to inspect the generated BPF.")
+		default:
+			p.Warnings = append(p.Warnings, fmt.Sprintf(
+				"chain root %q is not 'ipv4' or 'ipv6'; this attach point's packet bytes start at the network header. Use --dump-asm filter to inspect the generated BPF.",
+				root.ProtoName,
+			))
+		}
+		return
+	}
+	if root.ProtoName == "eth" {
 		return
 	}
 	p.Warnings = append(p.Warnings, fmt.Sprintf(

--- a/scripts/test/cgroup_pass.c
+++ b/scripts/test/cgroup_pass.c
@@ -1,0 +1,13 @@
+// Minimal cgroup-skb filter used by integration tests as the
+// fentry/fexit attach target for `bpf-ninja --cgroup / -p` on a
+// BPF_PROG_TYPE_CGROUP_SKB program. Returns SK_PASS (1)
+// unconditionally — bpf-ninja attaches as a tracing observer, the
+// dummy never gates real traffic.
+#include <linux/bpf.h>
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+
+SEC("cgroup_skb/ingress")
+int cgroup_pass(struct __sk_buff *skb) { return 1; }
+
+char _license[] SEC("license") = "GPL";

--- a/scripts/test/cleanup.sh
+++ b/scripts/test/cleanup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 sudo ip link delete veth0 2>/dev/null || true
 sudo ip netns delete xdptest 2>/dev/null || true
+sudo bpftool cgroup detach /sys/fs/cgroup/bpfninja-test ingress pinned /sys/fs/bpf/bpfninja_cgroup_pass 2>/dev/null || true
+sudo rm -f /sys/fs/bpf/bpfninja_cgroup_pass 2>/dev/null || true
+sudo rmdir /sys/fs/cgroup/bpfninja-test 2>/dev/null || true
 echo "cleanup done"

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -230,6 +230,93 @@ test_dsl_tc_exit_action() {
     run_count_test 3 --mode exit -p "$pid_t" -c 3 "eth/ipv4/icmp where action == TC_ACT_OK"
 }
 
+# --- cgroup-skb hook (setup.sh attaches cgroup_pass to a scratch
+# cgroup; skipped when cgroup2 / bpffs / bpftool support is missing).
+# The observed traffic is ping over loopback run from INSIDE the
+# scratch cgroup: cgroup-skb fires per-socket, so the pinging process
+# itself must be a cgroup member (veth traffic from the netns would
+# not traverse it). Packet bytes start at the IP header (no Ethernet),
+# hence the ipv4-rooted DSL and the LINKTYPE_RAW assertion.
+CGROUP_TEST_DIR=/sys/fs/cgroup/bpfninja-test
+
+require_cgroup_target() {
+    require_bpftool || return 1
+    if ! bpftool cgroup show "$CGROUP_TEST_DIR" 2>/dev/null | grep -q cgroup_pass; then
+        echo "skipping: cgroup_pass not attached (no cgroup2/bpffs?)" >&2
+        return 1
+    fi
+}
+
+cgroup_prog_id() {
+    bpftool cgroup show "$CGROUP_TEST_DIR" 2>/dev/null | awk '/cgroup_pass/ {print $1; exit}'
+}
+
+# send_cgroup_packets <count>: ping loopback from a shell placed into
+# the scratch cgroup, generating ICMP through the cgroup-skb hook.
+send_cgroup_packets() {
+    sudo sh -c "echo \$\$ > '$CGROUP_TEST_DIR/cgroup.procs'; ping -c $1 -W 1 127.0.0.1" >/dev/null 2>&1 || true
+}
+
+# run_cgroup_count_test <expected-min> <bpf-ninja-args...>
+run_cgroup_count_test() {
+    local expected=$1
+    shift
+    local err=$(mktemp)
+    timeout 10 "$BINARY" "$@" > /dev/null 2>"$err" &
+    local pid=$!
+    sleep 2
+    send_cgroup_packets 5
+    wait $pid 2>/dev/null || true
+    local count=$(capture_count "$err")
+    rm -f "$err"
+    [[ "$count" -ge "$expected" ]]
+}
+
+test_dsl_cgroup_entry() {
+    require_cgroup_target || return 1
+    local pid_c=$(cgroup_prog_id)
+    [[ -n "$pid_c" ]] || { echo "cgroup_pass program id not found" >&2; return 1; }
+    run_cgroup_count_test 3 -p "$pid_c" -c 3 "ipv4/icmp"
+}
+
+test_dsl_cgroup_exit_action() {
+    require_cgroup_target || return 1
+    local pid_c=$(cgroup_prog_id)
+    [[ -n "$pid_c" ]] || { echo "cgroup_pass program id not found" >&2; return 1; }
+    run_cgroup_count_test 3 --mode exit -p "$pid_c" -c 3 "ipv4/icmp where action == SK_PASS"
+}
+
+test_cgroup_path_selector() {
+    require_cgroup_target || return 1
+    run_cgroup_count_test 3 --cgroup "$CGROUP_TEST_DIR" -c 3 "ipv4/icmp"
+}
+
+# Asserts the pcap-ng written for a cgroup-skb capture carries
+# LINKTYPE_RAW (101), not Ethernet — packets start at the IP header.
+test_cgroup_pcap_linktype_raw() {
+    require_cgroup_target || return 1
+    local pid_c=$(cgroup_prog_id)
+    [[ -n "$pid_c" ]] || { echo "cgroup_pass program id not found" >&2; return 1; }
+    local pcap=$(mktemp --suffix=.pcap)
+    local err=$(mktemp)
+    timeout 10 "$BINARY" -w "$pcap" -p "$pid_c" -c 3 "ipv4/icmp" 2>"$err" &
+    local pid=$!
+    sleep 2
+    send_cgroup_packets 5
+    wait $pid 2>/dev/null || true
+    local ok=1
+    for shard in "$pcap".cpu*; do
+        [[ -e "$shard" ]] || continue
+        # tcpdump names DLT 101 "RAW (Raw IP)" in its -r banner (stderr).
+        if tcpdump -r "$shard" -c 1 2>&1 | grep -qi "RAW"; then
+            ok=0
+            break
+        fi
+    done
+    rm -f "$pcap" "$pcap".cpu* "$err"
+    [[ $ok -eq 0 ]]
+}
+
 # Exercises --func subfunction attach + --arg-filter argument reading against
 # xdp_argcap, whose capture_point(ctx, pkt_len) uses KEEP_ARGS to keep pkt_len
 # on the ABI. A real ping frame (~98 B) satisfies pkt_len>=60 (match) but none
@@ -377,6 +464,10 @@ run_test "dsl_capture_headers"     test_dsl_capture_headers
 run_test "dsl_exit_action"         test_dsl_exit_action
 run_test "dsl_tc_entry"            test_dsl_tc_entry
 run_test "dsl_tc_exit_action"      test_dsl_tc_exit_action
+run_test "dsl_cgroup_entry"        test_dsl_cgroup_entry
+run_test "dsl_cgroup_exit_action"  test_dsl_cgroup_exit_action
+run_test "cgroup_path_selector"    test_cgroup_path_selector
+run_test "cgroup_pcap_linktype"    test_cgroup_pcap_linktype_raw
 run_test "argfilter"               test_argfilter
 run_test "argfilter_set"           test_argfilter_set
 run_test "graceful_shutdown"       test_graceful_shutdown

--- a/scripts/test/run_tests.sh
+++ b/scripts/test/run_tests.sh
@@ -213,21 +213,21 @@ tc_prog_id() {
     bpftool prog show name tc_pass 2>/dev/null | head -1 | awk '{print $1}' | tr -d ':'
 }
 
-# Dummy tc clsact classifier returns TC_ACT_OK (=0); --mode tc-entry
-# and --mode tc-exit attach as fentry/fexit observers and capture
+# Dummy tc clsact classifier returns TC_ACT_OK (=0); --mode entry
+# and --mode exit attach as fentry/fexit observers and capture
 # packets on each ingress event.
 test_dsl_tc_entry() {
     require_bpftool || return 1
     local pid_t=$(tc_prog_id)
     [[ -n "$pid_t" ]] || { echo "tc_pass program not found" >&2; return 1; }
-    run_count_test 3 --mode tc-entry -p "$pid_t" -c 3 "eth/ipv4/icmp"
+    run_count_test 3 --mode entry -p "$pid_t" -c 3 "eth/ipv4/icmp"
 }
 
 test_dsl_tc_exit_action() {
     require_bpftool || return 1
     local pid_t=$(tc_prog_id)
     [[ -n "$pid_t" ]] || { echo "tc_pass program not found" >&2; return 1; }
-    run_count_test 3 --mode tc-exit -p "$pid_t" -c 3 "eth/ipv4/icmp where action == TC_ACT_OK"
+    run_count_test 3 --mode exit -p "$pid_t" -c 3 "eth/ipv4/icmp where action == TC_ACT_OK"
 }
 
 # Exercises --func subfunction attach + --arg-filter argument reading against

--- a/scripts/test/setup.sh
+++ b/scripts/test/setup.sh
@@ -3,9 +3,10 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Compile dummy XDP and TC classifier programs.
+# Compile dummy XDP, TC classifier, and cgroup-skb programs.
 clang -O2 -g -target bpf -c "$SCRIPT_DIR/xdp_pass.c" -o "$SCRIPT_DIR/xdp_pass.o"
 clang -O2 -g -target bpf -c "$SCRIPT_DIR/tc_pass.c" -o "$SCRIPT_DIR/tc_pass.o"
+clang -O2 -g -target bpf -c "$SCRIPT_DIR/cgroup_pass.c" -o "$SCRIPT_DIR/cgroup_pass.o"
 
 # Create netns + veth pair
 sudo ip netns add xdptest
@@ -26,6 +27,21 @@ sudo ip link set dev veth0 xdp obj "$SCRIPT_DIR/xdp_pass.o" sec xdp
 sudo tc qdisc add dev veth0 clsact
 sudo tc filter add dev veth0 ingress bpf direct-action obj "$SCRIPT_DIR/tc_pass.o" sec classifier
 
+# Attach the dummy cgroup-skb filter to a scratch cgroup v2 directory so
+# the cgroup-skb hook has a fentry/fexit target. Best-effort: skipped
+# cleanly when cgroup2 / bpffs / bpftool support is missing (the
+# corresponding tests then SKIP rather than FAIL).
+CGROUP_TEST_DIR=/sys/fs/cgroup/bpfninja-test
+CGROUP_PIN=/sys/fs/bpf/bpfninja_cgroup_pass
+if mountpoint -q /sys/fs/cgroup && mountpoint -q /sys/fs/bpf; then
+    sudo mkdir -p "$CGROUP_TEST_DIR" 2>/dev/null || true
+    sudo rm -f "$CGROUP_PIN" 2>/dev/null || true
+    if sudo bpftool prog load "$SCRIPT_DIR/cgroup_pass.o" "$CGROUP_PIN" 2>/dev/null; then
+        sudo bpftool cgroup attach "$CGROUP_TEST_DIR" ingress pinned "$CGROUP_PIN" 2>/dev/null || true
+    fi
+fi
+
 echo "setup complete: veth0 (10.0.0.1 + XDP + tc clsact) <-> xdptest:veth1 (10.0.0.2)"
 bpftool prog show name xdp_pass 2>/dev/null || true
 bpftool prog show name tc_pass 2>/dev/null || true
+bpftool cgroup show "$CGROUP_TEST_DIR" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Generalizes the attach-target machinery from hardcoded XDP/tc branches into a hook registry, and adds cgroup-skb (BPF_PROG_TYPE_CGROUP_SKB) as the third supported hook. One commit per phase:

1. **refactor(hook)** — new `internal/hook` registry (`Hook` descriptor: program-type set, packet prologue, kunai host caps, verdict table, link type). Collapses the four scattered `ebpf.ProgramType` switches; no behavior change.
2. **fix(output)** — exit-mode pcap-ng interfaces come from the hook's verdict table instead of a hardcoded XDP list. Fixes tc-exit mislabeling (`TC_ACT_UNSPEC` = -1 and 5..8 previously fell outside the xdp 0-4 table). Out-of-table verdicts get a lazily added `<hook>:UNKNOWN(n)` interface, and the shard merge maps interfaces by name rather than index.
3. **feat(cli)** — the hook kind is auto-detected from the target program type; `--mode` is reduced to `entry | exit | xdp` with `tc-entry`/`tc-exit` kept as deprecated aliases. `--dump-asm` gains `--dump-hook` (offline compiles have no program to detect from).
4. **feat(hook)** — cgroup-skb support: `pkg/kunai/host/cgroupskb` (SK_DROP/SK_PASS atoms, shared fexit fetcher ABI), `codegen.HostLayout.PacketStartsAtL3` (packet window starts at the network header; chain-root advice flips to ipv4/ipv6), LINKTYPE_RAW through the tcpdump-filter compile and pcap-ng output. The skb prologue is shared with tc.
5. **feat(cli)** — `--cgroup <cgroup v2 path>` enumerates attached cgroup-skb programs via BPF_PROG_QUERY (ingress + egress), plus integration tests and docs.

## Testing

- `make test` / `make lint` green; new unit tests for the registry↔host-vocab consistency, tc/unknown-verdict interface labeling, and the L3-start warning polarity
- `make test-bpf` green on the host kernel (7.2.0-rc2), incl. new cgroup-skb entry/exit verifier matrices; vimto spot-checks green on 6.1 / 6.6 / 7.0
- `make test-integration` 22/22 PASS, incl. 4 new cgroup-skb cases (fentry capture, fexit `where action == SK_PASS` — runtime confirmation of the args[1] verdict ABI, `--cgroup` selector, LINKTYPE_RAW assertion)