### PR TITLE
docs(kunai): refresh READMEs against current code and prose style

### DIFF
--- a/pkg/kunai/README.ja.md
+++ b/pkg/kunai/README.ja.md
@@ -2,15 +2,15 @@
 
 # kunai
 
-`kunai` は一行のパケットフィルタ DSL を target-portable な eBPF 命令列にコンパイルする小さな Go ライブラリ。プロトコルヘッダの記述には P4 風の vocabulary ファイルを使う。
+`kunai` は、一行のパケットフィルタ DSL を target-portable な eBPF 命令列にコンパイルする小さな Go ライブラリです。プロトコルヘッダの記述には P4 風の vocabulary ファイルを使います。
 
-[bpf-ninja](https://github.com/takehaya/bpf-ninja) から切り出されたもので、その default DSL filter モードの実体だが、パッケージ自体は self-contained。public surface に XDP 固有の依存はなく、連続したパケットバイト列のウィンドウを露出するホストであれば tracing / fentry / fexit / tc / userspace BPF など何にでも組み込める。
+[bpf-ninja](https://github.com/takehaya/bpf-ninja) から切り出されたライブラリで、bpf-ninja のデフォルト DSL フィルタモードの実体です。ただしパッケージ自体は自己完結しており、public surface に XDP 固有の依存はありません。連続したパケットバイト列のウィンドウを見せられるホストであれば、tracing、fentry/fexit、tc、userspace BPF のどれにでも組み込めます。
 
-> **ステータス**: pre-1.0。public API は小さい (`Compile` 1 つ) が、surface が安定するまでは変動しうる。1.0 までは minor バージョン間で breaking change があり得る。
+> ステータスは pre-1.0 です。public API は `Compile` 1 つと小さいものの、surface が安定するまでは変わる可能性があります。1.0 までは minor バージョン間で breaking change が起こり得ます。
 
 ## 何をするか
 
-次のような式を:
+次のような式を `kunai.Compile` に渡します。
 
 ```text
 eth/ipv4/udp/vxlan/eth/ipv4/tcp[dport==443]
@@ -21,13 +21,14 @@ eth/ipv6/srv6/tcp where any(srv6.segments.addr == fc00::1)              # aux he
 eth/ipv4/tcp where tcp.options.MSS.value == 1460                        # TCP option lookup
 ```
 
-`kunai.Compile` に渡すと以下が返る:
+すると以下が返ります。
 
-- main eBPF 命令列 (`R2` に `1` (accept) または `0` (reject) を書き込む)
-- オプションの bpf2bpf callback subprogram (`+`/`*`/`{n,m}` の chain quantifier が `bpf_loop` に lower される際に内部で使う)
-- `CaptureInfo` (各パケットのうち何バイトを perf-buffer / ring-buffer 出力に渡すべきかを示す)
+- main eBPF 命令列。`R2` に accept なら `1`、reject なら `0` を書き込みます。
+- bpf2bpf callback subprogram。chain quantifier の `+`/`*`/`{n,m}` が `bpf_loop` に lower されるときに内部で使われます。無ければ空です。
+- `CaptureInfo`。各パケットのうち何バイトを perf-buffer / ring-buffer 出力に渡すべきかを示します。
+- `Extractions` と `Warnings`。前者は `field in @set` 述語のためにフィルタが stack slot へ書き出したフィールドの一覧、後者は非致命的なコンパイル時の注意です。
 
-出力は **target-agnostic**: 2 レジスタ間の連続したパケットウィンドウと少数のワーキングレジスタを仮定するだけ。呼び出し側がホスト固有の prologue (パケットポインタのロード、scratch buffer への copy など) で wrap する。正確な ABI は [`codegen/codegen.go`](./codegen/codegen.go) のパッケージ doc を参照。
+出力は target-agnostic です。2 つのレジスタで挟まれた連続パケットウィンドウと、少数のワーキングレジスタだけを仮定します。呼び出し側は、パケットポインタのロードや scratch buffer へのコピーといったホスト固有の prologue で出力を包みます。正確な ABI は [`codegen/codegen.go`](./codegen/codegen.go) のパッケージ doc を参照してください。
 
 ## インストール
 
@@ -35,7 +36,7 @@ eth/ipv4/tcp where tcp.options.MSS.value == 1460                        # TCP op
 go get github.com/takehaya/bpf-ninja/pkg/kunai
 ```
 
-Go 1.25+ が必要。
+Go 1.25 以上が必要です。
 
 ## クイックスタート
 
@@ -76,32 +77,55 @@ func main() {
 }
 ```
 
-完全な動作例 (XDP fentry/fexit attach + perf-event capture) は親リポジトリ bpf-ninja の [`internal/program/program.go`](https://github.com/takehaya/bpf-ninja/blob/main/internal/program/program.go) を参照。
+XDP fentry/fexit attach と perf-event capture を含む完全な動作例は、親リポジトリ bpf-ninja の [`internal/program/program.go`](https://github.com/takehaya/bpf-ninja/blob/main/internal/program/program.go) を参照してください。
 
-## アーキテクチャ (一段落)
+## アーキテクチャ
 
-パイプラインは `expr → AST → IR → asm.Instructions`。AST は手書きの再帰下降パーサで構築、IR は vocab 解決済みの layer instance を保持し、すべてのフィールド参照を具体的な `*vocab.ProtocolSpec` にバインドする。codegen は IR を [cilium/ebpf](https://github.com/cilium/ebpf) の `asm.Instructions` に lower し、各 layer 境界で verifier-safe な bounds check を emit する。可変長 quantifier (`+`, `*`, `{n,m>4}`) と parser machine の self-loop は `bpf_loop` ヘルパ呼び出しを bpf2bpf subprogram に対して emit するため、**Linux 5.17+** が必要。predicate codegen は BPF_END byte-swap family を使うので BSWAP (`0xd7`、6.6+) には依存しない。CI matrix は `vimto` で 6.1 / 6.6 / 6.12 / 6.18 を gating。quantifier / parser-machine self-loop を含まない chain ならさらに古い kernel でも動作する。
+パイプラインは `expr → AST → IR → asm.Instructions` です。AST は手書きの再帰下降パーサが構築します。IR は vocab 解決済みの layer instance を保持し、すべてのフィールド参照を具体的な `*vocab.ProtocolSpec` にバインドします。codegen は IR を [cilium/ebpf](https://github.com/cilium/ebpf) の `asm.Instructions` に lower し、各 layer 境界で verifier-safe な bounds check を emit します。可変長 quantifier の `+`、`*`、`{n,m>4}` と parser machine の self-loop は bpf2bpf subprogram への `bpf_loop` 呼び出しに落ちるため、Linux 5.17 以上が必要です。predicate codegen は BPF_END 系の byte-swap を使うので、6.6 で入った BSWAP 命令 `0xd7` には依存しません。CI は `vimto` で 6.1 / 6.6 / 6.12 / 6.15 / 6.18 / 7.0 の matrix を検証します。quantifier も parser machine の self-loop も含まない chain なら、さらに古い kernel でも動きます。
 
-formal な EBNF は [`docs/ja/dsl-grammar.md`](https://github.com/takehaya/bpf-ninja/blob/main/docs/ja/dsl-grammar.md) にある。コード側のエントリポイント: `pkg/kunai/codegen/codegen.go` (compile pipeline + ABI)、`pkg/kunai/vocab/p4lite/` (P4-16 strict subset parser)、 `pkg/kunai/codegen/` の `parser_state.go` / `parser_trail.go` / `parser_select.go` / `parser_loop.go` 4 ファイル (可変長 header codegen — review 容易性のため機能境界で split)。
+formal な EBNF は [`docs/ja/dsl-grammar.md`](https://github.com/takehaya/bpf-ninja/blob/main/docs/ja/dsl-grammar.md) にあります。コード側のエントリポイントは、compile pipeline と ABI を記述した `pkg/kunai/codegen/codegen.go`、P4-16 strict subset パーサの `pkg/kunai/vocab/p4lite/`、そして可変長 header codegen を担う `pkg/kunai/codegen/` の `parser_state.go` / `parser_trail.go` / `parser_select.go` / `parser_loop.go` の 4 ファイルです。4 ファイルへの分割はレビューしやすさのためです。
 
 ## API
 
-public surface は意図的に最小。サブパッケージは export されているが semi-internal 扱い — `Compile` の戻り値の型付けや、runtime に独自 vocabulary ファイルを書く用途には必要だが、プログラミングインタフェースとして使うことは想定していない。
+public surface は意図的に最小です。サブパッケージは export されていますが semi-internal 扱いです。`Compile` の戻り値の型付けと、実行時に独自 vocabulary ファイルを与える用途のために公開しているだけで、プログラミングインタフェースとしての利用は想定していません。
 
 ```go
 // kunai
 func Compile(expr string, caps codegen.Capabilities) (codegen.Output, error)
 
-// codegen
+// codegen — フェーズ別の 3 グループを束ねる薄い集約体。
 type Capabilities struct {
-    // Action: symbolic 名 → 整数 (`where action == NAME` 用)。
-    // nil で action atom を無効化 (resolver が拒否)。
-    Action map[string]int32
-    // ActionFetcher: action u32 を R3 にロードする命令列を emit。
-    // Action が non-nil なら必須。
-    ActionFetcher ActionFetcher
-    // ReservedLabels: @label と衝突させない symbol 集合。
+    Lex  LexCaps    // parser: label の予約
+    Lang LangCaps   // resolver + codegen: action / set atom
+    Host HostLayout // codegen: ホストのパケットレイアウト
+}
+
+type LexCaps struct {
+    // ReservedLabels: @label が衝突してはならない symbol 名の集合。
+    // nil なら Compile が Lang.Action のキーから導出する。
     ReservedLabels map[string]bool
+}
+
+type LangCaps struct {
+    // Action: `where action == NAME` 用の symbolic 名 → 整数。
+    // nil で action atom を無効化 (resolver が拒否する)。
+    Action map[string]int32
+    // ActionFetcher: action の u32 を R3 にロードする命令列を emit する。
+    // Action が non-nil のとき必須。
+    ActionFetcher ActionFetcher
+    // SetSlots: `field in @set` 述語を、抽出フィールドを格納する
+    // R10 stack slot に解決する。nil で `in @set` を無効化。
+    SetSlots SetSlotResolver
+}
+
+type HostLayout struct {
+    // VlanInMetadata: kernel が outer VLAN tag を skb metadata へ
+    // 抜き出し済み (tc)。true なら vlan/qinq を含む chain を
+    // コンパイル時に拒否する。
+    VlanInMetadata bool
+    // PacketStartsAtL3: パケットウィンドウが L3 ヘッダから始まる
+    // (cgroup-skb)。true なら resolver は eth root の chain に警告する。
+    PacketStartsAtL3 bool
 }
 
 type ActionFetcher interface {
@@ -109,16 +133,23 @@ type ActionFetcher interface {
 }
 
 type Output struct {
-    Main      asm.Instructions
-    Callbacks asm.Instructions  // bpf2bpf subprogram (あれば)
-    Capture   CaptureInfo
+    Main        asm.Instructions
+    Callbacks   asm.Instructions // bpf2bpf subprogram (あれば)
+    Capture     CaptureInfo
+    Extractions []ExtractSlot    // `in @set` の map lookup 用に埋めた stack slot
+    Warnings    []string         // 非致命的な resolver / codegen の注意
 }
 type CaptureInfo struct {
-    MaxCapLen int  // 0 = caller default
+    MaxCapLen       int // 0 = caller default (ホストの DefaultCapLen に fallback)
+    FilterMinPrefix int // フィルタが実際に読むバイト数 (0 = caller fallback)
 }
 ```
 
-ホストは `Capabilities` 値を構築して kunai を自分の BPF attach point に接続する。kunai コアは host 固有 helper を持たず、canonical adapter は [`host/`](./host/) サブパッケージに置かれる。XDP fexit 例:
+`MaxCapLen` は、ホストが ringbuf に確保しパケットからコピーすべき payload バイト数です。非ゼロの値は明示的な `capture` 節に由来します。たとえば `capture headers` は 54 B、`capture headers+64` は 118 B、`capture absolute 96` は 96 B になります。DSL に `capture` 節が無い場合は 0 のままで、ホストは自身のデフォルトに fallback します。bpf-ninja は libpcap / tcpdump の全パケット挙動に合わせて `DefaultCapLen = 1500` を使います。節の省略は `capture all` の糖衣です。ringbuf 確保量を絞って throughput を稼ぎたい場合は、`capture headers` で明示的に opt-in するか、ホスト CLI の `--snaplen` で縮めます。
+
+`FilterMinPrefix` は、コンパイル済みフィルタがパケットから読む最大バイトオフセットです。chain の自然なヘッダ prefix 長と、マージ済み where 節の最右フィールド末尾を合成した値になります。tracing ホストの LoadEntry / LoadExit はこれを使って per-CPU scratch map への `bpf_probe_read_kernel` の読み取り量を決めるので、`eth/ipv4/tcp where tcp.dport == 443` のような単純なフィルタは 54 B だけを読み、保守的な `ScratchBufSize` 分のコピーを避けられます。0 は解析を断念したことを意味します。quantifier 付き chain や heterogeneous alternation がこれに当たり、ホストは scratch 全読みに fallback します。`FilterMinPrefix` は `MaxCapLen` から独立です。scratch 読みの最適化は、ユーザーが `capture headers` で ringbuf 側の最適化に opt-in したかどうかに関わらず常に効きます。
+
+ホストは `Capabilities` 値を構築して、kunai を自分の BPF attach point に接続します。kunai コアはホスト固有の helper を持たず、canonical adapter は [`host/`](./host/) 以下のサブパッケージにあります。現在は `host/xdp`、`host/tc`、`host/cgroupskb` の 3 つです。XDP fexit の場合は次のように書きます。
 
 ```go
 import xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
@@ -127,38 +158,38 @@ caps := xdphost.FexitCapabilities()
 out, err := kunai.Compile(expr, caps)
 ```
 
-他ホスト (userspace `BPF_PROG_TEST_RUN` / 独自 tracing) は `host/xdp/` と並ぶ形で `host/<name>/` を追加し、独自の `ActionFetcher` + symbol map を提供する。`Capabilities` / `ActionFetcher` の契約は [`codegen/caps.go`](./codegen/caps.go)、host が wrap すべき runFilter ABI は [`codegen/codegen.go`](./codegen/codegen.go) の package doc を参照。
+userspace の `BPF_PROG_TEST_RUN` や独自 tracing のような他のホストは、`host/xdp/` と並ぶ形で `host/<name>/` パッケージを追加し、独自の `ActionFetcher` と symbol map を提供します。`Capabilities` / `ActionFetcher` の契約は [`codegen/caps.go`](./codegen/caps.go) を、ホストが wrap すべき runFilter ABI は [`codegen/codegen.go`](./codegen/codegen.go) のパッケージ doc を参照してください。
 
-エラーは各フェーズからそのまま返る。`errors.As` / `errors.Is` で識別する:
+エラーは各フェーズからそのまま返ります。`errors.As` / `errors.Is` で識別します。
 
-- Lexer / parser エラーは `*lexer.SyntaxError`
-- Resolver エラーは `*resolve.Error` (syntax error 型のエイリアス、file/line/col を保持)
-- Codegen エラーには `codegen.ErrNotImplemented` が含まれる。これは MVP codegen がまだ emit していない有効な DSL に対するエラーで、本物のバグと区別するには `errors.Is(err, codegen.ErrNotImplemented)` を使う
+- lexer / parser のエラーは `*lexer.SyntaxError` です。
+- resolver のエラーは `*resolve.Error` です。syntax error 型のエイリアスで、file / line / col を保持します。
+- codegen のエラーには `codegen.ErrNotImplemented` が含まれます。これは MVP codegen がまだ emit していない有効な DSL に対するエラーで、本物のバグと区別するには `errors.Is(err, codegen.ErrNotImplemented)` を使います。
 
 ## 同梱 vocabulary
 
-ライブラリには 17 個のプロトコル定義が組み込み済み: `eth`, `vlan`, `qinq`, `cw`, `mpls`, `ipv4`, `ipv6`, `tcp`, `udp`, `icmp`, `icmp6`, `gre`, `esp`, `vxlan`, `geneve`, `gtp`, `srv6`。これらは [`protocols/`](./protocols/) 以下に `.p4` ファイルとして置かれ、ビルド時に `//go:embed` で埋め込まれる。
+ライブラリは `eth`, `vlan`, `qinq`, `cw`, `mpls`, `ipv4`, `ipv6`, `tcp`, `udp`, `icmp`, `icmp6`, `gre`, `esp`, `vxlan`, `geneve`, `gtp`, `srv6` の 17 プロトコル定義を同梱しています。[`protocols/`](./protocols/) 以下に `.p4` ファイルとして置かれ、ビルド時に `//go:embed` で埋め込まれます。
 
-新プロトコルを追加するには、`<name>.p4` を `protocols/` に置き、dispatch-constant の命名規約に従う。命名規約の正規定義は [`pkg/kunai/vocab/loader.go`](./vocab/loader.go) の `classifyConsts` 周辺の regex 群を参照。vocabulary loader は regex ベースで、起動時に malformed な名前を reject する。
+新しいプロトコルを追加するには、`<name>.p4` を `protocols/` に置き、dispatch 定数の命名規約に従います。命名規約の正規定義は [`pkg/kunai/vocab/loader.go`](./vocab/loader.go) の `classifyConsts` 周辺の regex 群です。loader は malformed な名前を起動時に reject します。
 
-`.p4` ファイルは P4-16 構文の strict subset であり、公式 `p4c --parse-only` を通る (CI で全変更について検証している)。テストハーネスは親リポジトリの `docker/p4c-check/` を参照。
+`.p4` ファイルは P4-16 構文の strict subset で、公式の `p4c --parse-only` を通ります。CI がすべての変更でこれを検証します。テストハーネスは親リポジトリの `docker/p4c-check/` にあります。
 
-vocabulary のパースは `dslvocab.Bundled()` 内で `sync.Once` により **process 内で 1 回限り**にキャッシュされる (`pkg/kunai/dslvocab/dslvocab.go`)。同 process で `kunai.Compile()` を複数回呼んでも 17 ファイルの再パースは発生しない。永続キャッシュ (build-time / on-disk) は parse コストが microsecond オーダーで意義が薄いため未実装。
+vocabulary のパース結果は、`pkg/kunai/dslvocab/` の `dslvocab.Bundled()` が `sync.Once` でキャッシュします。同一プロセスで `kunai.Compile()` を何度呼んでも、17 ファイルのパースは 1 回だけです。パースは microsecond オーダーで BPF プログラムのロードに比べて誤差のため、on-disk やビルド時の永続キャッシュは持ちません。
 
 ## バージョニングと安定性
 
-- public API: `kunai.Compile`, `kunai.CompileWithVocab` (カスタム vocab 受入)、 `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp` (bpf-ninja の `--dsl-help` 用)、 `codegen.Capabilities`、 `codegen.ActionFetcher`、 `codegen.Output`、 `codegen.CaptureInfo`、 `codegen.MainFilterFuncBTF` (host wrapper 用)、 `codegen.PositionedError` (位置情報付きエラー型)、 `host/xdp` / `host/tc` adapter パッケージ、上記のエラー型
-- それ以外 (AST node、IR 型、vocab loader 内部、parser 内部、`dslvocab.Bundled` キャッシュ) は予告なく変更される可能性あり
-- `pkg/kunai/dsltest` (gopacket-based packet-level harness) は **experimental**。1.0 までは `Runner` API / packet builder を予告なく変更する可能性あり。下流 test が依存する場合は tag 固定推奨
-- プロトコル vocabulary は public surface の一部として扱う — 新プロトコル追加は非破壊変更、リネーム/削除は破壊変更
+- public API は次のとおりです。`kunai.Compile`、カスタム vocab を受け入れる `kunai.CompileWithVocab`、bpf-ninja の `--dsl-help` が使う `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp`、`codegen.Capabilities` とその構成要素 `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver`、`codegen.ActionFetcher`、`codegen.Output` と `CaptureInfo` / `ExtractSlot`、host wrapper 用の `codegen.MainFilterFuncBTF`、位置情報付きエラー型の `codegen.PositionedError`、`host/xdp` / `host/tc` / `host/cgroupskb` の adapter パッケージ、上記のエラー型です。
+- それ以外の AST node、IR 型、vocab loader 内部、parser 内部、`dslvocab.Bundled` キャッシュは、予告なく変わる可能性があります。
+- gopacket ベースのパケットレベルハーネス `pkg/kunai/dsltest` は experimental です。1.0 までは `Runner` API と packet builder を予告なく変更する可能性があるので、下流のテストが依存する場合は tag を固定してください。
+- プロトコル vocabulary は public surface の一部として扱います。新プロトコルの追加は非破壊変更、リネームや削除は破壊変更です。
 
 ## 関連プロジェクト
 
-- [bpf-ninja](https://github.com/takehaya/bpf-ninja) — 本パッケージのメイン consumer である非侵襲 BPF 観測ツール (XDP / tc-bpf フックポイント)
-- [cilium/ebpf](https://github.com/cilium/ebpf) — codegen のターゲットである BPF アセンブラ / ローダ
-- [cloudflare/cbpfc](https://github.com/cloudflare/cbpfc) — 代替の classical-BPF (tcpdump 構文) コンパイラ。bpf-ninja は `--cbpf` 指定時の legacy 経路で使う
-- [p4lang/p4c](https://github.com/p4lang/p4c) — 公式 P4 コンパイラ。`.p4` vocab ファイルが P4-16 内に収まっていることを CI で検証するのに使う
+- [bpf-ninja](https://github.com/takehaya/bpf-ninja) は、本パッケージのメイン consumer である非侵襲 BPF 観測ツールです。XDP / tc / cgroup-skb のフックポイントを扱います。
+- [cilium/ebpf](https://github.com/cilium/ebpf) は、codegen がターゲットにする BPF アセンブラ / ローダです。
+- [cloudflare/cbpfc](https://github.com/cloudflare/cbpfc) は、tcpdump 構文の classical BPF を変換する代替コンパイラです。bpf-ninja は `--cbpf` 指定時の legacy 経路で使います。
+- [p4lang/p4c](https://github.com/p4lang/p4c) は公式の P4 コンパイラです。`.p4` vocab ファイルが P4-16 に収まっていることを CI で検証するのに使います。
 
 ## ライセンス
 
-親リポジトリ bpf-ninja と同じ。
+親リポジトリ bpf-ninja と同じです。

--- a/pkg/kunai/README.md
+++ b/pkg/kunai/README.md
@@ -26,8 +26,9 @@ eth/ipv4/tcp where tcp.options.MSS.value == 1460                        # TCP op
 - A main eBPF instruction stream that writes `1` (accept) or `0` (reject) into `R2`.
 - Optional bpf2bpf callback subprograms (used internally by the `+`/`*`/`{n,m}` chain quantifiers, which lower to `bpf_loop`).
 - A `CaptureInfo` describing how many bytes of each packet the host should hand to perf-buffer / ring-buffer output.
+- An `Extractions` list naming the packet fields the filter staged into stack slots for `field in @set` predicates, and a `Warnings` list of non-fatal compile notices.
 
-The output is **target-agnostic**: it assumes only a contiguous packet window between two registers and a small set of working registers. Callers wrap it in a host-specific prologue (load packet pointers, copy into a scratch buffer, etc.) — see [`codegen/codegen.go`](./codegen/codegen.go) package doc for the exact ABI.
+The output is **target-agnostic**: it assumes only a contiguous packet window between two registers and a small set of working registers. Callers wrap it in a host-specific prologue (load packet pointers, copy into a scratch buffer, etc.). See the [`codegen/codegen.go`](./codegen/codegen.go) package doc for the exact ABI.
 
 ## Installation
 
@@ -80,13 +81,13 @@ For a complete worked example (XDP fentry/fexit attach + perf-event capture), se
 
 ## Architecture (one paragraph)
 
-The pipeline is `expr → AST → IR → asm.Instructions`. The AST is built by a hand-written recursive-descent parser; the IR holds vocabulary-resolved layer instances and binds every field reference to a concrete `*vocab.ProtocolSpec`; codegen lowers the IR to [cilium/ebpf](https://github.com/cilium/ebpf) `asm.Instructions` with verifier-safe bounds checks at every layer boundary. Variable-length quantifiers (`+`, `*`, `{n,m>4}`) and parser-machine self-loops emit a `bpf_loop` helper call into a bpf2bpf subprogram, which lands in **Linux 5.17**. Predicate codegen sticks to the BPF_END byte-swap family so it does not require BSWAP (`0xd7`, 6.6+). CI gates the matrix on 6.1 / 6.6 / 6.12 / 6.18 (`vimto`); chains without quantifiers or parser-machine self-loops can run on even older kernels.
+The pipeline is `expr → AST → IR → asm.Instructions`. The AST is built by a hand-written recursive-descent parser; the IR holds vocabulary-resolved layer instances and binds every field reference to a concrete `*vocab.ProtocolSpec`; codegen lowers the IR to [cilium/ebpf](https://github.com/cilium/ebpf) `asm.Instructions` with verifier-safe bounds checks at every layer boundary. Variable-length quantifiers (`+`, `*`, `{n,m>4}`) and parser-machine self-loops emit a `bpf_loop` helper call into a bpf2bpf subprogram, which lands in **Linux 5.17**. Predicate codegen sticks to the BPF_END byte-swap family so it does not require BSWAP (`0xd7`, 6.6+). CI gates the matrix on 6.1 / 6.6 / 6.12 / 6.15 / 6.18 / 7.0 (`vimto`); chains without quantifiers or parser-machine self-loops can run on even older kernels.
 
-The formal EBNF lives in [`docs/ja/dsl-grammar.md`](https://github.com/takehaya/bpf-ninja/blob/main/docs/ja/dsl-grammar.md). Code-level entry points: `pkg/kunai/codegen/codegen.go` (compile pipeline + ABI), `pkg/kunai/vocab/p4lite/` (P4-16 strict subset parser), and the `parser_state.go` / `parser_trail.go` / `parser_select.go` / `parser_loop.go` quartet under `pkg/kunai/codegen/` (variable-length header codegen — split for review readability).
+The formal EBNF lives in [`docs/ja/dsl-grammar.md`](https://github.com/takehaya/bpf-ninja/blob/main/docs/ja/dsl-grammar.md). Code-level entry points: `pkg/kunai/codegen/codegen.go` (compile pipeline + ABI), `pkg/kunai/vocab/p4lite/` (P4-16 strict subset parser), and the `parser_state.go` / `parser_trail.go` / `parser_select.go` / `parser_loop.go` quartet under `pkg/kunai/codegen/` (variable-length header codegen, split for review readability).
 
 ## API
 
-The public surface is intentionally tiny. Sub-packages are exported but considered semi-internal — they are needed to type the return value of `Compile` and to author custom vocabulary files at runtime, not as a programming surface.
+The public surface is intentionally tiny. Sub-packages are exported but considered semi-internal: they exist to type the return value of `Compile` and to author custom vocabulary files at runtime, not as a programming surface.
 
 ```go
 // kunai
@@ -112,12 +113,20 @@ type LangCaps struct {
     // ActionFetcher emits insns that load the action u32 into R3.
     // Required iff Action is non-nil.
     ActionFetcher ActionFetcher
+    // SetSlots resolves a `field in @set` predicate to the R10 stack
+    // slot the filter stores the extracted field into.
+    // nil disables `in @set` atoms.
+    SetSlots SetSlotResolver
 }
 
 type HostLayout struct {
     // VlanInMetadata: the kernel pre-extracted the outer VLAN tag into
     // skb metadata (tc), so vlan/qinq layers are rejected at compile.
     VlanInMetadata bool
+    // PacketStartsAtL3: the packet window begins at the network header
+    // (cgroup-skb), so the resolver warns on an `eth/...` chain root
+    // instead of on a non-eth one.
+    PacketStartsAtL3 bool
 }
 
 type ActionFetcher interface {
@@ -125,9 +134,11 @@ type ActionFetcher interface {
 }
 
 type Output struct {
-    Main      asm.Instructions
-    Callbacks asm.Instructions  // bpf2bpf subprograms (if any)
-    Capture   CaptureInfo
+    Main        asm.Instructions
+    Callbacks   asm.Instructions // bpf2bpf subprograms (if any)
+    Capture     CaptureInfo
+    Extractions []ExtractSlot    // stack slots staged for `in @set` map lookups
+    Warnings    []string         // non-fatal resolver / codegen notices
 }
 type CaptureInfo struct {
     MaxCapLen       int  // 0 = caller default (host falls back to its DefaultCapLen)
@@ -140,26 +151,26 @@ ringbuf and copy from the packet. A non-zero value comes from an
 explicit `capture` clause (e.g. `capture headers` → 54 B,
 `capture headers+64` → 118 B, `capture absolute 96` → 96 B). When the
 DSL omits the `capture` clause entirely, the value stays at zero and
-the host is expected to fall back to its own default — `bpf-ninja`
+the host is expected to fall back to its own default. `bpf-ninja`
 uses `DefaultCapLen = 1500` to match libpcap / tcpdump's full-packet
 behaviour. The no-clause case is sugar for `capture all`; users who
 want the ringbuf-reservation throughput win must opt in explicitly
 with `capture headers` (or shrink via the host's CLI `--snaplen`).
 
 `FilterMinPrefix` is the maximum byte offset the compiled filter
-reads from the packet — chain's natural header prefix sum combined
-with the merged where-clause's rightmost field-end. The tracing
+reads from the packet: the chain's natural header prefix sum combined
+with the merged where-clause's rightmost field end. The tracing
 host (LoadEntry / LoadExit) uses it to size the
 `bpf_probe_read_kernel` into its per-CPU scratch map, so simple
 filters (e.g. `eth/ipv4/tcp where tcp.dport == 443` → 54 B) avoid
 copying the conservative `ScratchBufSize` per packet. Zero means
-the analyser bailed (quantified chain, het-alt) and the host
+the analyser bailed (quantified chain, heterogeneous alternation) and the host
 should fall back to the full scratch read. **`FilterMinPrefix` is
 independent of `MaxCapLen`**: the scratch-read optimisation always
 applies, whether or not the user opted into the ringbuf-reservation
 optimisation via `capture headers`.
 
-The host wires kunai to its specific BPF attach point by constructing a `Capabilities` value. The kunai core ships no host-specific helpers; canonical adapters live under [`host/`](./host/) sub-packages. For an XDP fexit attach point:
+The host wires kunai to its specific BPF attach point by constructing a `Capabilities` value. The kunai core ships no host-specific helpers; canonical adapters live under [`host/`](./host/): `host/xdp`, `host/tc`, and `host/cgroupskb`. For an XDP fexit attach point:
 
 ```go
 import xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
@@ -180,25 +191,25 @@ Errors are returned as-is from each phase. Recognise them with `errors.As`/`erro
 
 The library ships with 17 baked-in protocol definitions: `eth`, `vlan`, `qinq`, `cw`, `mpls`, `ipv4`, `ipv6`, `tcp`, `udp`, `icmp`, `icmp6`, `gre`, `esp`, `vxlan`, `geneve`, `gtp`, `srv6`. They live as `.p4` files under [`protocols/`](./protocols/) and are embedded at build time via `//go:embed`.
 
-To add a new protocol, drop a `<name>.p4` file into `protocols/` and follow the dispatch-constant naming convention. The loader's regex tables in [`pkg/kunai/vocab/loader.go`](./vocab/loader.go) (search for `classifyConsts` and `re*` regexes) are the authoritative reference — any malformed name is rejected at startup.
+To add a new protocol, drop a `<name>.p4` file into `protocols/` and follow the dispatch-constant naming convention. The loader's regex tables in [`pkg/kunai/vocab/loader.go`](./vocab/loader.go) (search for `classifyConsts` and `re*` regexes) are the authoritative reference. Any malformed name is rejected at startup.
 
-The `.p4` files are a strict subset of P4-16 syntax — they pass the official `p4c --parse-only` (CI verifies this on every change). See `docker/p4c-check/` in the parent repo for the test harness.
+The `.p4` files are a strict subset of P4-16 syntax: they pass the official `p4c --parse-only`, and CI verifies this on every change. See `docker/p4c-check/` in the parent repo for the test harness.
 
-Vocabulary parsing is memoised: `dslvocab.Bundled()` (in `pkg/kunai/dslvocab/`) wraps `vocab.Load` with `sync.Once`, so the 17 `.p4` files are parsed once per process and every subsequent `kunai.Compile()` call reuses the cached `ProtocolSpec` map. There is no persistent (on-disk / build-time) cache — parsing the bundled set takes microseconds and is dwarfed by BPF program load, so the in-memory cache is sufficient.
+Vocabulary parsing is memoised: `dslvocab.Bundled()` (in `pkg/kunai/dslvocab/`) wraps `vocab.Load` with `sync.Once`, so the 17 `.p4` files are parsed once per process and every subsequent `kunai.Compile()` call reuses the cached `ProtocolSpec` map. There is no persistent on-disk or build-time cache: parsing the bundled set takes microseconds and is dwarfed by BPF program load, so the in-memory cache is sufficient.
 
 ## Versioning & stability
 
-- Public API: `kunai.Compile`, `kunai.CompileWithVocab` (custom-vocab variant), `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp` (used by bpf-ninja's `--dsl-help`), `codegen.Capabilities`, `codegen.ActionFetcher`, `codegen.Output`, `codegen.CaptureInfo`, `codegen.MainFilterFuncBTF` (host wrapper helper), `codegen.PositionedError` (source-position-aware error type), the `host/xdp` and `host/tc` adapter packages, and the error types listed above.
+- Public API: `kunai.Compile`, `kunai.CompileWithVocab` (custom-vocab variant), `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp` (used by bpf-ninja's `--dsl-help`), `codegen.Capabilities` with its `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver` components, `codegen.ActionFetcher`, `codegen.Output` with `CaptureInfo` / `ExtractSlot`, `codegen.MainFilterFuncBTF` (host wrapper helper), `codegen.PositionedError` (source-position-aware error type), the `host/xdp`, `host/tc`, and `host/cgroupskb` adapter packages, and the error types listed above.
 - Everything else (AST nodes, IR types, vocab loader internals, parser internals, the `dslvocab.Bundled` cache) may change without notice.
-- `pkg/kunai/dsltest` (the gopacket-based packet-level harness) is **experimental** until 1.0 — its `Runner` API and packet builders may change without notice. Pin a tagged version if downstream tests depend on it.
-- The protocol vocabulary is treated as part of the public surface — adding new protocols is non-breaking; renaming or removing one is a breaking change.
+- `pkg/kunai/dsltest` (the gopacket-based packet-level harness) is **experimental** until 1.0: its `Runner` API and packet builders may change without notice. Pin a tagged version if downstream tests depend on it.
+- The protocol vocabulary is treated as part of the public surface: adding new protocols is non-breaking, while renaming or removing one is a breaking change.
 
 ## Related projects
 
-- [bpf-ninja](https://github.com/takehaya/bpf-ninja) — non-invasive BPF observability tool (XDP and tc-bpf hook points) that is the primary consumer of this package.
-- [cilium/ebpf](https://github.com/cilium/ebpf) — the BPF assembler / loader the codegen targets.
-- [cloudflare/cbpfc](https://github.com/cloudflare/cbpfc) — alternative classical-BPF (tcpdump syntax) compiler, used by bpf-ninja when `--cbpf` is set (legacy fallback).
-- [p4lang/p4c](https://github.com/p4lang/p4c) — official P4 compiler, used in CI to verify our `.p4` vocab files stay within P4-16.
+- [bpf-ninja](https://github.com/takehaya/bpf-ninja): non-invasive BPF observability tool (XDP, tc, and cgroup-skb hook points) that is the primary consumer of this package.
+- [cilium/ebpf](https://github.com/cilium/ebpf): the BPF assembler / loader the codegen targets.
+- [cloudflare/cbpfc](https://github.com/cloudflare/cbpfc): alternative classical-BPF (tcpdump syntax) compiler, used by bpf-ninja when `--cbpf` is set (legacy fallback).
+- [p4lang/p4c](https://github.com/p4lang/p4c): official P4 compiler, used in CI to verify our `.p4` vocab files stay within P4-16.
 
 ## License
 


### PR DESCRIPTION
## Summary

Refresh `pkg/kunai/README.md` and `README.ja.md`, which had drifted behind the code.

### Stale content fixed (both languages)
- CI kernel matrix: add 6.15 / 7.0 to match `bpf_load_test.yaml`
- Document the `host/cgroupskb` adapter and `HostLayout.PacketStartsAtL3`
- Document `Output.Extractions` / `Output.Warnings` and `LangCaps.SetSlots` (`field in @set`)
- Public-API list and related-projects hook points updated accordingly

### Japanese README catch-up
- Replace the pre-split flat `Capabilities` in the API section with the current `Lex`/`Lang`/`Host` structure
- Port the `MaxCapLen` / `FilterMinPrefix` explanation paragraphs that only existed in the English version

### Prose pass
- English: remove em dashes in running text, expand in-house shorthand (e.g. "het-alt")
- Japanese: full rewrite per house style (敬体に統一、体言止め・太字強調・文末括弧補足・ダッシュの除去)。コードブロックは無変更

Docs only, no code changes.