### PR TITLE
docs(protocols): correct the stale s-bit comment in mpls.p4

### DIFF
--- a/pkg/kunai/protocols/mpls.p4
+++ b/pkg/kunai/protocols/mpls.p4
@@ -1,7 +1,8 @@
 // MPLS label entry (RFC 3032). Each entry is 32 bits and a stack is
 // represented in the DSL via repetition (e.g. `mpls+`). The s bit
-// marks the bottom of the stack, but the resolver/codegen rely on
-// quantifier counts rather than peeking at s for now.
+// marks the bottom of the stack; it is declared below as
+// MPLS_CHAIN_END_S, and chain codegen masks it out of each consumed
+// label to end the walk early (see encodeChainEndField).
 header mpls_h {
     bit<20> label;
     bit<3>  tc;


### PR DESCRIPTION
The mpls.p4 header comment still claimed "the resolver/codegen rely on quantifier counts rather than peeking at s for now". That predates the chain-end mechanism and contradicts the rest of the file: `MPLS_CHAIN_END_S` is declared a few lines below, and chain codegen (`encodeChainEndField`) masks the s bit out of each consumed label to terminate the walk early, as pinned by `TestGenBpfLoopMplsEmitsChainEndCheck`, the D05/D06 corpus cases, and `TestMplsChainBoundaries`.

Comment-only change. Flagged while preparing the eBPF Workshop 2026 camera-ready, which references this file's sentinel declaration.