### PR TITLE
feat(kunai): accept multiple dispatch values per edge via _ALT consts

### DIFF
--- a/docs/ja/dsl-grammar.md
+++ b/docs/ja/dsl-grammar.md
@@ -269,6 +269,7 @@ Dispatch 命名規約は次のとおりです。loader が `vocab/loader.go` 内
 | 名前パターン | regex | 意味 |
 |---|---|---|
 | `KUNAI_<SELF>_<PARENT>_<FIELD>` | `reField` | 親の `field` がこの値のとき自分にディスパッチ |
+| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]` | `reField` + `reAltDispatch` | 同じ edge の追加受理値。base const の `AltValues` にマージされ、いずれかの値に一致すればディスパッチする (例: VXLAN の IANA 4789 と Linux 旧来値 8472)。`_alt` はフィールド名の末尾として予約 |
 | `KUNAI_<SELF>_<PARENT>_NO_CHECK = true` | `reNoCheck` | 検査なしで blind cast |
 | `<SELF>_MAX_DEPTH = N` | `reMaxDepth` | bpf_loop chain の上限 (既定 8、最大 64) |
 | `<SELF>_CHAIN_END_<FIELD> = V` | `reChainEnd` | chain 終了条件 (例: MPLS の s-bit) |

--- a/docs/ja/dsl-grammar.md
+++ b/docs/ja/dsl-grammar.md
@@ -269,7 +269,7 @@ Dispatch 命名規約は次のとおりです。loader が `vocab/loader.go` 内
 | 名前パターン | regex | 意味 |
 |---|---|---|
 | `KUNAI_<SELF>_<PARENT>_<FIELD>` | `reField` | 親の `field` がこの値のとき自分にディスパッチ |
-| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]` | `reField` + `reAltDispatch` | 同じ edge の追加受理値。base const の `AltValues` にマージされ、いずれかの値に一致すればディスパッチする (例: VXLAN の IANA 4789 と Linux 旧来値 8472)。`_alt` はフィールド名の末尾として予約 |
+| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[_NAME]` | `reField` + `reAltDispatch` | 同じ edge の追加受理値。base const の `AltValues` にマージされ、いずれかの値に一致すればディスパッチする。`<NAME>` は値の出自を示す説明用 (例: `KUNAI_VXLAN_UDP_DPORT_ALT_LINUX_LEGACY = 8472`)。番号形式 `_ALT<n>` はエラー。`_alt` はフィールド名の末尾として予約 |
 | `KUNAI_<SELF>_<PARENT>_NO_CHECK = true` | `reNoCheck` | 検査なしで blind cast |
 | `<SELF>_MAX_DEPTH = N` | `reMaxDepth` | bpf_loop chain の上限 (既定 8、最大 64) |
 | `<SELF>_CHAIN_END_<FIELD> = V` | `reChainEnd` | chain 終了条件 (例: MPLS の s-bit) |

--- a/docs/ja/dsl-vocab-authoring.md
+++ b/docs/ja/dsl-vocab-authoring.md
@@ -106,6 +106,7 @@ const は名前のパターンによって loader の `vocab/loader.go::classify
 | パターン | 型 | 意味 |
 |---|---|---|
 | `KUNAI_<SELF>_<PARENT>_<FIELD>` | `bit<N>` | Field dispatch。親の `field` がこの値のとき自分として展開する |
+| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]` | `bit<N>`、base と同幅 | 同じ edge の追加受理値。base の `AltValues` にマージされ、いずれかに一致すれば展開する。base 無し・幅違い・値重複はロードエラー。例: `KUNAI_VXLAN_UDP_DPORT_ALT = 8472` (Cilium / flannel の Linux 旧来 port) |
 | `KUNAI_<SELF>_<PARENT>_NO_CHECK` | `bool`、true 固定 | NoCheck dispatch。検査せず blind cast する |
 | `<SELF>_MAX_DEPTH` | `bit<N>`、1..64 | chain quantifier や parser self-loop など bpf_loop 系の反復上限。未宣言なら既定 8 |
 | `<SELF>_CHAIN_END_<FIELD>` | `bit<N>` | chain 終了条件。1 プロトコル 1 個まで。`<FIELD>` は primary に存在すること |

--- a/docs/ja/dsl-vocab-authoring.md
+++ b/docs/ja/dsl-vocab-authoring.md
@@ -106,7 +106,7 @@ const は名前のパターンによって loader の `vocab/loader.go::classify
 | パターン | 型 | 意味 |
 |---|---|---|
 | `KUNAI_<SELF>_<PARENT>_<FIELD>` | `bit<N>` | Field dispatch。親の `field` がこの値のとき自分として展開する |
-| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]` | `bit<N>`、base と同幅 | 同じ edge の追加受理値。base の `AltValues` にマージされ、いずれかに一致すれば展開する。base 無し・幅違い・値重複はロードエラー。例: `KUNAI_VXLAN_UDP_DPORT_ALT = 8472` (Cilium / flannel の Linux 旧来 port) |
+| `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[_NAME]` | `bit<N>`、base と同幅 | 同じ edge の追加受理値。base の `AltValues` にマージされ、いずれかに一致すれば展開する。`<NAME>` は値の出自の説明で、複数並べるときは名前で区別する。base 無し・幅違い・値重複・番号形式 `_ALT<n>` はロードエラー。例: `KUNAI_VXLAN_UDP_DPORT_ALT_LINUX_LEGACY = 8472` (Cilium / flannel の Linux 旧来 port) |
 | `KUNAI_<SELF>_<PARENT>_NO_CHECK` | `bool`、true 固定 | NoCheck dispatch。検査せず blind cast する |
 | `<SELF>_MAX_DEPTH` | `bit<N>`、1..64 | chain quantifier や parser self-loop など bpf_loop 系の反復上限。未宣言なら既定 8 |
 | `<SELF>_CHAIN_END_<FIELD>` | `bit<N>` | chain 終了条件。1 プロトコル 1 個まで。`<FIELD>` は primary に存在すること |

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -454,10 +454,9 @@ func chainFieldPeek(spec *vocab.ProtocolSpec, selfConst *vocab.DispatchConst, hs
 	if err != nil {
 		return nil, err
 	}
-	expected := int32(byteSwap(selfConst.Value, fieldBytes))
 	insns := append(asm.Instructions{}, foldOffsetIntoScalar(asm.R1, asm.R3, loadByteOff, breakLabel)...)
 	insns = append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R1, asm.R5, size, breakLabel)...)
-	insns = append(insns, asm.JNE.Imm(asm.R0, expected, breakLabel))
+	insns = append(insns, emitDispatchValueMatch(asm.R0, selfConst, fieldBytes, breakLabel)...)
 	return insns, nil
 }
 

--- a/pkg/kunai/codegen/bpfloop.go
+++ b/pkg/kunai/codegen/bpfloop.go
@@ -454,9 +454,13 @@ func chainFieldPeek(spec *vocab.ProtocolSpec, selfConst *vocab.DispatchConst, hs
 	if err != nil {
 		return nil, err
 	}
+	match, err := emitDispatchValueMatch(asm.R0, selfConst, fieldBytes, breakLabel)
+	if err != nil {
+		return nil, err
+	}
 	insns := append(asm.Instructions{}, foldOffsetIntoScalar(asm.R1, asm.R3, loadByteOff, breakLabel)...)
 	insns = append(insns, boundedScalarLoad(asm.R0, asm.R4, asm.R1, asm.R5, size, breakLabel)...)
-	insns = append(insns, emitDispatchValueMatch(asm.R0, selfConst, fieldBytes, breakLabel)...)
+	insns = append(insns, match...)
 	return insns, nil
 }
 

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -64,6 +64,7 @@ package codegen
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf/asm"
@@ -498,9 +499,13 @@ func emitFieldDispatchCheck(
 	if err != nil {
 		return nil, err
 	}
+	match, err := emitDispatchValueMatch(dst, c, fieldBytes, failLabel)
+	if err != nil {
+		return nil, err
+	}
 	insns := append(asm.Instructions{}, setupAddr...)
 	insns = append(insns, asm.LoadMem(dst, dst, int16(fieldOff-parentHS), size))
-	insns = append(insns, emitDispatchValueMatch(dst, c, fieldBytes, failLabel)...)
+	insns = append(insns, match...)
 	return insns, nil
 }
 
@@ -510,21 +515,36 @@ func emitFieldDispatchCheck(
 // vocabs stay byte-identical). A const with AltValues accepts any of
 // its declared values: JEq to a shared ok-landing for all but the last
 // value, then the usual JNE to failLabel for the last.
-func emitDispatchValueMatch(dst asm.Register, c *vocab.DispatchConst, fieldBytes int, failLabel string) asm.Instructions {
-	if len(c.AltValues) == 0 {
-		return asm.Instructions{asm.JNE.Imm(dst, int32(byteSwap(c.Value, fieldBytes)), failLabel)}
+//
+// Every compare is a sign-extending JEq/JNE.Imm against a zero-
+// extended load, so a byte-swapped value with the top bit set (only
+// reachable via a 4-byte dispatch field — no bundled vocab has one)
+// could never match; such values are rejected loudly instead of
+// miscompiling. The register-based compare the predicates use
+// (cmpRegEqU32) is not safe here: R5 is live in the bounded and
+// bpf_loop-callback dispatch contexts.
+func emitDispatchValueMatch(dst asm.Register, c *vocab.DispatchConst, fieldBytes int, failLabel string) (asm.Instructions, error) {
+	swapped := make([]int32, 0, 1+len(c.AltValues))
+	for _, v := range append([]uint64{c.Value}, c.AltValues...) {
+		le := byteSwap(v, fieldBytes)
+		if le > math.MaxInt32 {
+			return nil, fmt.Errorf("%w: dispatch const %q value %#x byte-swaps to %#x, which does not fit the sign-extended JEq/JNE immediate", ErrNotImplemented, c.Name, v, le)
+		}
+		swapped = append(swapped, int32(le))
 	}
-	values := append([]uint64{c.Value}, c.AltValues...)
+	if len(swapped) == 1 {
+		return asm.Instructions{asm.JNE.Imm(dst, swapped[0], failLabel)}, nil
+	}
 	okLabel := nextAltDispatchLabel("multiok")
-	insns := make(asm.Instructions, 0, len(values)+1)
-	for _, v := range values[:len(values)-1] {
-		insns = append(insns, asm.JEq.Imm(dst, int32(byteSwap(v, fieldBytes)), okLabel))
+	insns := make(asm.Instructions, 0, len(swapped)+1)
+	for _, le := range swapped[:len(swapped)-1] {
+		insns = append(insns, asm.JEq.Imm(dst, le, okLabel))
 	}
 	insns = append(insns,
-		asm.JNE.Imm(dst, int32(byteSwap(values[len(values)-1], fieldBytes)), failLabel),
+		asm.JNE.Imm(dst, swapped[len(swapped)-1], failLabel),
 		landingNoop(okLabel),
 	)
-	return insns
+	return insns, nil
 }
 
 // emitFieldDispatchCheckBounded is the PTR_TO_PACKET-safe counterpart
@@ -566,9 +586,13 @@ func emitFieldDispatchCheckBounded(
 	if err != nil {
 		return nil, err
 	}
+	match, err := emitDispatchValueMatch(dst, c, fieldBytes, failLabel)
+	if err != nil {
+		return nil, err
+	}
 	insns := foldOffsetIntoScalar(scalar, offsetReg, int32(fieldOff+byteOff), failLabel)
 	insns = append(insns, boundedScalarLoad(dst, asm.R0, scalar, asm.R1, size, failLabel)...)
-	insns = append(insns, emitDispatchValueMatch(dst, c, fieldBytes, failLabel)...)
+	insns = append(insns, match...)
 	return insns, nil
 }
 

--- a/pkg/kunai/codegen/codegen.go
+++ b/pkg/kunai/codegen/codegen.go
@@ -498,13 +498,33 @@ func emitFieldDispatchCheck(
 	if err != nil {
 		return nil, err
 	}
-	expected := int32(byteSwap(c.Value, fieldBytes))
 	insns := append(asm.Instructions{}, setupAddr...)
-	insns = append(insns,
-		asm.LoadMem(dst, dst, int16(fieldOff-parentHS), size),
-		asm.JNE.Imm(dst, expected, failLabel),
-	)
+	insns = append(insns, asm.LoadMem(dst, dst, int16(fieldOff-parentHS), size))
+	insns = append(insns, emitDispatchValueMatch(dst, c, fieldBytes, failLabel)...)
 	return insns, nil
+}
+
+// emitDispatchValueMatch emits the value-comparison tail of a field
+// dispatch check; dst already holds the loaded field bytes. The common
+// single-value const keeps the historical one-JNE shape (existing
+// vocabs stay byte-identical). A const with AltValues accepts any of
+// its declared values: JEq to a shared ok-landing for all but the last
+// value, then the usual JNE to failLabel for the last.
+func emitDispatchValueMatch(dst asm.Register, c *vocab.DispatchConst, fieldBytes int, failLabel string) asm.Instructions {
+	if len(c.AltValues) == 0 {
+		return asm.Instructions{asm.JNE.Imm(dst, int32(byteSwap(c.Value, fieldBytes)), failLabel)}
+	}
+	values := append([]uint64{c.Value}, c.AltValues...)
+	okLabel := nextAltDispatchLabel("multiok")
+	insns := make(asm.Instructions, 0, len(values)+1)
+	for _, v := range values[:len(values)-1] {
+		insns = append(insns, asm.JEq.Imm(dst, int32(byteSwap(v, fieldBytes)), okLabel))
+	}
+	insns = append(insns,
+		asm.JNE.Imm(dst, int32(byteSwap(values[len(values)-1], fieldBytes)), failLabel),
+		landingNoop(okLabel),
+	)
+	return insns
 }
 
 // emitFieldDispatchCheckBounded is the PTR_TO_PACKET-safe counterpart
@@ -546,10 +566,9 @@ func emitFieldDispatchCheckBounded(
 	if err != nil {
 		return nil, err
 	}
-	expected := int32(byteSwap(c.Value, fieldBytes))
 	insns := foldOffsetIntoScalar(scalar, offsetReg, int32(fieldOff+byteOff), failLabel)
 	insns = append(insns, boundedScalarLoad(dst, asm.R0, scalar, asm.R1, size, failLabel)...)
-	insns = append(insns, asm.JNE.Imm(dst, expected, failLabel))
+	insns = append(insns, emitDispatchValueMatch(dst, c, fieldBytes, failLabel)...)
 	return insns, nil
 }
 

--- a/pkg/kunai/codegen/multivalue_dispatch_test.go
+++ b/pkg/kunai/codegen/multivalue_dispatch_test.go
@@ -1,0 +1,121 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/bpf-ninja/pkg/kunai/parser"
+	"github.com/takehaya/bpf-ninja/pkg/kunai/resolve"
+	"github.com/takehaya/bpf-ninja/pkg/kunai/vocab"
+)
+
+// genMultiValueVocab compiles expr against a synthetic two-protocol
+// vocab: an eth-like parent and a fixed 4-byte child `foo` whose
+// dispatch consts are supplied by the caller.
+func genMultiValueVocab(t *testing.T, fooConsts, expr string) (Output, error) {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"vocab/eth.p4": &fstest.MapFile{Data: []byte(`
+header eth_h { bit<48> dst; bit<48> src; bit<16> ethertype; }
+parser EthParser(packet_in pkt, out eth_h hdr) {
+    state start { pkt.extract(hdr); transition accept; }
+}
+`)},
+		"vocab/foo.p4": &fstest.MapFile{Data: []byte(`
+header foo_h { bit<16> kind; bit<16> body; }
+` + fooConsts + `
+parser FooParser(packet_in pkt, out foo_h hdr) {
+    state start { pkt.extract(hdr); transition accept; }
+}
+`)},
+	}
+	specs, err := vocab.Load(fsys, "vocab")
+	if err != nil {
+		t.Fatalf("vocab.Load: %v", err)
+	}
+	f, err := parser.Parse(expr, "", nil)
+	if err != nil {
+		t.Fatalf("parser.Parse: %v", err)
+	}
+	prog, err := resolve.Resolve(f, specs, nil)
+	if err != nil {
+		t.Fatalf("resolve.Resolve: %v", err)
+	}
+	return Gen(prog, Capabilities{})
+}
+
+// countDispatchMatchShape counts the JEq→multiok / JNE pairs of the
+// multi-value dispatch tail in an instruction stream.
+func countDispatchMatchShape(insns asm.Instructions) (jeqToMultiok, landings int) {
+	for _, ins := range insns {
+		if ins.OpCode.JumpOp() == asm.JEq && strings.HasPrefix(ins.Reference(), "dsl_altdisp_multiok_") {
+			jeqToMultiok++
+		}
+		if strings.HasPrefix(ins.Symbol(), "dsl_altdisp_multiok_") {
+			landings++
+		}
+	}
+	return
+}
+
+// TestGenSelfLoopMultiValueDispatch pins the bpf_loop self-dispatch
+// peek (chainFieldPeek) with AltValues: a `foo+` chain whose self-
+// dispatch const carries an alternate value must emit the JEq→multiok
+// chain inside the callback subprogram, not just in Main.
+func TestGenSelfLoopMultiValueDispatch(t *testing.T) {
+	out, err := genMultiValueVocab(t, `
+const bit<16> KUNAI_FOO_ETH_ETHERTYPE = 0x1234;
+const bit<16> KUNAI_FOO_FOO_KIND = 1;
+const bit<16> KUNAI_FOO_FOO_KIND_ALT = 2;
+`, "eth/foo+")
+	if err != nil {
+		t.Fatalf("Gen: %v", err)
+	}
+	if len(out.Callbacks) == 0 {
+		t.Fatal("expected a bpf_loop callback subprogram for foo+")
+	}
+	jeq, landings := countDispatchMatchShape(out.Callbacks)
+	if jeq == 0 || landings == 0 {
+		t.Errorf("callback stream: JEq-to-multiok = %d, landings = %d; want both >= 1", jeq, landings)
+	}
+}
+
+// TestGenRejectsHighBitDispatchValue pins the immediate-range guard:
+// a dispatch value whose byte-swapped form exceeds MaxInt32 (0x80
+// over a 4-byte field swaps to 0x80000000) must fail codegen loudly
+// instead of emitting a sign-extended compare that can never match.
+func TestGenRejectsHighBitDispatchValue(t *testing.T) {
+	fsys := fstest.MapFS{
+		"vocab/bar.p4": &fstest.MapFile{Data: []byte(`
+header bar_h { bit<32> tag; }
+parser BarParser(packet_in pkt, out bar_h hdr) {
+    state start { pkt.extract(hdr); transition accept; }
+}
+`)},
+		"vocab/foo.p4": &fstest.MapFile{Data: []byte(`
+header foo_h { bit<16> kind; }
+const bit<32> KUNAI_FOO_BAR_TAG = 0x80;
+parser FooParser(packet_in pkt, out foo_h hdr) {
+    state start { pkt.extract(hdr); transition accept; }
+}
+`)},
+	}
+	specs, err := vocab.Load(fsys, "vocab")
+	if err != nil {
+		t.Fatalf("vocab.Load: %v", err)
+	}
+	f, err := parser.Parse("bar/foo", "", nil)
+	if err != nil {
+		t.Fatalf("parser.Parse: %v", err)
+	}
+	prog, err := resolve.Resolve(f, specs, nil)
+	if err != nil {
+		t.Fatalf("resolve.Resolve: %v", err)
+	}
+	if _, err := Gen(prog, Capabilities{}); err == nil || !strings.Contains(err.Error(), "byte-swaps") {
+		t.Errorf("expected immediate-range error, got %v", err)
+	}
+}

--- a/pkg/kunai/dsltest/builders.go
+++ b/pkg/kunai/dsltest/builders.go
@@ -520,6 +520,13 @@ func BuildSRv6(t testing.TB, opts SRv6Opts) []byte {
 // `extract; transition accept` so this exercises dispatch + extract;
 // inner Ethernet support is not declared in the vocab.
 func BuildEthIPv4UDPVXLAN(t testing.TB, vni uint32) []byte {
+	return BuildEthIPv4UDPVXLANPort(t, vni, 4789)
+}
+
+// BuildEthIPv4UDPVXLANPort is BuildEthIPv4UDPVXLAN with an explicit
+// outer UDP destination port, for the dual-port dispatch tests (IANA
+// 4789 vs the Linux legacy 8472 that Cilium / flannel default to).
+func BuildEthIPv4UDPVXLANPort(t testing.TB, vni uint32, dport uint16) []byte {
 	t.Helper()
 	d := Defaults()
 	eth := &layers.Ethernet{SrcMAC: d.SrcMAC, DstMAC: d.DstMAC, EthernetType: layers.EthernetTypeIPv4}
@@ -529,7 +536,7 @@ func BuildEthIPv4UDPVXLAN(t testing.TB, vni uint32) []byte {
 		DstIP:    d.DstIP.To4(),
 		Protocol: layers.IPProtocolUDP,
 	}
-	udp := &layers.UDP{SrcPort: 12345, DstPort: 4789}
+	udp := &layers.UDP{SrcPort: 12345, DstPort: layers.UDPPort(dport)}
 	_ = udp.SetNetworkLayerForChecksum(v4)
 	vx := &layers.VXLAN{ValidIDFlag: true, VNI: vni}
 	buf := gopacket.NewSerializeBuffer()

--- a/pkg/kunai/dsltest/runner_test.go
+++ b/pkg/kunai/dsltest/runner_test.go
@@ -612,7 +612,9 @@ func TestQinQLeaf(t *testing.T) {
 func TestVXLANDispatch(t *testing.T) {
 	r := New(t, "eth/ipv4/udp/vxlan")
 	r.MustMatch(t, BuildEthIPv4UDPVXLAN(t, 0x010203), "vxlan dispatch + extract")
+	r.MustMatch(t, BuildEthIPv4UDPVXLANPort(t, 0x010203, 8472), "vxlan over the Linux legacy port 8472 (AltValues dispatch) must also match")
 	r.MustReject(t, BuildEthIPv4UDP(t, 12345, 53, []byte("dns")), "non-vxlan UDP (dport=53) must reject vxlan filter")
+	r.MustReject(t, BuildEthIPv4UDPVXLANPort(t, 0x010203, 4790), "off-by-one port 4790 must reject both dispatch values")
 }
 
 // TestGeneveDispatch exercises the geneve vocab: UDP dport 6081 +

--- a/pkg/kunai/protocols/vxlan.p4
+++ b/pkg/kunai/protocols/vxlan.p4
@@ -7,8 +7,12 @@ header vxlan_h {
     bit<8>  reserved2;
 }
 
-// Dispatch from UDP via the IANA-assigned destination port.
+// Dispatch from UDP via the IANA-assigned destination port, plus the
+// Linux kernel's pre-IANA default 8472 that Cilium and flannel still
+// ship as their VXLAN default. The _ALT suffix folds the second value
+// into the same dispatch edge (vocab/loader.go mergeAltDispatchConsts).
 const bit<16> KUNAI_VXLAN_UDP_DPORT = 4789;
+const bit<16> KUNAI_VXLAN_UDP_DPORT_ALT = 8472;
 
 parser VxlanParser(packet_in pkt, out vxlan_h hdr) {
     state start {

--- a/pkg/kunai/protocols/vxlan.p4
+++ b/pkg/kunai/protocols/vxlan.p4
@@ -9,10 +9,11 @@ header vxlan_h {
 
 // Dispatch from UDP via the IANA-assigned destination port, plus the
 // Linux kernel's pre-IANA default 8472 that Cilium and flannel still
-// ship as their VXLAN default. The _ALT suffix folds the second value
-// into the same dispatch edge (vocab/loader.go mergeAltDispatchConsts).
+// ship as their VXLAN default. The _ALT_<NAME> suffix folds the extra
+// value into the same dispatch edge (vocab/loader.go
+// mergeAltDispatchConsts); the name documents where it comes from.
 const bit<16> KUNAI_VXLAN_UDP_DPORT = 4789;
-const bit<16> KUNAI_VXLAN_UDP_DPORT_ALT = 8472;
+const bit<16> KUNAI_VXLAN_UDP_DPORT_ALT_LINUX_LEGACY = 8472;
 
 parser VxlanParser(packet_in pkt, out vxlan_h hdr) {
     state start {

--- a/pkg/kunai/resolve/layer.go
+++ b/pkg/kunai/resolve/layer.go
@@ -2,6 +2,7 @@ package resolve
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/takehaya/bpf-ninja/pkg/kunai/ast"
@@ -205,7 +206,8 @@ func selectAltParentDispatch(spec *vocab.ProtocolSpec, alts []*ir.LayerInstance,
 }
 
 func altDispatchAgrees(a, b *vocab.DispatchConst) bool {
-	return a.Type == b.Type && a.FieldName == b.FieldName && a.Value == b.Value && a.Bits == b.Bits
+	return a.Type == b.Type && a.FieldName == b.FieldName && a.Value == b.Value && a.Bits == b.Bits &&
+		slices.Equal(a.AltValues, b.AltValues)
 }
 
 func autoKey(proto string, index int) string {

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -236,6 +236,11 @@ var (
 	reSanityName = regexp.MustCompile(`^(?:[A-Z0-9_]+_)?SANITY_[A-Z0-9_]+$`)
 	reChainEnd   = regexp.MustCompile(`^CHAIN_END_([A-Z0-9_]+)$`)
 	reField      = regexp.MustCompile(`^([A-Z0-9]+)_([A-Z0-9_]+)$`)
+	// reAltDispatch matches the lowercase FieldName a `..._ALT[n]`
+	// dispatch const parses into ("dport_alt", "dport_alt2", ...);
+	// m[1] is the base field the alt value folds into. `_alt` is
+	// therefore a reserved suffix in dispatch-field position.
+	reAltDispatch = regexp.MustCompile(`^([a-z0-9_]+)_alt[0-9]*$`)
 )
 
 // classifyResult bundles the per-protocol metadata classifyConsts
@@ -475,7 +480,57 @@ func classifyConsts(cs []*p4lite.Const, protoName, source string, knownProtos ma
 		}
 		return classifyResult{}, fmt.Errorf("%s: const %q does not match <SELF>_{<PARENT>_<FIELD>|MAX_DEPTH|CHAIN_END_<FIELD>} or KUNAI_<SELF>_{<PARENT>_<FIELD>|<PARENT>_NO_CHECK}", source, c.Name)
 	}
+	if err := mergeAltDispatchConsts(&res, source); err != nil {
+		return classifyResult{}, err
+	}
 	return res, nil
+}
+
+// mergeAltDispatchConsts folds `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]`
+// consts into the AltValues of their base `KUNAI_<SELF>_<PARENT>_<FIELD>`
+// const, so one dispatch edge can accept several field values (e.g.
+// VXLAN over the IANA port 4789 and the Linux legacy port 8472).
+// classifyKunaiConst has already parsed the alt const as a regular
+// field dispatch whose FieldName carries the `_alt[n]` suffix; here we
+// strip the suffix, locate the base const with the same parent and
+// field, and move the value across. An alt without a base, a width
+// mismatch, or a value already accepted on the edge is a load error.
+func mergeAltDispatchConsts(res *classifyResult, source string) error {
+	var alts []*DispatchConst
+	kept := res.Consts[:0]
+	for i := range res.Consts {
+		c := res.Consts[i]
+		if c.Type == DispatchField {
+			if m := reAltDispatch.FindStringSubmatch(c.FieldName); m != nil {
+				c.FieldName = m[1]
+				alts = append(alts, &c)
+				continue
+			}
+		}
+		kept = append(kept, c)
+	}
+	res.Consts = kept
+	for _, a := range alts {
+		var base *DispatchConst
+		for i := range res.Consts {
+			c := &res.Consts[i]
+			if c.Type == DispatchField && c.Parent == a.Parent && c.FieldName == a.FieldName {
+				base = c
+				break
+			}
+		}
+		if base == nil {
+			return fmt.Errorf("%s: alt dispatch const %q has no base KUNAI_ const for parent %q field %q to fold into", source, a.Name, a.Parent, a.FieldName)
+		}
+		if base.Bits != a.Bits {
+			return fmt.Errorf("%s: alt dispatch const %q is bit<%d> but base %q is bit<%d>", source, a.Name, a.Bits, base.Name, base.Bits)
+		}
+		if a.Value == base.Value || slices.Contains(base.AltValues, a.Value) {
+			return fmt.Errorf("%s: alt dispatch const %q duplicates value %d already accepted on edge %q", source, a.Name, a.Value, base.Name)
+		}
+		base.AltValues = append(base.AltValues, a.Value)
+	}
+	return nil
 }
 
 // isOptFlagKey reports whether the suffix after "<SELF>_" names one of

--- a/pkg/kunai/vocab/loader.go
+++ b/pkg/kunai/vocab/loader.go
@@ -236,11 +236,16 @@ var (
 	reSanityName = regexp.MustCompile(`^(?:[A-Z0-9_]+_)?SANITY_[A-Z0-9_]+$`)
 	reChainEnd   = regexp.MustCompile(`^CHAIN_END_([A-Z0-9_]+)$`)
 	reField      = regexp.MustCompile(`^([A-Z0-9]+)_([A-Z0-9_]+)$`)
-	// reAltDispatch matches the lowercase FieldName a `..._ALT[n]`
-	// dispatch const parses into ("dport_alt", "dport_alt2", ...);
-	// m[1] is the base field the alt value folds into. `_alt` is
-	// therefore a reserved suffix in dispatch-field position.
-	reAltDispatch = regexp.MustCompile(`^([a-z0-9_]+)_alt[0-9]*$`)
+	// reAltDispatch matches the lowercase FieldName a `..._ALT` or
+	// `..._ALT_<NAME>` dispatch const parses into ("dport_alt",
+	// "dport_alt_linux_legacy", ...); m[1] is the base field the alt
+	// value folds into, and <NAME> documents where the value comes
+	// from. `_alt` is therefore a reserved suffix in dispatch-field
+	// position. A numbered `_ALT<n>` shape is rejected with its own
+	// diagnostic (reAltNumbered) — a number cannot say what the value
+	// means, a name can.
+	reAltDispatch = regexp.MustCompile(`^(.+)_alt(?:_[a-z0-9][a-z0-9_]*)?$`)
+	reAltNumbered = regexp.MustCompile(`^.+_alt[0-9]+$`)
 )
 
 // classifyResult bundles the per-protocol metadata classifyConsts
@@ -486,10 +491,13 @@ func classifyConsts(cs []*p4lite.Const, protoName, source string, knownProtos ma
 	return res, nil
 }
 
-// mergeAltDispatchConsts folds `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]`
-// consts into the AltValues of their base `KUNAI_<SELF>_<PARENT>_<FIELD>`
-// const, so one dispatch edge can accept several field values (e.g.
-// VXLAN over the IANA port 4789 and the Linux legacy port 8472).
+// mergeAltDispatchConsts folds `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT` and
+// `..._ALT_<NAME>` consts into the AltValues of their base
+// `KUNAI_<SELF>_<PARENT>_<FIELD>` const, so one dispatch edge can
+// accept several field values (e.g. VXLAN over the IANA port 4789 and
+// the Linux legacy port 8472). <NAME> is purely documentary — it says
+// where the value comes from — and P4's identifier uniqueness keeps
+// alts apart; a numbered `_ALT<n>` is rejected in favor of a name.
 // classifyKunaiConst has already parsed the alt const as a regular
 // field dispatch whose FieldName carries the `_alt[n]` suffix; here we
 // strip the suffix, locate the base const with the same parent and
@@ -501,6 +509,9 @@ func mergeAltDispatchConsts(res *classifyResult, source string) error {
 	for i := range res.Consts {
 		c := res.Consts[i]
 		if c.Type == DispatchField {
+			if reAltNumbered.MatchString(c.FieldName) {
+				return fmt.Errorf("%s: alt dispatch const %q uses a numbered _ALT<n> suffix — name the value instead (_ALT_<NAME>, e.g. _ALT_LINUX_LEGACY) so the vocab says what it is", source, c.Name)
+			}
 			if m := reAltDispatch.FindStringSubmatch(c.FieldName); m != nil {
 				c.FieldName = m[1]
 				alts = append(alts, &c)

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -2666,3 +2666,84 @@ parser B(packet_in pkt, out bar_h h) { state start { pkt.extract(h); transition 
 		t.Errorf("expected 'no lowering for' diagnostic, got %v", err)
 	}
 }
+
+// TestLoadVxlanAltPort pins the bundled vxlan vocab's dual-port
+// dispatch: the Linux legacy port 8472 (Cilium / flannel default)
+// folds into KUNAI_VXLAN_UDP_DPORT's AltValues and the _ALT const
+// itself does not survive as a separate dispatch edge.
+func TestLoadVxlanAltPort(t *testing.T) {
+	vxlan := loadBundled(t)["vxlan"]
+	dc, ok := indexByName(vxlan.Consts)["KUNAI_VXLAN_UDP_DPORT"]
+	if !ok || dc.Value != 4789 {
+		t.Fatalf("KUNAI_VXLAN_UDP_DPORT = %+v", dc)
+	}
+	if len(dc.AltValues) != 1 || dc.AltValues[0] != 8472 {
+		t.Errorf("AltValues = %v, want [8472]", dc.AltValues)
+	}
+	if _, ok := indexByName(vxlan.Consts)["KUNAI_VXLAN_UDP_DPORT_ALT"]; ok {
+		t.Error("_ALT const must be folded into the base, not kept as its own edge")
+	}
+}
+
+// altVocabFS builds a two-protocol vocab where foo dispatches under
+// bar with the given const block, for the alt-dispatch error tests.
+func altVocabFS(consts string) fstest.MapFS {
+	return fstest.MapFS{
+		"vocab/bar.p4": &fstest.MapFile{Data: []byte(`
+header bar_h { bit<8> x; }
+parser B(packet_in pkt, out bar_h h) { state start { pkt.extract(h); transition accept; } }
+`)},
+		"vocab/foo.p4": &fstest.MapFile{Data: []byte(`
+header foo_h { bit<8> y; }
+` + consts + `
+parser F(packet_in pkt, out foo_h h) { state start { pkt.extract(h); transition accept; } }
+`)},
+	}
+}
+
+func TestLoadAltDispatchMerges(t *testing.T) {
+	specs, err := Load(altVocabFS(`
+const bit<8> KUNAI_FOO_BAR_X = 1;
+const bit<8> KUNAI_FOO_BAR_X_ALT = 2;
+const bit<8> KUNAI_FOO_BAR_X_ALT2 = 3;
+`), "vocab")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	dc := specs["foo"].SelectDispatchConst("bar")
+	if dc == nil || dc.Value != 1 {
+		t.Fatalf("SelectDispatchConst = %+v", dc)
+	}
+	if len(dc.AltValues) != 2 || dc.AltValues[0] != 2 || dc.AltValues[1] != 3 {
+		t.Errorf("AltValues = %v, want [2 3]", dc.AltValues)
+	}
+}
+
+func TestLoadAltDispatchWithoutBase(t *testing.T) {
+	_, err := Load(altVocabFS(`
+const bit<8> KUNAI_FOO_BAR_X_ALT = 2;
+`), "vocab")
+	if err == nil || !strings.Contains(err.Error(), "no base") {
+		t.Errorf("expected 'no base' error, got %v", err)
+	}
+}
+
+func TestLoadAltDispatchDuplicateValue(t *testing.T) {
+	_, err := Load(altVocabFS(`
+const bit<8> KUNAI_FOO_BAR_X = 1;
+const bit<8> KUNAI_FOO_BAR_X_ALT = 1;
+`), "vocab")
+	if err == nil || !strings.Contains(err.Error(), "duplicates value") {
+		t.Errorf("expected duplicate-value error, got %v", err)
+	}
+}
+
+func TestLoadAltDispatchBitsMismatch(t *testing.T) {
+	_, err := Load(altVocabFS(`
+const bit<8> KUNAI_FOO_BAR_X = 1;
+const bit<16> KUNAI_FOO_BAR_X_ALT = 2;
+`), "vocab")
+	if err == nil || !strings.Contains(err.Error(), "bit<") {
+		t.Errorf("expected width-mismatch error, got %v", err)
+	}
+}

--- a/pkg/kunai/vocab/loader_test.go
+++ b/pkg/kunai/vocab/loader_test.go
@@ -2680,8 +2680,8 @@ func TestLoadVxlanAltPort(t *testing.T) {
 	if len(dc.AltValues) != 1 || dc.AltValues[0] != 8472 {
 		t.Errorf("AltValues = %v, want [8472]", dc.AltValues)
 	}
-	if _, ok := indexByName(vxlan.Consts)["KUNAI_VXLAN_UDP_DPORT_ALT"]; ok {
-		t.Error("_ALT const must be folded into the base, not kept as its own edge")
+	if _, ok := indexByName(vxlan.Consts)["KUNAI_VXLAN_UDP_DPORT_ALT_LINUX_LEGACY"]; ok {
+		t.Error("_ALT_<NAME> const must be folded into the base, not kept as its own edge")
 	}
 }
 
@@ -2705,7 +2705,7 @@ func TestLoadAltDispatchMerges(t *testing.T) {
 	specs, err := Load(altVocabFS(`
 const bit<8> KUNAI_FOO_BAR_X = 1;
 const bit<8> KUNAI_FOO_BAR_X_ALT = 2;
-const bit<8> KUNAI_FOO_BAR_X_ALT2 = 3;
+const bit<8> KUNAI_FOO_BAR_X_ALT_VENDOR_B = 3;
 `), "vocab")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -2745,5 +2745,15 @@ const bit<16> KUNAI_FOO_BAR_X_ALT = 2;
 `), "vocab")
 	if err == nil || !strings.Contains(err.Error(), "bit<") {
 		t.Errorf("expected width-mismatch error, got %v", err)
+	}
+}
+
+func TestLoadAltDispatchRejectsNumberedSuffix(t *testing.T) {
+	_, err := Load(altVocabFS(`
+const bit<8> KUNAI_FOO_BAR_X = 1;
+const bit<8> KUNAI_FOO_BAR_X_ALT2 = 2;
+`), "vocab")
+	if err == nil || !strings.Contains(err.Error(), "_ALT_<NAME>") {
+		t.Errorf("expected numbered-suffix rejection pointing at _ALT_<NAME>, got %v", err)
 	}
 }

--- a/pkg/kunai/vocab/model.go
+++ b/pkg/kunai/vocab/model.go
@@ -470,6 +470,12 @@ type DispatchConst struct {
 	Bits      int    // width of the constant; Field only
 	Value     uint64 // integer value; Field only
 	Bool      bool   // truth value; NoCheck only (must be true to be valid)
+	// AltValues holds additional accepted values for the same dispatch
+	// edge, folded in from `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]`
+	// consts (e.g. VXLAN's IANA 4789 plus the Linux legacy 8472). The
+	// dispatch check passes when the field equals Value or any entry
+	// here. Field only; empty for the common single-value edge.
+	AltValues []uint64
 }
 
 // --- Parse state machine (within-protocol structure) ---


### PR DESCRIPTION
## Summary

A dispatch edge could only carry one accepted field value, so the bundled vxlan vocab (IANA dport 4789) could not follow VXLAN on the Linux legacy port 8472, which Cilium and flannel still ship as their default. A default-config Cilium overlay was therefore unreachable for any `udp/vxlan/...` chain.

This adds multi-value dispatch edges, declared entirely on the .p4 side:

- `KUNAI_<SELF>_<PARENT>_<FIELD>_ALT[n]` consts fold extra accepted values into the base const's `AltValues` at vocab load time (`mergeAltDispatchConsts`). An alt without a base const, a width mismatch, or a duplicate value is a load error. `_alt` becomes a reserved suffix in dispatch-field position.
- Codegen funnels every dispatch equality (fast path, bounded path, bpf_loop self-loop peek) through a shared `emitDispatchValueMatch`: single-value edges keep the historical one-JNE shape byte-identical, multi-value edges emit a JEq chain to a shared landing plus the usual JNE.
- `vxlan.p4` declares `KUNAI_VXLAN_UDP_DPORT_ALT = 8472` alongside 4789.

## Testing

- Loader unit tests: bundled vxlan AltValues pin, merge across `_ALT`/`_ALT2`, no-base / width-mismatch / duplicate-value load errors.
- dsltest (real BPF load + run): `eth/ipv4/udp/vxlan` matches on 4789 and 8472, rejects dport 53 and the off-by-one 4790.
- `go test ./...` green, `make p4c-check` green (p4c still parses vxlan.p4), golangci-lint clean on the touched packages.
- End-to-end: against a default-port (8472) Cilium 1.20.1 VXLAN overlay in a kind cluster, `eth/ipv4/udp/vxlan/eth/ipv4/icmp` on the node's `cil_from_netdev` captured exactly the inner ICMP of mixed ICMP+HTTP pod-to-pod traffic, encapsulated frames intact.

Note: `internal/program` TestArgFilter fails on my 7.2.0-rc2 box identically on origin/main, unrelated to this change.