### PR TITLE
feat(hook): add netfilter (BPF_PROG_TYPE_NETFILTER) hook adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This project was renamed from **xdp-ninja** (July 2026): the tool has outgrown XDP — it also observes tc-bpf programs, and more BPF hook points are planned. GitHub redirects the old repository URL, but the Go module path changed to `github.com/takehaya/bpf-ninja`, so `go install` / imports need the new path. Environment variables are now `BPF_NINJA_*` (the old `XDP_NINJA_*` names are no longer read).
 
-bpf-ninja captures packets at BPF hook points — XDP, tc-bpf, and cgroup-skb, with more planned. `tcpdump` runs below XDP and can't show what XDP or tc-bpf did to the packet, and cBPF filters can't walk into VXLAN / GTP / MPLS / SRv6 inner headers. Attach via fentry/fexit to a running XDP without modifying it, or `--mode xdp` for standalone capture on a netdev. Filters use the built-in DSL by default — chains like `eth/ipv4/udp/vxlan/eth/ipv4/tcp`. Plain tcpdump syntax via [cbpfc](https://github.com/cloudflare/cbpfc) is still accepted via `--cbpf`, kept for backwards compatibility and planned to retire once the DSL surface stabilises. Output is pcap (pcapng) to stdout.🥷
+bpf-ninja captures packets at BPF hook points — XDP, tc-bpf, cgroup-skb, and netfilter, with more planned. `tcpdump` runs below XDP and can't show what XDP or tc-bpf did to the packet, and cBPF filters can't walk into VXLAN / GTP / MPLS / SRv6 inner headers. Attach via fentry/fexit to a running XDP without modifying it, or `--mode xdp` for standalone capture on a netdev. Filters use the built-in DSL by default — chains like `eth/ipv4/udp/vxlan/eth/ipv4/tcp`. Plain tcpdump syntax via [cbpfc](https://github.com/cloudflare/cbpfc) is still accepted via `--cbpf`, kept for backwards compatibility and planned to retire once the DSL surface stabilises. Output is pcap (pcapng) to stdout.🥷
 
 ## Install
 
@@ -25,7 +25,7 @@ make build
 
 ## Modes
 
-`--mode` selects the capture point; the hook kind (XDP, TC clsact, cgroup-skb) is auto-detected from the target program's type:
+`--mode` selects the capture point; the hook kind (XDP, TC clsact, cgroup-skb, netfilter) is auto-detected from the target program's type:
 
 | Mode | Attach via | Existing program needed | Sees return action | Typical use |
 |---|---|---|---|---|
@@ -40,6 +40,7 @@ Supported hooks and how to name the target:
 | XDP | `-i <iface>` (interface's XDP) or `-p <progID>` | |
 | TC clsact | `-p <progID>` only (interface lookup for clsact is not yet wired) | |
 | cgroup-skb | `--cgroup <cgroup v2 path>` (enumerates attached programs) or `-p <progID>` | packet bytes start at the IP header — root DSL chains at `ipv4`/`ipv6`, pcap-ng is LINKTYPE_RAW |
+| netfilter | `-p <progID>` (kernel 6.4+, programs attached to NF_INET_* hooks via bpf_link) | packet bytes start at the IP header, same L3-start notes as cgroup-skb; exit-mode verdicts are `NF_DROP` / `NF_ACCEPT` |
 
 `entry`/`exit` are non-invasive: the target program is unmodified, attach is via BPF trampoline. `xdp` is the standalone path for "I just want to capture, there's nothing else here". `tc-entry`/`tc-exit` remain as deprecated aliases for `entry`/`exit`.
 
@@ -65,7 +66,7 @@ sudo bpf-ninja --cbpf -i eth0 "host 10.0.0.1 and tcp port 80" | tcpdump -n -r -
 # (output is sharded across per-CPU files; see "Sharded output" below)
 sudo bpf-ninja -i eth0 -w capture.pcap -c 100
 
-# Attach by BPF program ID — works for XDP, tc clsact, and cgroup-skb
+# Attach by BPF program ID — works for XDP, tc clsact, cgroup-skb, and netfilter
 # programs alike (the hook is auto-detected from the program type)
 sudo bpf-ninja -p 42 | tcpdump -n -r -
 
@@ -267,7 +268,7 @@ int parse_headers(struct xdp_md *ctx) {
 | `--cbpf` | Use the legacy tcpdump/cBPF syntax (compiled via cbpfc); default is the built-in DSL. Prints a deprecation notice when used. | all |
 | `--dsl-help` | Print the DSL grammar + bundled protocol catalogue and exit (no `-i`/`-p` required) | — |
 | `--dump-asm` | Print compiled eBPF asm and exit. Values: `filter` (kunai/cbpfc body only) \| `full` (wrapped program). No `-i`/`-p` required | — |
-| `--dump-hook` | Hook whose capabilities/prologue `--dump-asm` renders: `xdp` (default) \| `tc` \| `cgroup-skb` (offline compiles have no target program to auto-detect from) | — |
+| `--dump-hook` | Hook whose capabilities/prologue `--dump-asm` renders: `xdp` (default) \| `tc` \| `cgroup-skb` \| `netfilter` (offline compiles have no target program to auto-detect from) | — |
 | `--func` | Attach to a specific `__noinline` subfunction by BTF name | entry, exit |
 | `--list-funcs` | List available BTF functions in the target program and exit | entry, exit |
 | `--list-progs` | List tail call targets reachable from the target program and exit | entry, exit |
@@ -291,7 +292,7 @@ Common:
 
 Mode-specific:
 
-- **`--mode entry` / `exit`**: a target BPF program (XDP, tc clsact, or cgroup-skb) already loaded with BTF. With `-i`, an XDP program attached to the interface; tc targets go by `-p <progID>`; cgroup-skb targets by `--cgroup <path>` or `-p`.
+- **`--mode entry` / `exit`**: a target BPF program (XDP, tc clsact, cgroup-skb, or netfilter) already loaded with BTF. With `-i`, an XDP program attached to the interface; tc targets go by `-p <progID>`; cgroup-skb targets by `--cgroup <path>` or `-p`.
 - **`--mode xdp`**: no XDP attached to the interface (bpf-ninja becomes the XDP program).
 - **DSL with chain quantifier (`+`, `*`, `{n,m>4}`), parser-machine self-loop (variable-length headers like IPv6 ext / GTP options / SRv6 segments), or alternation (`(a|b)`)**: kernel 5.17+ (uses `bpf_loop` + bpf2bpf subprograms). Plain DSL chains and `--cbpf` filters work on 5.8+.
 

--- a/cmd/bpf-ninja/main.go
+++ b/cmd/bpf-ninja/main.go
@@ -112,7 +112,7 @@ var flags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "dump-hook",
-		Usage: "hook whose capabilities/prologue --dump-asm renders (no target program exists to auto-detect from): xdp | tc | cgroup-skb (default xdp; deprecated --mode tc-* aliases imply tc)",
+		Usage: "hook whose capabilities/prologue --dump-asm renders (no target program exists to auto-detect from): xdp | tc | cgroup-skb | netfilter (default xdp; deprecated --mode tc-* aliases imply tc)",
 	},
 	&cli.BoolFlag{
 		Name: "verbose", Aliases: []string{"v"},

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -22,9 +22,11 @@ sudo bpf-ninja -i veth0 "eth/ipv4/tcp[dport==443]"
 | `exit` | fexit trampoline | 必須 (BTF 付) | ○ (`XDP_PASS`/`TC_ACT_OK`/...) | 判断結果を観測する。`where action == XDP_DROP` 等で絞れる |
 | `xdp` | netdev に直接 attach | 不要 (既に attach されているとエラー) | n/a (常に `XDP_PASS`) | XDP が attach されていない netdev の standalone capture |
 
-hook 種別 (XDP / TC clsact / cgroup-skb) は指定不要です。ターゲットプログラムの型から自動判別されます。`-p <progID>` はどの対応型でも受け付け、`-i <iface>` は interface の XDP プログラムを引き、`--cgroup <path>` は cgroup v2 パスに attach された cgroup-skb プログラムを列挙します (BPF_PROG_QUERY、ingress + egress)。TC clsact filter (`tc filter add ... direction ingress/egress` で張ったもの) も fentry/fexit の対象にできますが、TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
+hook 種別 (XDP / TC clsact / cgroup-skb / netfilter) は指定不要です。ターゲットプログラムの型から自動判別されます。`-p <progID>` はどの対応型でも受け付け、`-i <iface>` は interface の XDP プログラムを引き、`--cgroup <path>` は cgroup v2 パスに attach された cgroup-skb プログラムを列挙します (BPF_PROG_QUERY、ingress + egress)。TC clsact filter (`tc filter add ... direction ingress/egress` で張ったもの) も fentry/fexit の対象にできますが、TC clsact qdisc の interface walk は未配線のため、target 指定は `-p <progID>` のみです。
 
 cgroup-skb ターゲットには注意点が 2 つあります。パケットは network header (L3) 始まりで Ethernet ヘッダを含まないため、DSL チェインは `ipv4/...` または `ipv6/...` を起点にします (`eth/...` は警告付きで誤 parse になります)。pcap-ng 出力も LINKTYPE_RAW になり、Wireshark / tcpdump はバージョン nibble から v4/v6 を自動判定します。
+
+netfilter ターゲット (BPF_PROG_TYPE_NETFILTER、カーネル 6.4+) も同じく L3 始まりで、cgroup-skb と同じ注意点が当てはまります。target 指定は `-p <progID>` のみで、exit mode の verdict は `where action == NF_DROP / NF_ACCEPT` で絞れます (カーネルが netfilter BPF の返り値をこの 2 値に制限しているため、これで全 verdict です)。
 
 旧 `--mode tc-entry` / `tc-exit` は `entry` / `exit` の deprecated alias として残っています (stderr に警告が出ます)。
 

--- a/docs/ja/dsl-usage.md
+++ b/docs/ja/dsl-usage.md
@@ -26,7 +26,7 @@ hook 種別 (XDP / TC clsact / cgroup-skb / netfilter) は指定不要です。�
 
 cgroup-skb ターゲットには注意点が 2 つあります。パケットは network header (L3) 始まりで Ethernet ヘッダを含まないため、DSL チェインは `ipv4/...` または `ipv6/...` を起点にします (`eth/...` は警告付きで誤 parse になります)。pcap-ng 出力も LINKTYPE_RAW になり、Wireshark / tcpdump はバージョン nibble から v4/v6 を自動判定します。
 
-netfilter ターゲット (BPF_PROG_TYPE_NETFILTER、カーネル 6.4+) も同じく L3 始まりで、cgroup-skb と同じ注意点が当てはまります。target 指定は `-p <progID>` のみで、exit mode の verdict は `where action == NF_DROP / NF_ACCEPT` で絞れます (カーネルが netfilter BPF の返り値をこの 2 値に制限しているため、これで全 verdict です)。
+netfilter ターゲット (BPF_PROG_TYPE_NETFILTER、カーネル 6.4+) も同じく L3 始まりで、cgroup-skb と同じ注意点が当てはまります。target 指定は `-p <progID>` のみで、exit mode の verdict は `where action == NF_DROP` または `where action == NF_ACCEPT` で絞れます (両方拾うなら `or` でつなぎます) (カーネルが netfilter BPF の返り値をこの 2 値に制限しているため、これで全 verdict です)。
 
 旧 `--mode tc-entry` / `tc-exit` は `entry` / `exit` の deprecated alias として残っています (stderr に警告が出ます)。
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -25,6 +25,7 @@ const (
 	KindXDP       Kind = "xdp"
 	KindTC        Kind = "tc"
 	KindCgroupSKB Kind = "cgroup-skb"
+	KindNetfilter Kind = "netfilter"
 )
 
 // Hook describes one attach-target kind.
@@ -65,7 +66,7 @@ type ActionName struct {
 
 // registry lists all supported hooks. Order defines the wording of
 // SupportedLabel (and therefore user-facing error messages).
-var registry = []*Hook{xdpHook, tcHook, cgroupSKBHook}
+var registry = []*Hook{xdpHook, tcHook, cgroupSKBHook, netfilterHook}
 
 // ByProgramType finds the hook covering pt. The single lookup replaces
 // the per-site `pt == XDP || pt == SchedCLS || ...` supported-type checks.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	cgskbhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/cgroupskb"
+	nfhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/netfilter"
 	tchost "github.com/takehaya/bpf-ninja/pkg/kunai/host/tc"
 	xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
 )
@@ -61,6 +62,7 @@ func TestHookActionsMatchHostVocab(t *testing.T) {
 		{KindXDP, xdphost.Actions, func(k string) string { return "xdp:" + strings.TrimPrefix(k, "XDP_") }},
 		{KindTC, tchost.Actions, func(k string) string { return "tc:" + k }},
 		{KindCgroupSKB, cgskbhost.Actions, func(k string) string { return "cgroup-skb:" + k }},
+		{KindNetfilter, nfhost.Actions, func(k string) string { return "netfilter:" + k }},
 	}
 	for _, c := range cases {
 		h, ok := ByName(c.hook)

--- a/internal/hook/netfilter.go
+++ b/internal/hook/netfilter.go
@@ -1,0 +1,91 @@
+package hook
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"github.com/google/gopacket/layers"
+	nfhost "github.com/takehaya/bpf-ninja/pkg/kunai/host/netfilter"
+)
+
+var netfilterHook = &Hook{
+	Kind:      KindNetfilter,
+	ProgTypes: []ebpf.ProgramType{ebpf.Netfilter},
+	// A netfilter program (kernel 6.4+) receives `struct bpf_nf_ctx *`
+	// at args[0] — not the sk_buff itself — so the prologue derefs
+	// ctx->skb first and then reuses the shared sk_buff window loads.
+	// The hook sits at the IP layer: skb->data points at the network
+	// (L3) header, hence LinkTypeRaw and the L3-start capabilities.
+	PacketPrologue: nfPacketPrologue,
+	EntryCaps:      nfhost.EntryCapabilities,
+	FexitCaps:      nfhost.FexitCapabilities,
+	// Mirrors nfhost.Actions; consistency is asserted by
+	// TestHookActionsMatchHostVocab. The verifier caps netfilter BPF
+	// returns to NF_DROP/NF_ACCEPT, so the table is complete.
+	Actions: []ActionName{
+		{Value: 0, Name: "netfilter:NF_DROP"},
+		{Value: 1, Name: "netfilter:NF_ACCEPT"},
+	},
+	LinkType: layers.LinkTypeRaw,
+}
+
+// nfPacketPrologue reads the packet window from a netfilter program's
+// `struct bpf_nf_ctx` context: one extra pointer hop (ctx->skb, offset
+// resolved from kernel BTF) in front of the same sk_buff data/len loads
+// the tc and cgroup-skb hooks use. R6 keeps the original ctx per the
+// PacketPrologue contract; R7 is used as the skb scratch (skb->len is
+// read before R7 is overwritten with skb->data).
+func nfPacketPrologue() (asm.Instructions, error) {
+	skbOff, err := nfCtxSkbOffset()
+	if err != nil {
+		return nil, fmt.Errorf("resolving struct bpf_nf_ctx offsets via BTF: %w", err)
+	}
+	dataOff, lenOff, err := skBuffPacketOffsets()
+	if err != nil {
+		return nil, fmt.Errorf("resolving struct sk_buff offsets via BTF: %w", err)
+	}
+	return append(tracingPrelude(),
+		asm.LoadMem(asm.R7, asm.R6, int16(skbOff), asm.DWord),  // R7 = ctx->skb
+		asm.LoadMem(asm.R9, asm.R7, int16(lenOff), asm.Word),   // R9 = skb->len
+		asm.LoadMem(asm.R7, asm.R7, int16(dataOff), asm.DWord), // R7 = skb->data
+		asm.Mov.Reg(asm.R8, asm.R7),
+		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + len
+	), nil
+}
+
+// nfCtxSkbOffset returns the kernel BTF byte offset of
+// `struct bpf_nf_ctx`'s `skb` member. The struct is two pointers today
+// (state, skb) but the offset is resolved from BTF like the sk_buff
+// members, so a future member insertion cannot silently skew the read.
+// Cached at first call, same rationale as skBuffPacketOffsets.
+func nfCtxSkbOffset() (uint32, error) {
+	nfCtxOnce.Do(func() {
+		spec, err := btf.LoadKernelSpec()
+		if err != nil {
+			nfCtxErr = fmt.Errorf("loading kernel BTF: %w", err)
+			return
+		}
+		var ctx *btf.Struct
+		if err := spec.TypeByName("bpf_nf_ctx", &ctx); err != nil {
+			nfCtxErr = fmt.Errorf("BTF type bpf_nf_ctx not found (netfilter BPF needs kernel 6.4+): %w", err)
+			return
+		}
+		for _, m := range ctx.Members {
+			if m.Name == "skb" {
+				nfCtxSkbOff = m.Offset.Bytes()
+				return
+			}
+		}
+		nfCtxErr = fmt.Errorf("BTF struct bpf_nf_ctx has no skb member")
+	})
+	return nfCtxSkbOff, nfCtxErr
+}
+
+var (
+	nfCtxOnce   sync.Once
+	nfCtxSkbOff uint32
+	nfCtxErr    error
+)

--- a/internal/hook/netfilter.go
+++ b/internal/hook/netfilter.go
@@ -34,25 +34,29 @@ var netfilterHook = &Hook{
 
 // nfPacketPrologue reads the packet window from a netfilter program's
 // `struct bpf_nf_ctx` context: one extra pointer hop (ctx->skb, offset
-// resolved from kernel BTF) in front of the same sk_buff data/len loads
-// the tc and cgroup-skb hooks use. R6 keeps the original ctx per the
-// PacketPrologue contract; R7 is used as the skb scratch (skb->len is
-// read before R7 is overwritten with skb->data).
+// resolved from kernel BTF) in front of the same sk_buff window loads
+// the tc and cgroup-skb hooks use. Like skbPacketPrologue the window
+// is clamped to the linear head `len - data_len`; see that function
+// for why. R6 keeps the original ctx per the PacketPrologue contract;
+// R7 is the skb scratch (len and data_len are read before R7 is
+// overwritten with skb->data).
 func nfPacketPrologue() (asm.Instructions, error) {
 	skbOff, err := nfCtxSkbOffset()
 	if err != nil {
 		return nil, fmt.Errorf("resolving struct bpf_nf_ctx offsets via BTF: %w", err)
 	}
-	dataOff, lenOff, err := skBuffPacketOffsets()
+	dataOff, lenOff, dataLenOff, err := skBuffPacketOffsets()
 	if err != nil {
 		return nil, fmt.Errorf("resolving struct sk_buff offsets via BTF: %w", err)
 	}
 	return append(tracingPrelude(),
-		asm.LoadMem(asm.R7, asm.R6, int16(skbOff), asm.DWord),  // R7 = ctx->skb
-		asm.LoadMem(asm.R9, asm.R7, int16(lenOff), asm.Word),   // R9 = skb->len
-		asm.LoadMem(asm.R7, asm.R7, int16(dataOff), asm.DWord), // R7 = skb->data
+		asm.LoadMem(asm.R7, asm.R6, int16(skbOff), asm.DWord),    // R7 = ctx->skb
+		asm.LoadMem(asm.R9, asm.R7, int16(lenOff), asm.Word),     // R9 = skb->len
+		asm.LoadMem(asm.R8, asm.R7, int16(dataLenOff), asm.Word), // R8 = skb->data_len
+		asm.Sub.Reg(asm.R9, asm.R8),                              // R9 = linear head length
+		asm.LoadMem(asm.R7, asm.R7, int16(dataOff), asm.DWord),   // R7 = skb->data
 		asm.Mov.Reg(asm.R8, asm.R7),
-		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + len
+		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + headlen
 	), nil
 }
 

--- a/internal/hook/skbuff_btf.go
+++ b/internal/hook/skbuff_btf.go
@@ -8,7 +8,11 @@ import (
 )
 
 // skBuffPacketOffsets returns the kernel BTF byte offsets of
-// `struct sk_buff`'s `data` (8B pointer) and `len` (4B u32) members.
+// `struct sk_buff`'s `data` (8B pointer), `len` (4B u32), and
+// `data_len` (4B u32) members. `len - data_len` is the linear head
+// length (skb_headlen()); the prologues clamp the packet window to it
+// because a GRO/GSO or fragmented skb keeps `data_len` bytes in frags
+// that a flat read from `data` must not cross.
 // tc clsact fexit/fentry programs receive a `struct sk_buff *` (the
 // kernel struct, NOT the BPF-rewritten `__sk_buff` view) at args[0],
 // so the linear-region read needs the actual member offsets — which
@@ -16,7 +20,7 @@ import (
 //
 // Cached at first call: BTF spec load + walk is on the order of
 // milliseconds, fine to amortise across all probes loaded in-process.
-func skBuffPacketOffsets() (data uint32, length uint32, err error) {
+func skBuffPacketOffsets() (data uint32, length uint32, dataLen uint32, err error) {
 	skBuffOnce.Do(func() {
 		var spec *btf.Spec
 		spec, skBuffErr = btf.LoadKernelSpec()
@@ -29,7 +33,7 @@ func skBuffPacketOffsets() (data uint32, length uint32, err error) {
 			skBuffErr = fmt.Errorf("BTF type sk_buff not found: %w", err)
 			return
 		}
-		var foundData, foundLen bool
+		var foundData, foundLen, foundDataLen bool
 		for _, m := range skb.Members {
 			switch m.Name {
 			case "data":
@@ -38,19 +42,23 @@ func skBuffPacketOffsets() (data uint32, length uint32, err error) {
 			case "len":
 				skBuffLenOff = m.Offset.Bytes()
 				foundLen = true
+			case "data_len":
+				skBuffDataLenOff = m.Offset.Bytes()
+				foundDataLen = true
 			}
 		}
-		if !foundData || !foundLen {
-			skBuffErr = fmt.Errorf("BTF struct sk_buff missing data or len member (data=%v len=%v)", foundData, foundLen)
+		if !foundData || !foundLen || !foundDataLen {
+			skBuffErr = fmt.Errorf("BTF struct sk_buff missing data, len, or data_len member (data=%v len=%v data_len=%v)", foundData, foundLen, foundDataLen)
 			return
 		}
 	})
-	return skBuffDataOff, skBuffLenOff, skBuffErr
+	return skBuffDataOff, skBuffLenOff, skBuffDataLenOff, skBuffErr
 }
 
 var (
-	skBuffOnce    sync.Once
-	skBuffDataOff uint32
-	skBuffLenOff  uint32
-	skBuffErr     error
+	skBuffOnce       sync.Once
+	skBuffDataOff    uint32
+	skBuffLenOff     uint32
+	skBuffDataLenOff uint32
+	skBuffErr        error
 )

--- a/internal/hook/skbuff_btf_test.go
+++ b/internal/hook/skbuff_btf_test.go
@@ -10,7 +10,7 @@ import (
 // wrap rather than fail loudly.
 func TestSkBuffPacketOffsetsResolvesValidOffsets(t *testing.T) {
 	t.Helper()
-	dataOff, lenOff, err := skBuffPacketOffsets()
+	dataOff, lenOff, dataLenOff, err := skBuffPacketOffsets()
 	if err != nil {
 		t.Skipf("kernel BTF not available (skBuff resolve failed): %v", err)
 	}
@@ -27,6 +27,12 @@ func TestSkBuffPacketOffsetsResolvesValidOffsets(t *testing.T) {
 	if lenOff > int16Max {
 		t.Errorf("len offset %d exceeds int16 LDX immediate range", lenOff)
 	}
+	if dataLenOff == 0 {
+		t.Errorf("data_len offset = 0; expected non-zero member offset in struct sk_buff")
+	}
+	if dataLenOff > int16Max {
+		t.Errorf("data_len offset %d exceeds int16 LDX immediate range", dataLenOff)
+	}
 }
 
 // TestSkBuffPacketOffsetsCachesResult pins the sync.Once cache: two
@@ -36,12 +42,12 @@ func TestSkBuffPacketOffsetsResolvesValidOffsets(t *testing.T) {
 // direct equality compare is the right check.
 func TestSkBuffPacketOffsetsCachesResult(t *testing.T) {
 	t.Helper()
-	d1, l1, err1 := skBuffPacketOffsets()
-	d2, l2, err2 := skBuffPacketOffsets()
+	d1, l1, dl1, err1 := skBuffPacketOffsets()
+	d2, l2, dl2, err2 := skBuffPacketOffsets()
 	if err1 != err2 {
 		t.Errorf("two calls returned different errors (cache not sticky): %v vs %v", err1, err2)
 	}
-	if d1 != d2 || l1 != l2 {
-		t.Errorf("offsets differ across calls: (%d,%d) vs (%d,%d) — cache not working", d1, l1, d2, l2)
+	if d1 != d2 || l1 != l2 || dl1 != dl2 {
+		t.Errorf("offsets differ across calls: (%d,%d,%d) vs (%d,%d,%d) — cache not working", d1, l1, dl1, d2, l2, dl2)
 	}
 }

--- a/internal/hook/tc.go
+++ b/internal/hook/tc.go
@@ -39,16 +39,23 @@ var tcHook = &Hook{
 // struct sk_buff * (the kernel struct, NOT the BPF-rewritten __sk_buff
 // view — that rewrite does not fire in tracing context). Member offsets
 // drift across kernel versions, so they are resolved from kernel BTF at
-// runtime. sk_buff has no data_end member; it is computed as data + len.
+// runtime. sk_buff has no data_end member; it is computed as data plus
+// the LINEAR head length `len - data_len` (skb_headlen()), not the
+// total `len`: a GRO/GSO or fragmented skb keeps `data_len` bytes in
+// frags, and a flat probe_read from `data` past the head would copy
+// unrelated kernel memory into the capture. The window (and therefore
+// caplen) is clamped to the head; frag bytes are not captured.
 func skbPacketPrologue() (asm.Instructions, error) {
-	dataOff, lenOff, err := skBuffPacketOffsets()
+	dataOff, lenOff, dataLenOff, err := skBuffPacketOffsets()
 	if err != nil {
 		return nil, fmt.Errorf("resolving struct sk_buff offsets via BTF: %w", err)
 	}
 	return append(tracingPrelude(),
-		asm.LoadMem(asm.R7, asm.R6, int16(dataOff), asm.DWord), // R7 = skb->data
-		asm.LoadMem(asm.R9, asm.R6, int16(lenOff), asm.Word),   // R9 = skb->len
+		asm.LoadMem(asm.R7, asm.R6, int16(dataOff), asm.DWord),   // R7 = skb->data
+		asm.LoadMem(asm.R9, asm.R6, int16(lenOff), asm.Word),     // R9 = skb->len
+		asm.LoadMem(asm.R8, asm.R6, int16(dataLenOff), asm.Word), // R8 = skb->data_len
+		asm.Sub.Reg(asm.R9, asm.R8),                              // R9 = linear head length
 		asm.Mov.Reg(asm.R8, asm.R7),
-		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + len
+		asm.Add.Reg(asm.R8, asm.R9), // R8 = data + headlen
 	), nil
 }

--- a/internal/program/linear_head_datapath_test.go
+++ b/internal/program/linear_head_datapath_test.go
@@ -1,0 +1,217 @@
+package program
+
+// Real-datapath confirmation of the linear-head clamp in the skb
+// prologues: on modern kernels (5.19+) tcp_sendmsg places the payload
+// entirely in page frags, so every bulk-TCP skb a cgroup-skb egress
+// program sees is non-linear (skb->data_len > 0). Before the clamp the
+// capture window ended at data + skb->len and the copied "payload"
+// bytes came from unrelated kernel memory past the linear head; with
+// the clamp the window ends at data + (len - data_len), so those
+// records carry the L3/L4 headers and nothing else.
+//
+// The test sends a known 0xA5 byte pattern over loopback TCP inside a
+// scratch cgroup with a pass-all cgroup-skb egress program attached and
+// captures with a dport filter. Assertions:
+//   (1) at least one record's IP total length exceeds its caplen,
+//       proving a non-linear skb was actually exercised (guard against
+//       the test silently passing on a linear-only path), and
+//   (2) every captured byte after the TCP header equals the pattern.
+// On the unclamped code (2) fails with overwhelming probability: the
+// bytes past the head are whatever the kernel heap held.
+//
+// Root + cgroup v2 required; skipped otherwise. Run via make test-bpf
+// or: sudo -E go test ./internal/program -run TestLinearHeadClamp -v
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/takehaya/bpf-ninja/internal/capture/fastrb"
+	"github.com/takehaya/bpf-ninja/internal/testutil"
+)
+
+const cgroupSKBEgressPassSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+SEC("cgroup_skb/egress")
+int cgroup_skb_egress_pass_test(struct __sk_buff *skb) { return 1; }
+char _license[] SEC("license") = "GPL";
+`
+
+// moveSelfToCgroup writes the test process into path's cgroup.procs and
+// returns a restore function that moves it back where it came from.
+func moveSelfToCgroup(t *testing.T, path string) func() {
+	t.Helper()
+	raw, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		t.Fatalf("reading /proc/self/cgroup: %v", err)
+	}
+	// "0::/some/path" on cgroup v2.
+	orig := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(raw)), "0::"))
+	pid := []byte(fmt.Sprintf("%d", os.Getpid()))
+	if err := os.WriteFile(path+"/cgroup.procs", pid, 0); err != nil {
+		t.Fatalf("moving self into %s: %v", path, err)
+	}
+	return func() {
+		_ = os.WriteFile("/sys/fs/cgroup"+orig+"/cgroup.procs", pid, 0)
+	}
+}
+
+func TestLinearHeadClampAtCgroupSKB(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	cgPath := fmt.Sprintf("/sys/fs/cgroup/bpfninja-linear-%d", os.Getpid())
+	if err := os.Mkdir(cgPath, 0o755); err != nil {
+		t.Skipf("cgroup v2 root not writable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(cgPath) })
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, cgroupSKBEgressPassSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"cgroup_skb_egress_pass_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading cgroup-skb egress program: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Prog.Close() })
+
+	lnk, err := link.AttachCgroup(link.CgroupOptions{
+		Path: cgPath, Attach: ebpf.AttachCGroupInetEgress, Program: objs.Prog,
+	})
+	if err != nil {
+		t.Fatalf("attaching to cgroup: %v", err)
+	}
+	t.Cleanup(func() { _ = lnk.Close() })
+
+	// TCP server on loopback; the observer filter keys on its port so
+	// only the client-to-server data direction is captured.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	probe := loadProbeOrFail(t, objs.Prog, "cgroup_skb_egress_pass_test",
+		fmt.Sprintf("ipv4/tcp[dport==%d]", port), false, true)
+	_ = probe
+
+	// Bulk transfer with a fixed pattern. 256 KiB guarantees GSO-sized
+	// non-linear skbs on lo (TSO is on by default there).
+	const pattern = 0xA5
+	payload := make([]byte, 256<<10)
+	for i := range payload {
+		payload[i] = pattern
+	}
+	done := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		buf := make([]byte, 64<<10)
+		for {
+			if _, err := conn.Read(buf); err != nil {
+				done <- nil
+				return
+			}
+		}
+	}()
+
+	restore := moveSelfToCgroup(t, cgPath)
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		restore()
+		t.Fatalf("dial: %v", err)
+	}
+	if _, err := conn.Write(payload); err != nil {
+		restore()
+		t.Fatalf("write: %v", err)
+	}
+	_ = conn.Close()
+	restore()
+	<-done
+
+	// Drain and check every captured record.
+	innerSize := int(shardRingbufSize(RingbufSize, runtime.NumCPU()))
+	readers := make([]*fastrb.Reader, len(probe.InnerMaps))
+	for i, m := range probe.InnerMaps {
+		rd, err := fastrb.New(m.FD(), innerSize)
+		if err != nil {
+			t.Fatalf("fastrb on shard %d: %v", i, err)
+		}
+		readers[i] = rd
+	}
+	defer func() {
+		for _, rd := range readers {
+			_ = rd.Close()
+		}
+	}()
+
+	var records, nonLinear, badBytes int
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		for _, rd := range readers {
+			rd.ReadBatch(func(rec []byte) {
+				// The ringbuf slot is fixed-size (metadata + snaplen, a
+				// verifier constraint); the valid packet length is the
+				// caplen field at metadata offset 14.
+				if len(rec) < metadataSize {
+					return
+				}
+				caplen := int(binary.LittleEndian.Uint16(rec[14:16]))
+				if caplen < 20 || metadataSize+caplen > len(rec) {
+					return
+				}
+				pkt := rec[metadataSize : metadataSize+caplen] // raw IP, L3 start
+				records++
+				ihl := int(pkt[0]&0x0f) * 4
+				totLen := int(binary.BigEndian.Uint16(pkt[2:4]))
+				if totLen > caplen {
+					nonLinear++ // packet longer than the clamped window
+				}
+				if len(pkt) < ihl+20 {
+					return
+				}
+				doff := int(pkt[ihl+12]>>4) * 4
+				for _, b := range pkt[min(ihl+doff, len(pkt)):] {
+					if b != pattern {
+						badBytes++
+					}
+				}
+			})
+		}
+		if records > 0 && time.Now().After(deadline.Add(-1500*time.Millisecond)) {
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if records == 0 {
+		t.Fatal("no packets captured; cgroup egress path not exercised")
+	}
+	if nonLinear == 0 {
+		t.Fatal("no record with IP total length beyond the capture window; the non-linear skb case was not exercised")
+	}
+	if badBytes != 0 {
+		t.Fatalf("%d captured payload bytes differ from the sent pattern across %d records; the capture window read past the linear head", badBytes, records)
+	}
+	t.Logf("records=%d nonLinear=%d (all post-header bytes match the pattern)", records, nonLinear)
+}

--- a/internal/program/linear_head_datapath_test.go
+++ b/internal/program/linear_head_datapath_test.go
@@ -12,9 +12,11 @@ package program
 // The test sends a known 0xA5 byte pattern over loopback TCP inside a
 // scratch cgroup with a pass-all cgroup-skb egress program attached and
 // captures with a dport filter. Assertions:
-//   (1) at least one record's IP total length exceeds its caplen,
-//       proving a non-linear skb was actually exercised (guard against
-//       the test silently passing on a linear-only path), and
+//   (1) at least one record's IP total length exceeds its caplen
+//       while caplen is below the snaplen limit, proving the window
+//       was cut by the head clamp and not by snaplen, i.e. a
+//       non-linear skb was actually exercised (guard against the test
+//       silently passing on a linear-only path), and
 //   (2) every captured byte after the TCP header equals the pattern.
 // On the unclamped code (2) fails with overwhelming probability: the
 // bytes past the head are whatever the kernel heap held.
@@ -181,8 +183,12 @@ func TestLinearHeadClampAtCgroupSKB(t *testing.T) {
 				records++
 				ihl := int(pkt[0]&0x0f) * 4
 				totLen := int(binary.BigEndian.Uint16(pkt[2:4]))
-				if totLen > caplen {
-					nonLinear++ // packet longer than the clamped window
+				// caplen == DefaultCapLen would mean the snaplen limit
+				// cut the record, which a fully linear GSO packet also
+				// produces; only a window shorter than both the packet
+				// and the snaplen proves the head clamp fired.
+				if totLen > caplen && caplen < DefaultCapLen {
+					nonLinear++
 				}
 				if len(pkt) < ihl+20 {
 					return

--- a/internal/program/load_dsl_test.go
+++ b/internal/program/load_dsl_test.go
@@ -292,3 +292,37 @@ func TestBpfEntryWithDSLFilterCgroupSKB(t *testing.T) {
 func TestBpfExitWithDSLFilterCgroupSKB(t *testing.T) {
 	runFilterMatrix(t, loadDummyCgroupSKB(t), cgroupSKBFuncName, dslCgroupSKBExitExprs, true, true)
 }
+
+// dslNetfilterEntryExprs is the netfilter fentry-side DSL matrix. Like
+// cgroup-skb the packet window starts at the network header (chains
+// root at ipv4/ipv6); the context differs — the prologue derefs
+// bpf_nf_ctx->skb before the shared sk_buff window loads — so the
+// matrix re-pins the same L3-rooted shapes on that prologue, including
+// a parser-machine (bpf_loop) path and an option-walk predicate.
+var dslNetfilterEntryExprs = []string{
+	"ipv4/tcp",
+	"ipv4/udp",
+	"ipv6/tcp",
+	"ipv4/tcp[dport==443]",
+	"ipv4/tcp where tcp.dport == 443",
+	"ipv4/tcp capture headers+64",
+	"ipv4/udp/gtp/ipv4/tcp",
+	"ipv6/srv6/tcp",
+	"ipv4/tcp where tcp.options.MSS.value == 1460",
+}
+
+// dslNetfilterExitExprs covers the netfilter fexit-side action atoms
+// (NF_DROP=0 / NF_ACCEPT=1).
+var dslNetfilterExitExprs = []string{
+	"ipv4/tcp",
+	"ipv4/tcp where action == NF_DROP",
+	"ipv4/tcp where action == NF_ACCEPT or action == NF_DROP",
+}
+
+func TestBpfEntryWithDSLFilterNetfilter(t *testing.T) {
+	runFilterMatrix(t, loadDummyNetfilter(t), netfilterFuncName, dslNetfilterEntryExprs, false, true)
+}
+
+func TestBpfExitWithDSLFilterNetfilter(t *testing.T) {
+	runFilterMatrix(t, loadDummyNetfilter(t), netfilterFuncName, dslNetfilterExitExprs, true, true)
+}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -573,10 +573,18 @@ func runFilter(filter asm.Instructions, scratchFD, scanLen int) asm.Instructions
 		asm.JEq.Imm(asm.R0, 0, "exit"),
 		asm.StoreMem(asm.R10, -24, asm.R0, asm.DWord),
 
-		// ヘッダコピー: bpf_probe_read_kernel(scratch, scanLen, data)
+		// ヘッダコピー: bpf_probe_read_kernel(scratch, min(pkt_len, scanLen), data)。
+		// コピー長を R9 (線形ヘッド長) でもクランプする。固定 scanLen の
+		// ままだとヘッドが scanLen より短い skb で先の kernel メモリを読み、
+		// 読み先が unmapped だと helper が失敗して scratch 全体が
+		// ゼロ化され、本物のヘッダまで消えて filter が false negative
+		// になる。probe_read_kernel は size 0 も許容する
+		// (ARG_CONST_SIZE_OR_ZERO) ので下限のガードは不要。
 		asm.Mov.Reg(asm.R1, asm.R0),
+		asm.Mov.Reg(asm.R2, asm.R9),
+		asm.JLE.Imm(asm.R2, int32(scanLen), "copy_len_ok"),
 		asm.Mov.Imm(asm.R2, int32(scanLen)),
-		asm.Mov.Reg(asm.R3, asm.R7),
+		asm.Mov.Reg(asm.R3, asm.R7).WithSymbol("copy_len_ok"),
 		asm.FnProbeReadKernel.Call(),
 
 		// R0 = scratch 先頭, R1 = scratch + min(pkt_len, scanLen)

--- a/internal/program/testutil_test.go
+++ b/internal/program/testutil_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 	"github.com/takehaya/bpf-ninja/internal/capture"
 	"github.com/takehaya/bpf-ninja/internal/filter"
 	"github.com/takehaya/bpf-ninja/internal/testutil"
@@ -312,4 +313,54 @@ func loadProbeOrFail(t *testing.T, xdpProg *ebpf.Program, funcName, filterExpr s
 	}
 	t.Cleanup(func() { _ = probe.Close() })
 	return probe
+}
+
+const netfilterFuncName = "netfilter_pass_test"
+
+// struct bpf_nf_ctx must be a REAL struct definition (not a forward
+// declaration): the tracing trampoline types the observer's args[0]
+// by resolving the target BTF's ctx type name against the kernel's
+// ctx_convert table, and a FWD kind fails the struct check — args[0]
+// then degrades to an untyped scalar and the prologue's ctx->skb read
+// is rejected. Mirrors real netfilter programs, which compile against
+// vmlinux.h and carry the full definition.
+const netfilterPassSource = `
+#include <linux/bpf.h>
+#define SEC(NAME) __attribute__((section(NAME), used))
+struct nf_hook_state;
+struct sk_buff;
+struct bpf_nf_ctx {
+	const struct nf_hook_state *state;
+	struct sk_buff *skb;
+};
+SEC("netfilter")
+int netfilter_pass_test(struct bpf_nf_ctx *ctx) { return 1; }
+char _license[] SEC("license") = "GPL";
+`
+
+// loadDummyNetfilter compiles and loads a minimal netfilter program
+// with BTF — peer of loadDummyCgroupSKB. Returns NF_ACCEPT (1); the
+// observer attaches as fentry/fexit, so no nf_hook link is needed for
+// the verifier-load matrix. Skips on kernels without
+// BPF_PROG_TYPE_NETFILTER (< 6.4).
+func loadDummyNetfilter(t testing.TB) *ebpf.Program {
+	t.Helper()
+	testutil.SkipIfNotRoot(t)
+	if err := features.HaveProgramType(ebpf.Netfilter); errors.Is(err, ebpf.ErrNotSupported) {
+		t.Skipf("BPF_PROG_TYPE_NETFILTER not supported by this kernel (need 6.4+)")
+	}
+
+	spec, err := ebpf.LoadCollectionSpec(testutil.CompileBPFSource(t, netfilterPassSource))
+	if err != nil {
+		t.Fatalf("loading collection spec: %v", err)
+	}
+
+	var objs struct {
+		Prog *ebpf.Program `ebpf:"netfilter_pass_test"`
+	}
+	if err := spec.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatalf("loading netfilter program: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Prog.Close() })
+	return objs.Prog
 }

--- a/pkg/kunai/README.ja.md
+++ b/pkg/kunai/README.ja.md
@@ -149,7 +149,7 @@ type CaptureInfo struct {
 
 `FilterMinPrefix` は、コンパイル済みフィルタがパケットから読む最大バイトオフセットです。chain の自然なヘッダ prefix 長と、マージ済み where 節の最右フィールド末尾を合成した値になります。tracing ホストの LoadEntry / LoadExit はこれを使って per-CPU scratch map への `bpf_probe_read_kernel` の読み取り量を決めるので、`eth/ipv4/tcp where tcp.dport == 443` のような単純なフィルタは 54 B だけを読み、保守的な `ScratchBufSize` 分のコピーを避けられます。0 は解析を断念したことを意味します。quantifier 付き chain や heterogeneous alternation がこれに当たり、ホストは scratch 全読みに fallback します。`FilterMinPrefix` は `MaxCapLen` から独立です。scratch 読みの最適化は、ユーザーが `capture headers` で ringbuf 側の最適化に opt-in したかどうかに関わらず常に効きます。
 
-ホストは `Capabilities` 値を構築して、kunai を自分の BPF attach point に接続します。kunai コアはホスト固有の helper を持たず、canonical adapter は [`host/`](./host/) 以下のサブパッケージにあります。現在は `host/xdp`、`host/tc`、`host/cgroupskb` の 3 つです。XDP fexit の場合は次のように書きます。
+ホストは `Capabilities` 値を構築して、kunai を自分の BPF attach point に接続します。kunai コアはホスト固有の helper を持たず、canonical adapter は [`host/`](./host/) 以下のサブパッケージにあります。現在は `host/xdp`、`host/tc`、`host/cgroupskb`、`host/netfilter` の 4 つです。XDP fexit の場合は次のように書きます。
 
 ```go
 import xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
@@ -178,7 +178,7 @@ vocabulary のパース結果は、`pkg/kunai/dslvocab/` の `dslvocab.Bundled()
 
 ## バージョニングと安定性
 
-- public API は次のとおりです。`kunai.Compile`、カスタム vocab を受け入れる `kunai.CompileWithVocab`、bpf-ninja の `--dsl-help` が使う `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp`、`codegen.Capabilities` とその構成要素 `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver`、`codegen.ActionFetcher`、`codegen.Output` と `CaptureInfo` / `ExtractSlot`、host wrapper 用の `codegen.MainFilterFuncBTF`、位置情報付きエラー型の `codegen.PositionedError`、`host/xdp` / `host/tc` / `host/cgroupskb` の adapter パッケージ、上記のエラー型です。
+- public API は次のとおりです。`kunai.Compile`、カスタム vocab を受け入れる `kunai.CompileWithVocab`、bpf-ninja の `--dsl-help` が使う `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp`、`codegen.Capabilities` とその構成要素 `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver`、`codegen.ActionFetcher`、`codegen.Output` と `CaptureInfo` / `ExtractSlot`、host wrapper 用の `codegen.MainFilterFuncBTF`、位置情報付きエラー型の `codegen.PositionedError`、`host/xdp` / `host/tc` / `host/cgroupskb` / `host/netfilter` の adapter パッケージ、上記のエラー型です。
 - それ以外の AST node、IR 型、vocab loader 内部、parser 内部、`dslvocab.Bundled` キャッシュは、予告なく変わる可能性があります。
 - gopacket ベースのパケットレベルハーネス `pkg/kunai/dsltest` は experimental です。1.0 までは `Runner` API と packet builder を予告なく変更する可能性があるので、下流のテストが依存する場合は tag を固定してください。
 - プロトコル vocabulary は public surface の一部として扱います。新プロトコルの追加は非破壊変更、リネームや削除は破壊変更です。

--- a/pkg/kunai/README.md
+++ b/pkg/kunai/README.md
@@ -170,7 +170,7 @@ independent of `MaxCapLen`**: the scratch-read optimisation always
 applies, whether or not the user opted into the ringbuf-reservation
 optimisation via `capture headers`.
 
-The host wires kunai to its specific BPF attach point by constructing a `Capabilities` value. The kunai core ships no host-specific helpers; canonical adapters live under [`host/`](./host/): `host/xdp`, `host/tc`, and `host/cgroupskb`. For an XDP fexit attach point:
+The host wires kunai to its specific BPF attach point by constructing a `Capabilities` value. The kunai core ships no host-specific helpers; canonical adapters live under [`host/`](./host/): `host/xdp`, `host/tc`, `host/cgroupskb`, and `host/netfilter`. For an XDP fexit attach point:
 
 ```go
 import xdphost "github.com/takehaya/bpf-ninja/pkg/kunai/host/xdp"
@@ -199,14 +199,14 @@ Vocabulary parsing is memoised: `dslvocab.Bundled()` (in `pkg/kunai/dslvocab/`) 
 
 ## Versioning & stability
 
-- Public API: `kunai.Compile`, `kunai.CompileWithVocab` (custom-vocab variant), `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp` (used by bpf-ninja's `--dsl-help`), `codegen.Capabilities` with its `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver` components, `codegen.ActionFetcher`, `codegen.Output` with `CaptureInfo` / `ExtractSlot`, `codegen.MainFilterFuncBTF` (host wrapper helper), `codegen.PositionedError` (source-position-aware error type), the `host/xdp`, `host/tc`, and `host/cgroupskb` adapter packages, and the error types listed above.
+- Public API: `kunai.Compile`, `kunai.CompileWithVocab` (custom-vocab variant), `kunai.SyntaxHelp` / `kunai.ExamplesHelp` / `kunai.WriteProtocolCatalogue` / `kunai.WriteProtocolHelp` (used by bpf-ninja's `--dsl-help`), `codegen.Capabilities` with its `LexCaps` / `LangCaps` / `HostLayout` / `SetSlotResolver` components, `codegen.ActionFetcher`, `codegen.Output` with `CaptureInfo` / `ExtractSlot`, `codegen.MainFilterFuncBTF` (host wrapper helper), `codegen.PositionedError` (source-position-aware error type), the `host/xdp`, `host/tc`, `host/cgroupskb`, and `host/netfilter` adapter packages, and the error types listed above.
 - Everything else (AST nodes, IR types, vocab loader internals, parser internals, the `dslvocab.Bundled` cache) may change without notice.
 - `pkg/kunai/dsltest` (the gopacket-based packet-level harness) is **experimental** until 1.0: its `Runner` API and packet builders may change without notice. Pin a tagged version if downstream tests depend on it.
 - The protocol vocabulary is treated as part of the public surface: adding new protocols is non-breaking, while renaming or removing one is a breaking change.
 
 ## Related projects
 
-- [bpf-ninja](https://github.com/takehaya/bpf-ninja): non-invasive BPF observability tool (XDP, tc, and cgroup-skb hook points) that is the primary consumer of this package.
+- [bpf-ninja](https://github.com/takehaya/bpf-ninja): non-invasive BPF observability tool (XDP, tc, cgroup-skb, and netfilter hook points) that is the primary consumer of this package.
 - [cilium/ebpf](https://github.com/cilium/ebpf): the BPF assembler / loader the codegen targets.
 - [cloudflare/cbpfc](https://github.com/cloudflare/cbpfc): alternative classical-BPF (tcpdump syntax) compiler, used by bpf-ninja when `--cbpf` is set (legacy fallback).
 - [p4lang/p4c](https://github.com/p4lang/p4c): official P4 compiler, used in CI to verify our `.p4` vocab files stay within P4-16.

--- a/pkg/kunai/host/netfilter/netfilter.go
+++ b/pkg/kunai/host/netfilter/netfilter.go
@@ -1,0 +1,79 @@
+// Package netfilter provides kunai host adapters for hosts attached as
+// fentry / fexit on a netfilter (BPF_PROG_TYPE_NETFILTER, kernel 6.4+)
+// program. Importing this package is the canonical way to enable
+// netfilter specific DSL atoms (currently `where action ==
+// NF_DROP/NF_ACCEPT`) in a kunai filter; the kunai core itself holds no
+// netfilter knowledge — see pkg/kunai/codegen/caps.go for the
+// Capabilities contract this package conforms to.
+//
+// A netfilter program hooks the IP layer (NF_INET_* hook points), so
+// the packet window starts at the NETWORK (L3) header — there is no
+// Ethernet header — and both capability sets carry
+// HostLayout.PacketStartsAtL3. DSL chains should root at ipv4/ipv6.
+package netfilter
+
+import (
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/takehaya/bpf-ninja/pkg/kunai/codegen"
+)
+
+// Actions matches the verdicts a netfilter BPF program may return.
+// The kernel verifier restricts the return value to NF_DROP (0) and
+// NF_ACCEPT (1) (net/netfilter/nf_bpf_link.c); the other classic
+// NF_* verdicts (STOLEN / QUEUE / REPEAT) are rejected at load time
+// and therefore never observable, so they are intentionally absent.
+var Actions = map[string]int32{
+	"NF_DROP":   0,
+	"NF_ACCEPT": 1,
+}
+
+// FexitFetcher returns a codegen.ActionFetcher for hosts attached as
+// fexit on a netfilter program. It assumes the host wrapper saved the
+// BPF tracing args pointer at stack[-48] at program entry and that
+// args[1] is the verdict slot — the same tracing-args ABI as the xdp,
+// tc, and cgroup-skb fetchers, met by the bpf-ninja host program (see
+// internal/program/program.go).
+//
+// Different host wrappers with a different stack ABI should provide
+// their own fetcher rather than reusing this one.
+func FexitFetcher() codegen.ActionFetcher { return fexitFetcher{} }
+
+type fexitFetcher struct{}
+
+func (fexitFetcher) EmitFetch(dst asm.Register) asm.Instructions {
+	return asm.Instructions{
+		asm.LoadMem(dst, asm.R10, -48, asm.DWord),
+		asm.LoadMem(dst, dst, 8, asm.Word),
+	}
+}
+
+// FexitCapabilities returns the standard codegen.Capabilities for hosts
+// attached as fexit on a netfilter program. The Lang group carries the
+// NF_* action atoms; Host sets PacketStartsAtL3 (no Ethernet header in
+// the window) and VlanInMetadata (with no L2 header there are no
+// in-band VLAN tags to parse either).
+func FexitCapabilities() codegen.Capabilities {
+	return codegen.Capabilities{
+		Lang: codegen.LangCaps{
+			Action:        Actions,
+			ActionFetcher: FexitFetcher(),
+		},
+		Host: hostLayout(),
+	}
+}
+
+// EntryCapabilities returns the codegen.Capabilities for hosts attached
+// as fentry on a netfilter program. fentry has no verdict yet, so the
+// Lang group stays empty; the packet-layout facts hold at both attach
+// points.
+func EntryCapabilities() codegen.Capabilities {
+	return codegen.Capabilities{Host: hostLayout()}
+}
+
+func hostLayout() codegen.HostLayout {
+	return codegen.HostLayout{
+		VlanInMetadata:   true,
+		PacketStartsAtL3: true,
+	}
+}

--- a/pkg/kunai/host/netfilter/netfilter.go
+++ b/pkg/kunai/host/netfilter/netfilter.go
@@ -1,8 +1,8 @@
 // Package netfilter provides kunai host adapters for hosts attached as
 // fentry / fexit on a netfilter (BPF_PROG_TYPE_NETFILTER, kernel 6.4+)
 // program. Importing this package is the canonical way to enable
-// netfilter specific DSL atoms (currently `where action ==
-// NF_DROP/NF_ACCEPT`) in a kunai filter; the kunai core itself holds no
+// netfilter specific DSL atoms (currently `where action == NF_DROP`
+// and `where action == NF_ACCEPT`) in a kunai filter; the kunai core itself holds no
 // netfilter knowledge — see pkg/kunai/codegen/caps.go for the
 // Capabilities contract this package conforms to.
 //


### PR DESCRIPTION
## Summary

Adds the fourth hook kind after xdp / tc / cgroup-skb: BPF programs attached to NF_INET_* hooks via bpf_link (kernel 6.4+).

- `pkg/kunai/host/netfilter`: capabilities adapter (79 lines). L3-start packet window like cgroup-skb; exit-mode action atoms are NF_DROP / NF_ACCEPT, which is the complete verdict set because the kernel restricts netfilter BPF return values to those two.
- `internal/hook/netfilter.go` (91 lines): hook record + prologue. The tracing context differs from the skb hooks — args[0] is `struct bpf_nf_ctx`, so the prologue derefs `ctx->skb` (offset resolved from kernel BTF, like the existing sk_buff members) before the shared data/len loads. R6 keeps the ctx per the PacketPrologue contract.
- Registry / dump-hook / docs wiring; DSL load-test matrices mirroring the cgroup-skb ones.

## Testing

- `go test ./...` green; `internal/program -run TestBpf` (root, real loads) green including the new netfilter entry/exit matrices.
- Non-obvious verifier interaction pinned in a comment: the dummy target must define `struct bpf_nf_ctx` fully — a forward declaration makes the trampoline's ctx typing fail the struct check, args[0] degrades to an untyped scalar, and the `ctx->skb` read is rejected.
- Kernels without BPF_PROG_TYPE_NETFILTER skip via `features.HaveProgramType` (vimto matrix 6.1 skip / 6.6–7.0 green, run locally).
- Live end-to-end on a stock 6.8 VM: dummy prog attached to NF_INET_LOCAL_IN via bpf_link, `bpf-ninja -p <id> 'ipv4/icmp'` captured loopback echo request+reply as raw-IP pcap-ng, and `--mode exit 'ipv4/icmp where action == NF_ACCEPT'` recorded all packets on the `netfilter:NF_ACCEPT` interface.