### PR TITLE
test(dsltest): pin any() conjunction semantics at the packet level

### DIFF
--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -1158,6 +1158,32 @@ func TestTCPOptionLookupSACKBlockAllQuantifier(t *testing.T) {
 	r.MustReject(t, Build(t, zero), "block 0.right = 0 fails the all() predicate")
 }
 
+// TestTCPOptionLookupSACKBlockAnyConjunction pins the same-element
+// semantics of a boolean body inside any(): any(P and Q) holds only
+// when a single block satisfies both predicates. The discriminating
+// packet has one block satisfying only P and another satisfying only
+// Q; it must reject under any(P and Q) and match under the
+// two-quantifier form any(P) and any(Q), which reads across blocks.
+func TestTCPOptionLookupSACKBlockAnyConjunction(t *testing.T) {
+	same := New(t, "eth/ipv4/tcp where any(tcp.options.SACK.blocks.left == 0x100 and tcp.options.SACK.blocks.right == 0x200)")
+
+	split := Defaults()
+	split.TCPOptions = []layers.TCPOption{
+		sackOption([2]uint32{0x100, 0x999}, [2]uint32{0x888, 0x200}),
+	}
+	same.MustReject(t, Build(t, split), "P and Q hold only on different blocks: any(P and Q) must not match")
+
+	joint := Defaults()
+	joint.TCPOptions = []layers.TCPOption{
+		sackOption([2]uint32{0x100, 0x200}),
+	}
+	same.MustMatch(t, Build(t, joint), "one block satisfies both predicates")
+
+	two := New(t, "eth/ipv4/tcp where any(tcp.options.SACK.blocks.left == 0x100) and any(tcp.options.SACK.blocks.right == 0x200)")
+	two.MustMatch(t, Build(t, split), "separate quantifiers may be satisfied by different blocks")
+	two.MustMatch(t, Build(t, joint), "a single block satisfying both also satisfies both quantifiers")
+}
+
 // TestTCPOptionsMaxDataOffset drives data_offset=15 (maximum),
 // lifting the TCP header to 60 B = 40 B of options. Mirror of the
 // IPv4 max-IHL stress test for the TCP HDRLEN path.


### PR DESCRIPTION
Adds a packet-level test fixing the element-wise semantics of a boolean body inside `any()`, which the eBPF Workshop 2026 camera-ready now states explicitly in Sec 3.2:

- `any(P and Q)` holds only when a **single** SACK block satisfies both predicates. The discriminating packet, whose blocks satisfy the two predicates only separately, must reject.
- The two-quantifier form `any(P) and any(Q)` expresses the other reading and must match that same packet.

Until now the stacked `any(...) and any(...)` form was only pinned at the instruction-count level (TestM2Envelope) and no test exercised `and` inside a quantifier body at all, so the semantics were asserted but not behaviorally fixed.